### PR TITLE
feat: move session file to .git directory to prevent tracking

### DIFF
--- a/b00t-cli/src/commands/session.rs
+++ b/b00t-cli/src/commands/session.rs
@@ -46,7 +46,7 @@ pub enum SessionCommands {
     Clear,
     #[clap(about = "Mark README.md as read for this session")]
     MarkReadmeRead,
-    #[clap(about = "Generate documented ._b00t_.toml template")]
+    #[clap(about = "Generate documented _b00t_.toml template")]
     Template,
     #[clap(about = "Check if output should be verbose for current shell")]
     ShouldShowOutput,
@@ -184,9 +184,9 @@ impl SessionCommands {
 
 fn generate_session_template() -> Result<()> {
     let template = r#"# b00t Session Configuration Template
-# 🤓 This file (._b00t_.toml) contains session memory and configuration
-# 🤓 It's automatically created in your git repository root when using b00t-cli
-# 🤓 The file is added to .gitignore to keep session data local
+# 🤓 This file (_b00t_.toml) contains session memory and configuration
+# 🤓 It's automatically created in your .git/ directory when using b00t-cli
+# 🤓 The file is stored in .git/ so it's automatically ignored by git
 
 [metadata]
 # 🤓 Session metadata (automatically managed)

--- a/b00t-cli/src/session_memory.rs
+++ b/b00t-cli/src/session_memory.rs
@@ -100,17 +100,23 @@ impl Default for SessionMetadata {
 }
 
 impl SessionMemory {
-    /// Get the git root path for storing ._b00t_.toml
+    /// Get the git root path for storing _b00t_.toml in .git/ directory
     pub fn get_config_path() -> Result<PathBuf> {
         let git_root = get_workspace_root();
-        Ok(PathBuf::from(git_root))
+        Ok(PathBuf::from(git_root).join(".git"))
     }
 
-    /// Ensure ._b00t_.toml is in .gitignore
+    /// Ensure _b00t_.toml is in .gitignore (no longer needed since it's in .git/)
     fn ensure_gitignore_entry() -> Result<()> {
-        let config_dir = Self::get_config_path()?;
-        let gitignore_path = config_dir.join(".gitignore");
-        let target_entry = "._b00t_.toml";
+        // No longer needed since _b00t_.toml is stored in .git/ directory
+        // which is automatically ignored by git
+        Ok(())
+    }
+
+    fn _unused_ensure_gitignore_entry() -> Result<()> {
+        let git_root = get_workspace_root();
+        let gitignore_path = PathBuf::from(git_root).join(".gitignore");
+        let target_entry = "_b00t_.toml";
 
         // Check if .gitignore exists
         if !gitignore_path.exists() {
@@ -152,8 +158,8 @@ impl SessionMemory {
         // Ensure ._b00t_.toml is in .gitignore before creating/loading
         Self::ensure_gitignore_entry().context("Failed to ensure .gitignore entry")?;
         
-        // Use confy to load from ._b00t_.toml in git root
-        let mut memory: SessionMemory = confy::load_path(config_dir.join("._b00t_.toml"))
+        // Use confy to load from _b00t_.toml in .git directory
+        let mut memory: SessionMemory = confy::load_path(config_dir.join("_b00t_.toml"))
             .context("Failed to load session memory")?;
 
         // Initialize metadata if this is first load
@@ -177,7 +183,7 @@ impl SessionMemory {
     /// Save session memory using confy
     pub fn save(&self) -> Result<()> {
         let config_dir = Self::get_config_path()?;
-        confy::store_path(config_dir.join("._b00t_.toml"), self)
+        confy::store_path(config_dir.join("_b00t_.toml"), self)
             .context("Failed to save session memory")
     }
 
@@ -589,7 +595,7 @@ mod tests {
     fn test_gitignore_entry_creation() -> Result<()> {
         let temp_dir = TempDir::new()?;
         let gitignore_path = temp_dir.path().join(".gitignore");
-        let target_entry = "._b00t_.toml";
+        let target_entry = "_b00t_.toml";
 
         // Test creating .gitignore when it doesn't exist
         assert!(!gitignore_path.exists());
@@ -608,7 +614,7 @@ mod tests {
     fn test_gitignore_entry_detection() -> Result<()> {
         let temp_dir = TempDir::new()?;
         let gitignore_path = temp_dir.path().join(".gitignore");
-        let target_entry = "._b00t_.toml";
+        let target_entry = "_b00t_.toml";
 
         // Create .gitignore with entry already present
         fs::write(&gitignore_path, format!("*.log\n{}\n*.tmp\n", target_entry))?;

--- a/b00t-cli/tests/session_memory_test.rs
+++ b/b00t-cli/tests/session_memory_test.rs
@@ -8,8 +8,11 @@ fn test_session_memory_basic_operations() {
     let original_dir = env::current_dir().unwrap();
     env::set_current_dir(&temp_dir).unwrap();
     
-    // Initialize git repo to create valid git root
+    // Initialize git repo to create valid git root with .git directory
     std::process::Command::new("git").args(&["init"]).output().unwrap();
+    std::fs::create_dir_all(temp_dir.path().join(".git")).unwrap();
+    // Ensure .git directory exists
+    std::fs::create_dir_all(temp_dir.path().join(".git")).unwrap();
     
     // Test creating and loading session memory
     let mut memory = SessionMemory::load().unwrap();
@@ -35,8 +38,8 @@ fn test_session_memory_basic_operations() {
     assert!(keys.iter().any(|(key, type_)| key == "counter" && type_ == "number"));
     assert!(keys.iter().any(|(key, type_)| key == "enabled" && type_ == "flag"));
     
-    // Verify TOML file was created
-    assert!(temp_dir.path().join("._b00t_.toml").exists());
+    // Verify TOML file was created in .git directory
+    assert!(temp_dir.path().join(".git/_b00t_.toml").exists());
     
     // Test clear operation
     memory.clear().unwrap();
@@ -52,6 +55,7 @@ fn test_session_memory_persistence() {
     env::set_current_dir(&temp_dir).unwrap();
     
     std::process::Command::new("git").args(&["init"]).output().unwrap();
+    std::fs::create_dir_all(temp_dir.path().join(".git")).unwrap();
     
     // Create and populate session memory
     {
@@ -77,6 +81,7 @@ fn test_readme_tracking() {
     env::set_current_dir(&temp_dir).unwrap();
     
     std::process::Command::new("git").args(&["init"]).output().unwrap();
+    std::fs::create_dir_all(temp_dir.path().join(".git")).unwrap();
     
     // Test README tracking functionality
     let mut memory = SessionMemory::load().unwrap();
@@ -102,6 +107,7 @@ fn test_metadata_tracking() {
     env::set_current_dir(&temp_dir).unwrap();
     
     std::process::Command::new("git").args(&["init"]).output().unwrap();
+    std::fs::create_dir_all(temp_dir.path().join(".git")).unwrap();
     std::process::Command::new("git").args(&["checkout", "-b", "test-branch"]).output().ok();
     
     let memory = SessionMemory::load().unwrap();


### PR DESCRIPTION
## Summary
- Move session file location from `._b00t_.toml` (repo root) to `_b00t_.toml` (.git/ directory)
- Remove leading dot from filename since .git/ is automatically ignored by git
- Simplify gitignore logic since file is now in untracked .git/ directory

## Test plan
- [x] Verified session commands work with new file location
- [x] Confirmed session data is stored in `.git/_b00t_.toml`
- [x] Updated and validated all tests pass
- [x] Confirmed file is no longer tracked by git

## Changes
- Modified `SessionMemory::get_config_path()` to return `.git/` directory path
- Updated file references from `._b00t_.toml` to `_b00t_.toml` 
- Simplified `ensure_gitignore_entry()` since file is now automatically ignored
- Updated documentation and help text to reflect new location
- Fixed test assertions to expect file in `.git/` directory

This ensures session data is never accidentally committed to version control.

🤖 Generated with [Claude Code](https://claude.ai/code)