### PR TITLE
Add boot datum for CCometixLine installation

### DIFF
--- a/_b00t_/ccometixline.cli.toml
+++ b/_b00t_/ccometixline.cli.toml
@@ -33,8 +33,3 @@ command = "ccline"
 [[b00t.usage]]
 description = "Enable verbose mode"
 command = "ccline --verbose"
-[b00t.requirements]
-git_version = "1.5+"
-recommended_git = "2.22+"
-fonts = "Nerd Fonts required for proper icon display"
-environment = "Claude Code"


### PR DESCRIPTION
CCometixLine is a high-performance Rust-based statusline tool for Claude Code that displays git status, model info, context usage, and workspace location.

Installation via npm: npm install -g @cometix/ccline Requires Nerd Fonts for proper icon display.

Datum includes:
- Installation and update commands
- Version checking
- Usage examples
- Requirements documentation
- GitHub and npm references