### PR TITLE
Add Docker container and GitHub Actions workflow for _b00t_ framework

### DIFF
--- a/.github/workflows/b00t-container.yml
+++ b/.github/workflows/b00t-container.yml
@@ -1,0 +1,75 @@
+name: Build and Publish _b00t_ Container
+
+on:
+  push:
+    branches: [ main ]
+    paths:
+      - 'setup.sh'
+      - '_b00t_/docker.🐳/Dockerfile'
+      - '.github/workflows/b00t-container.yml'
+  pull_request:
+    branches: [ main ]
+    paths:
+      - 'setup.sh'
+      - '_b00t_/docker.🐳/Dockerfile'
+  schedule:
+    - cron: '0 0 * * 0'  # Weekly build on Sundays at midnight
+  workflow_dispatch:  # Allow manual trigger
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: elasticdotventures/dotfiles
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Generate version tags
+        id: meta
+        run: |
+          VERSION_DATE=$(date +'%Y-%m-%d')
+          echo "VERSION_DATE=$VERSION_DATE" >> $GITHUB_ENV
+          echo "version_date=$VERSION_DATE" >> $GITHUB_OUTPUT
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: _b00t_/docker.🐳/Dockerfile
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: |
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.VERSION_DATE }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Update README with badge
+        if: github.event_name != 'pull_request'
+        run: |
+          echo "[![Container Build Status](https://github.com/elasticdotventures/dotfiles/actions/workflows/b00t-container.yml/badge.svg)](https://github.com/elasticdotventures/dotfiles/actions/workflows/b00t-container.yml)" >> README.tmp
+          cat README.md >> README.tmp
+          mv README.tmp README.md
+          
+      - name: Commit README changes
+        if: github.event_name != 'pull_request'
+        uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          commit_message: "docs: Update README with container build status badge [skip ci]"
+          file_pattern: README.md

--- a/.gitignore
+++ b/.gitignore
@@ -256,3 +256,4 @@ dist
 .yarn/install-state.gz
 .pnp.*
 yarn.lock
+agentsea/*

--- a/README.md
+++ b/README.md
@@ -83,3 +83,37 @@ gh issue develop # --checkout
 
 # # Add the container as a submodule
 git submodule add https://github.com/simonhyll/devcontainer .devcontainer
+
+# Container Usage
+
+[![Container Build Status](https://github.com/elasticdotventures/dotfiles/actions/workflows/b00t-container.yml/badge.svg)](https://github.com/elasticdotventures/dotfiles/actions/workflows/b00t-container.yml)
+
+The _b00t_ framework is available as a Docker container through GitHub Container Registry (ghcr.io). The container includes all developer tools and is built on Ubuntu 24.04 LTS (Noble Numbat).
+
+## Pulling the Container
+
+```bash
+# Pull the latest version
+docker pull ghcr.io/elasticdotventures/dotfiles:latest
+
+# Pull a specific date-versioned image
+docker pull ghcr.io/elasticdotventures/dotfiles:YYYY-MM-DD
+```
+
+## Running the Container
+
+```bash
+# Run with the current directory mounted as a volume
+docker run --rm -it -v $(pwd):/workspace ghcr.io/elasticdotventures/dotfiles:latest
+
+# Run with specific environment variables
+docker run --rm -it -v $(pwd):/workspace -e VAR_NAME=value ghcr.io/elasticdotventures/dotfiles:latest
+```
+
+## Container Features
+
+- Based on Ubuntu 24.04 LTS (Noble Numbat)
+- Includes all developer tools installed via setup.sh
+- Pre-configured with _b00t_ initialization framework
+- Ready-to-use development environment with Python, Rust, Node.js, and more
+- Optimized for use with VS Code Remote Containers

--- a/_b00t_/docker.🐳/Dockerfile
+++ b/_b00t_/docker.🐳/Dockerfile
@@ -1,0 +1,111 @@
+# _b00t_ Development Environment Container
+FROM ubuntu:24.04
+
+# Set non-interactive frontend for apt
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Set labels
+LABEL org.opencontainers.image.source=https://github.com/elasticdotventures/dotfiles
+LABEL org.opencontainers.image.description="_b00t_ initialization framework with comprehensive developer tooling"
+LABEL org.opencontainers.image.licenses=MIT
+
+# Set working directory
+WORKDIR /root
+
+# Install initial dependencies needed to clone the repository and run setup.sh
+RUN apt-get update && apt-get install -y \
+    git \
+    curl \
+    wget \
+    unzip \
+    ca-certificates \
+    software-properties-common \
+    sudo \
+    apt-utils \
+    gnupg \
+    lsb-release \
+    build-essential \
+    pkg-config \
+    cmake \
+    bat \
+    tree \
+    fzf \
+    ripgrep \
+    jq \
+    stow \
+    inotify-tools \
+    libclang-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+# Create necessary directories
+RUN mkdir -p /root/.local/bin /root/.kube
+
+# Clone the dotfiles repository
+RUN git clone https://github.com/elasticdotventures/dotfiles /root/.dotfiles --depth 1
+
+# Change to dotfiles directory
+WORKDIR /root/.dotfiles
+
+# Install Rust with non-interactive mode
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+ENV PATH="/root/.cargo/bin:${PATH}"
+
+# Install OpenTofu (Terraform alternative)
+RUN curl --proto '=https' --tlsv1.2 -fsSL 'https://packages.opentofu.org/install/repositories/opentofu/tofu/script.deb.sh?any=true' | bash \
+    && apt-get update && apt-get install -y tofu && rm -rf /var/lib/apt/lists/*
+
+# Install AWS CLI
+RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" \
+    && unzip awscliv2.zip \
+    && ./aws/install \
+    && rm -rf aws awscliv2.zip
+
+# Install Google Cloud SDK
+RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list \
+    && curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key --keyring /usr/share/keyrings/cloud.google.gpg add - \
+    && apt-get update && apt-get install -y google-cloud-cli \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install other tools from cargo
+RUN cargo install starship --locked \
+    && cargo install dotenvy --bin dotenvy --features cli \
+    && cargo install datafusion-cli
+
+# Install Just command runner
+RUN curl --proto '=https' --tlsv1.2 -sSf https://just.systems/install.sh | bash -s -- --to /usr/local/bin
+
+# Install eget and move it to the right location
+RUN curl -sSfL https://raw.githubusercontent.com/zyedidia/eget/master/install.sh | bash \
+    && cp eget /usr/local/bin/ \
+    && chmod +x /usr/local/bin/eget
+
+# Install wasm-to-oci
+RUN wget https://github.com/engineerd/wasm-to-oci/releases/download/v0.1.2/linux-amd64-wasm-to-oci \
+    && mv linux-amd64-wasm-to-oci wasm-to-oci \
+    && chmod +x wasm-to-oci \
+    && cp wasm-to-oci /usr/local/bin/
+
+# Install Direnv
+RUN curl -sfL https://direnv.net/install.sh | bash
+
+# Install Pixi
+RUN curl -fsSL https://pixi.sh/install.sh | bash
+
+# Set up shell configuration
+RUN echo 'eval "$(starship init bash)"' >> /root/.bashrc \
+    && echo 'eval "$(direnv hook bash)"' >> /root/.bashrc \
+    && echo 'alias tf=tofu' >> /root/.bashrc \
+    && echo 'alias itree="rg --files | tree --fromfile"' >> /root/.bashrc
+
+# Stow the dotfiles
+RUN stow -d /root/.dotfiles -t /root bash
+
+# Ensure the .bashrc is sourced on container start
+RUN echo "source ~/.bashrc" >> /root/.profile
+
+# Set the default working directory
+WORKDIR /workspace
+
+# Set the entrypoint to bash
+ENTRYPOINT ["/bin/bash"]
+CMD ["-l"]


### PR DESCRIPTION
This PR adds:

1. Dockerfile for containerizing the _b00t_ framework with all developer tools
2. GitHub Actions workflow to automatically build and publish the container to GHCR
3. README updates with container usage instructions and build status badge

The container will be published to ghcr.io/elasticdotventures/dotfiles with date-based versioning.