### PR TITLE
Ensure workspace version inheritance

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -389,8 +389,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "b00t-c0re"
+version = "0.7.3"
+dependencies = [
+ "js-sys",
+ "serde",
+ "serde-wasm-bindgen",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
 name = "b00t-c0re-lib"
-version = "0.7.0"
+version = "0.7.3"
 dependencies = [
  "anyhow",
  "chrono",
@@ -420,7 +432,7 @@ dependencies = [
 
 [[package]]
 name = "b00t-chat"
-version = "0.1.0"
+version = "0.7.3"
 dependencies = [
  "anyhow",
  "async-nats",
@@ -448,7 +460,7 @@ dependencies = [
 
 [[package]]
 name = "b00t-cli"
-version = "0.7.2"
+version = "0.7.3"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -483,7 +495,7 @@ dependencies = [
 
 [[package]]
 name = "b00t-grok"
-version = "0.7.2"
+version = "0.7.3"
 dependencies = [
  "anyhow",
  "async-openai",
@@ -502,7 +514,7 @@ dependencies = [
 
 [[package]]
 name = "b00t-mcp"
-version = "0.7.2"
+version = "0.7.3"
 dependencies = [
  "anyhow",
  "axum 0.8.6",
@@ -542,7 +554,7 @@ dependencies = [
 
 [[package]]
 name = "b00t-py"
-version = "0.7.2"
+version = "0.7.3"
 dependencies = [
  "anyhow",
  "b00t-c0re-lib",
@@ -2173,7 +2185,7 @@ dependencies = [
 
 [[package]]
 name = "k0mmand3r"
-version = "0.1.5"
+version = "0.7.3"
 dependencies = [
  "decimal-rs",
  "indexmap 2.12.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,8 @@ members = [
     "b00t-cli",
     "b00t-mcp", 
     "b00t-c0re-lib", 
+    "b00t-c0re-npm",
+    "b00t-lib-chat",
     "b00t-grok",
     "k0mmand3r",
     "b00t-py",
@@ -12,7 +14,7 @@ resolver = "2"
 [workspace.package]
 # 🤓 Version management centralized in b00t-c0re-lib
 # All workspace crates inherit from the single source of truth
-version = "0.7.2"
+version = "0.7.3"
 edition = "2024"
 authors = ["Brian Horakh <brian@promptexecution.com>"]
 license = "MIT"
@@ -23,6 +25,7 @@ repository = "https://github.com/elasticdotventures/dotfiles"
 b00t-cli = { path = "b00t-cli" }
 b00t-c0re-lib = { path = "b00t-c0re-lib" }
 b00t-grok = { path = "b00t-grok", default-features = false }
+b00t-chat = { path = "b00t-lib-chat" }
 
 # Common dependencies that could be shared across workspace members
 serde = { version = "1.0", features = ["derive"] }

--- a/b00t-c0re-lib/Cargo.toml
+++ b/b00t-c0re-lib/Cargo.toml
@@ -2,7 +2,7 @@
 name = "b00t-c0re-lib"
 # 🤓 SINGLE SOURCE OF TRUTH for b00t ecosystem versioning
 # All other crates (b00t-cli, b00t-mcp) should reference this version
-version = "0.7.0"
+version.workspace = true
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/b00t-c0re-npm/Cargo.toml
+++ b/b00t-c0re-npm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "b00t-c0re"
-version = "0.1.0"
+version.workspace = true
 edition = "2021"
 description = "Core Rust functionality for b00t framework with WebAssembly bindings"
 license = "MIT"

--- a/b00t-c0re-npm/src/lib.rs
+++ b/b00t-c0re-npm/src/lib.rs
@@ -21,7 +21,10 @@ pub fn b00t_version() -> String {
 /// Core b00t greeting - stay aligned!
 #[wasm_bindgen]
 pub fn b00t_greet(name: &str) -> String {
-    format!("🥾 Hello {}, welcome to b00t! Stay aligned, get cake! 🎂", name)
+    format!(
+        "🥾 Hello {}, welcome to b00t! Stay aligned, get cake! 🎂",
+        name
+    )
 }
 
 /// Check if a command looks like a slash command

--- a/b00t-cli/Cargo.toml
+++ b/b00t-cli/Cargo.toml
@@ -50,7 +50,7 @@ confy = "2.0.0"
 libc = "0.2"
 reqwest = { version = "0.12.23", features = ["json"] }
 whoami = "1.5"
-b00t-chat = { path = "../b00t-lib-chat" }
+b00t-chat = { workspace = true }
 
 
 [dev-dependencies]

--- a/b00t-cli/tests/hello_world_test.rs
+++ b/b00t-cli/tests/hello_world_test.rs
@@ -1,3 +1,4 @@
+use b00t_c0re_lib::version;
 use std::env;
 use std::fs;
 use std::path::Path;
@@ -17,14 +18,17 @@ fn setup_test_environment(temp_dir: &Path) -> Result<(), std::io::Error> {
     fs::create_dir_all(&session_dir)?;
 
     // Create minimal _b00t_.toml to prevent session memory errors
-    let toml_content = r#"
+    let toml_content = format!(
+        r#"
 [session]
 initialized = true
 agent_type = "test"
 
 [b00t]
-version = "0.7.0"
-"#;
+version = "{version}"
+"#,
+        version = version::VERSION
+    );
     fs::write(session_dir.join("_b00t_.toml"), toml_content)?;
 
     Ok(())

--- a/b00t-lib-chat/Cargo.toml
+++ b/b00t-lib-chat/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "b00t-chat"
-version = "0.1.0"
+version.workspace = true
 edition = "2021"
 description = "b00t chat coordination system with multi-transport support"
 license = "MIT"
@@ -49,11 +49,5 @@ rand = "0.8"
 default = []
 python = ["pyo3"]
 wasm = ["wasm-bindgen", "js-sys", "web-sys", "serde-wasm-bindgen"]
-
-[profile.release]
-lto = true
-codegen-units = 1
-panic = "abort"
-strip = true
 
 # Examples are in examples/ directory, not as bins

--- a/b00t-mcp/Cargo.toml
+++ b/b00t-mcp/Cargo.toml
@@ -35,7 +35,7 @@ tracing.workspace = true
 # b00t-mcp specific dependencies
 b00t-cli = { workspace = true }
 b00t-c0re-lib = { workspace = true }
-b00t-chat = { path = "../b00t-lib-chat" }
+b00t-chat = { workspace = true }
 shellexpand = "3.1.0"
 dirs = "6.0"
 once_cell = "1.19"

--- a/k0mmand3r/Cargo.toml
+++ b/k0mmand3r/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "k0mmand3r"
-version = "0.1.5"
+version.workspace = true
 edition = "2021"
 authors = [ "Brian H. <brianh@elastic.ventures>" ]
 license = "MIT"


### PR DESCRIPTION
## Summary
- extend workspace membership to include all b00t crates and expose shared deps
- make every manifest inherit \ so  remains sole source of truth
- update test fixtures to read the runtime version rather than a literal string