### PR TITLE
fix: resolve HashMap import and b00t_cli namespace errors in datum.rs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -418,7 +418,7 @@ dependencies = [
 
 [[package]]
 name = "b00t-c0re-lib"
-version = "0.7.23"
+version = "0.7.24"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -450,7 +450,7 @@ dependencies = [
 
 [[package]]
 name = "b00t-chat"
-version = "0.7.23"
+version = "0.7.24"
 dependencies = [
  "anyhow",
  "async-nats",
@@ -488,7 +488,7 @@ dependencies = [
 
 [[package]]
 name = "b00t-cli"
-version = "0.7.23"
+version = "0.7.24"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -525,7 +525,7 @@ dependencies = [
 
 [[package]]
 name = "b00t-grok"
-version = "0.7.23"
+version = "0.7.24"
 dependencies = [
  "anyhow",
  "async-openai",
@@ -544,7 +544,7 @@ dependencies = [
 
 [[package]]
 name = "b00t-ipc"
-version = "0.7.23"
+version = "0.7.24"
 dependencies = [
  "anyhow",
  "async-nats",
@@ -563,7 +563,7 @@ dependencies = [
 
 [[package]]
 name = "b00t-mcp"
-version = "0.7.23"
+version = "0.7.24"
 dependencies = [
  "anyhow",
  "axum 0.8.7",
@@ -603,7 +603,7 @@ dependencies = [
 
 [[package]]
 name = "b00t-py"
-version = "0.7.23"
+version = "0.7.24"
 dependencies = [
  "anyhow",
  "b00t-c0re-lib",
@@ -2429,7 +2429,7 @@ dependencies = [
 
 [[package]]
 name = "k0mmand3r"
-version = "0.7.23"
+version = "0.7.24"
 dependencies = [
  "decimal-rs",
  "indexmap 2.12.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ resolver = "2"
 [workspace.package]
 # 🤓 Version management centralized in b00t-c0re-lib
 # All workspace crates inherit from the single source of truth
-version = "0.7.23"
+version = "0.7.24"
 edition = "2024"
 authors = ["Brian Horakh <brian@promptexecution.com>"]
 license = "MIT"

--- a/b00t-cli/src/commands/datum.rs
+++ b/b00t-cli/src/commands/datum.rs
@@ -1,6 +1,7 @@
 use crate::datum_utils;
 use anyhow::Result;
 use clap::Parser;
+use std::collections::HashMap;
 
 #[derive(Parser, Debug)]
 pub enum DatumCommands {
@@ -168,14 +169,11 @@ fn handle_tree(
     group_by_type: bool,
     types_filter: Option<&str>,
 ) -> Result<()> {
-    use serde_json::json;
-    use std::collections::HashMap;
-
     // Load all datums
     let datums = datum_utils::get_all_datums(b00t_path)?;
 
     // Filter by types if specified
-    let filtered_datums: HashMap<String, b00t_cli::BootDatum> = if let Some(types_str) = types_filter {
+    let filtered_datums: HashMap<String, crate::BootDatum> = if let Some(types_str) = types_filter {
         let types: Vec<String> = types_str
             .split(',')
             .map(|s| s.trim().to_lowercase())
@@ -215,7 +213,7 @@ fn handle_tree(
     Ok(())
 }
 
-fn generate_flat_tree(datums: &HashMap<String, b00t_cli::BootDatum>) -> Result<serde_json::Value> {
+fn generate_flat_tree(datums: &HashMap<String, crate::BootDatum>) -> Result<serde_json::Value> {
     use serde_json::json;
 
     let mut nodes = Vec::new();
@@ -247,7 +245,7 @@ fn generate_flat_tree(datums: &HashMap<String, b00t_cli::BootDatum>) -> Result<s
     Ok(json!(nodes))
 }
 
-fn generate_grouped_tree(datums: &HashMap<String, b00t_cli::BootDatum>) -> Result<serde_json::Value> {
+fn generate_grouped_tree(datums: &HashMap<String, crate::BootDatum>) -> Result<serde_json::Value> {
     use serde_json::json;
     use std::collections::BTreeMap;
 
@@ -294,16 +292,16 @@ fn generate_grouped_tree(datums: &HashMap<String, b00t_cli::BootDatum>) -> Resul
     Ok(json!(root_nodes))
 }
 
-fn get_icon_for_type(dtype: &Option<b00t_cli::DatumType>) -> String {
+fn get_icon_for_type(dtype: &Option<crate::DatumType>) -> String {
     match dtype {
-        Some(b00t_cli::DatumType::Cli) => "fas fa-terminal".to_string(),
-        Some(b00t_cli::DatumType::Mcp) => "fas fa-plug".to_string(),
-        Some(b00t_cli::DatumType::Ai) => "fas fa-robot".to_string(),
-        Some(b00t_cli::DatumType::AiModel) => "fas fa-brain".to_string(),
-        Some(b00t_cli::DatumType::K8s) => "fas fa-dharmachakra".to_string(),
-        Some(b00t_cli::DatumType::Job) => "fas fa-tasks".to_string(),
-        Some(b00t_cli::DatumType::Stack) => "fas fa-layer-group".to_string(),
-        Some(b00t_cli::DatumType::Agent) => "fas fa-user-secret".to_string(),
+        Some(crate::DatumType::Cli) => "fas fa-terminal".to_string(),
+        Some(crate::DatumType::Mcp) => "fas fa-plug".to_string(),
+        Some(crate::DatumType::Ai) => "fas fa-robot".to_string(),
+        Some(crate::DatumType::AiModel) => "fas fa-brain".to_string(),
+        Some(crate::DatumType::K8s) => "fas fa-dharmachakra".to_string(),
+        Some(crate::DatumType::Job) => "fas fa-tasks".to_string(),
+        Some(crate::DatumType::Stack) => "fas fa-layer-group".to_string(),
+        Some(crate::DatumType::Agent) => "fas fa-user-secret".to_string(),
         _ => "jstree-file".to_string(),
     }
 }


### PR DESCRIPTION
## Summary
- Fix compilation errors in `b00t-cli/src/commands/datum.rs`
- Add missing `HashMap` import at module level
- Replace `b00t_cli::` with `crate::` for internal type references (`BootDatum`, `DatumType`)
- Remove duplicate local imports

## Changes
**b00t-cli/src/commands/datum.rs:**
- Added `use std::collections::HashMap;` at module level
- Replaced all `b00t_cli::BootDatum` → `crate::BootDatum`
- Replaced all `b00t_cli::DatumType` → `crate::DatumType`
- Removed redundant local `use` statements in `handle_tree()`

## Test Plan
- [x] `cargo build --workspace` completes successfully
- [x] No compilation errors in b00t-cli or b00t-mcp