### PR TITLE
Fix CLI config file path resolution bug (closes #53)

### DIFF
--- a/b00t-cli/src/lib.rs
+++ b/b00t-cli/src/lib.rs
@@ -564,16 +564,18 @@ pub fn get_config(
     ];
 
     let mut path_buf = std::path::PathBuf::new();
-    path_buf.push(shellexpand::tilde(path).to_string());
+    let expanded_path = shellexpand::tilde(path).to_string();
+    path_buf.push(expanded_path);
 
     for ext in &extensions {
         let filename = format!("{}{}", command, ext);
-        path_buf.set_file_name(&filename);
+        path_buf.push(&filename); // 🤓 FIX: use push instead of set_file_name to avoid removing _b00t_ directory
         if path_buf.exists() {
             let content = std::fs::read_to_string(&path_buf)?;
             let config: UnifiedConfig = toml::from_str(&content)?;
             return Ok((config, filename));
         }
+        path_buf.pop(); // 🤓 FIX: remove the filename for next iteration
     }
 
     eprintln!("{} UNDEFINED", command);


### PR DESCRIPTION
## Summary
Fixed critical bug in `get_config()` function where CLI configuration files were not being found due to incorrect path handling.

## Problem
- `b00t cli check rustc` returned "UNDEFINED" instead of proper status
- `path_buf.set_file_name()` was incorrectly replacing the `_b00t_` directory name
- Configuration files at `~/.dotfiles/_b00t_/*.cli.toml` were not being located

## Solution  
- Changed `path_buf.set_file_name(&filename)` to `path_buf.push(&filename)`
- Added `path_buf.pop()` after each iteration to clean up for next extension
- Proper path construction now preserves directory structure

## Test plan
- [x] Verified `b00t cli check rustc` now returns `🥾😱 rustc (not installed)` 
- [x] Confirmed config files are found at correct path `/home/brianh/.dotfiles/_b00t_/rustc.cli.toml`
- [x] Installed updated binary with `cargo install --path . --force`
- [x] All CLI config lookups now work correctly

🤖 Generated with [Claude Code](https://claude.ai/code)