### PR TITLE
fix: Remove duplicate types and imports after merge

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -147,7 +147,7 @@ version = "0.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "86dde77d8a733a9dbaf865a9eb65c72e09c88f3d14d3dd0d2aecf511920ee4fe"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-util",
  "memchr",
@@ -186,7 +186,7 @@ checksum = "6bf39a15c8d613eb61892dc9a287c02277639ebead41ee611ad23aaa613f1a82"
 dependencies = [
  "async-openai-macros",
  "backoff",
- "base64",
+ "base64 0.22.1",
  "bytes",
  "derive_builder",
  "eventsource-stream",
@@ -293,7 +293,7 @@ dependencies = [
  "axum-core 0.4.5",
  "bytes",
  "futures-util",
- "http",
+ "http 1.3.1",
  "http-body",
  "http-body-util",
  "itoa",
@@ -321,7 +321,7 @@ dependencies = [
  "bytes",
  "form_urlencoded",
  "futures-util",
- "http",
+ "http 1.3.1",
  "http-body",
  "http-body-util",
  "hyper",
@@ -353,7 +353,7 @@ dependencies = [
  "async-trait",
  "bytes",
  "futures-util",
- "http",
+ "http 1.3.1",
  "http-body",
  "http-body-util",
  "mime",
@@ -372,7 +372,7 @@ checksum = "59446ce19cd142f8833f856eb31f3eb097812d1479ab224f54d72428ca21ea22"
 dependencies = [
  "bytes",
  "futures-core",
- "http",
+ "http 1.3.1",
  "http-body",
  "http-body-util",
  "mime",
@@ -395,7 +395,7 @@ dependencies = [
  "cookie",
  "futures-core",
  "futures-util",
- "http",
+ "http 1.3.1",
  "http-body",
  "http-body-util",
  "mime",
@@ -418,7 +418,7 @@ dependencies = [
 
 [[package]]
 name = "b00t-c0re-lib"
-version = "0.7.26"
+version = "0.7.35"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -450,7 +450,7 @@ dependencies = [
 
 [[package]]
 name = "b00t-chat"
-version = "0.7.26"
+version = "0.7.35"
 dependencies = [
  "anyhow",
  "async-nats",
@@ -488,7 +488,7 @@ dependencies = [
 
 [[package]]
 name = "b00t-cli"
-version = "0.7.26"
+version = "0.7.35"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -522,13 +522,14 @@ dependencies = [
  "tokio",
  "toml",
  "tracing",
+ "url",
  "uuid",
  "whoami",
 ]
 
 [[package]]
 name = "b00t-grok"
-version = "0.7.26"
+version = "0.7.35"
 dependencies = [
  "anyhow",
  "async-openai",
@@ -547,7 +548,7 @@ dependencies = [
 
 [[package]]
 name = "b00t-ipc"
-version = "0.7.26"
+version = "0.7.35"
 dependencies = [
  "anyhow",
  "async-nats",
@@ -566,7 +567,7 @@ dependencies = [
 
 [[package]]
 name = "b00t-mcp"
-version = "0.7.26"
+version = "0.7.35"
 dependencies = [
  "anyhow",
  "axum 0.8.7",
@@ -575,7 +576,7 @@ dependencies = [
  "b00t-c0re-lib",
  "b00t-chat",
  "b00t-cli",
- "base64",
+ "base64 0.22.1",
  "chrono",
  "clap",
  "dirs",
@@ -606,7 +607,7 @@ dependencies = [
 
 [[package]]
 name = "b00t-py"
-version = "0.7.26"
+version = "0.7.35"
 dependencies = [
  "anyhow",
  "b00t-c0re-lib",
@@ -648,6 +649,12 @@ name = "base16ct"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
+
+[[package]]
+name = "base64"
+version = "0.21.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
 name = "base64"
@@ -1632,6 +1639,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "fs2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "fs_extra"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1822,6 +1839,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "gremlin-client"
+version = "0.8.10"
+source = "git+https://github.com/wolf4ood/gremlin-rs.git#d2505d3f80afb244442d66556ef2e2fac75234e0"
+dependencies = [
+ "base64 0.21.7",
+ "chrono",
+ "lazy_static",
+ "native-tls",
+ "r2d2",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "thiserror 1.0.69",
+ "tungstenite",
+ "uuid",
+]
+
+[[package]]
 name = "group"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1843,7 +1878,7 @@ dependencies = [
  "fnv",
  "futures-core",
  "futures-sink",
- "http",
+ "http 1.3.1",
  "indexmap 2.12.0",
  "slab",
  "tokio",
@@ -1926,6 +1961,17 @@ dependencies = [
 
 [[package]]
 name = "http"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
+name = "http"
 version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4a85d31aea989eead29a3aaf9e1115a180df8282431156e533de47660892565"
@@ -1942,7 +1988,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
- "http",
+ "http 1.3.1",
 ]
 
 [[package]]
@@ -1953,7 +1999,7 @@ checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
 dependencies = [
  "bytes",
  "futures-core",
- "http",
+ "http 1.3.1",
  "http-body",
  "pin-project-lite",
 ]
@@ -1990,7 +2036,7 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "h2",
- "http",
+ "http 1.3.1",
  "http-body",
  "httparse",
  "httpdate",
@@ -2008,7 +2054,7 @@ version = "0.27.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
 dependencies = [
- "http",
+ "http 1.3.1",
  "hyper",
  "hyper-util",
  "log",
@@ -2056,12 +2102,12 @@ version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52e9a2a24dc5c6821e71a7030e1e14b7b632acac55c40e9d2e082c621261bb56"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-channel",
  "futures-core",
  "futures-util",
- "http",
+ "http 1.3.1",
  "http-body",
  "hyper",
  "ipnet",
@@ -2413,7 +2459,7 @@ version = "10.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c76e1c7d7df3e34443b3621b459b066a7b79644f059fc8b2db7070c825fd417e"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "ed25519-dalek",
  "getrandom 0.2.16",
  "hmac",
@@ -2432,7 +2478,7 @@ dependencies = [
 
 [[package]]
 name = "k0mmand3r"
-version = "0.7.26"
+version = "0.7.35"
 dependencies = [
  "decimal-rs",
  "indexmap 2.12.0",
@@ -2450,7 +2496,7 @@ version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d13f06d5326a915becaffabdfab75051b8cdc260c2a5c06c0e90226ede89a692"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "chrono",
  "serde",
  "serde_json",
@@ -2495,13 +2541,13 @@ version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4987d57a184d2b5294fdad3d7fc7f278899469d21a4da39a8f6ca16426567a36"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "chrono",
  "either",
  "futures",
  "home",
- "http",
+ "http 1.3.1",
  "http-body",
  "http-body-util",
  "hyper",
@@ -2534,7 +2580,7 @@ dependencies = [
  "chrono",
  "derive_more",
  "form_urlencoded",
- "http",
+ "http 1.3.1",
  "json-patch",
  "k8s-openapi",
  "schemars",
@@ -2910,10 +2956,10 @@ version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51e219e79014df21a225b1860a479e2dcd7cbd9130f4defd4bd0e191ea31d67d"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "chrono",
  "getrandom 0.2.16",
- "http",
+ "http 1.3.1",
  "rand 0.8.5",
  "reqwest",
  "serde",
@@ -3005,7 +3051,7 @@ checksum = "d7a6d09a73194e6b66df7c8f1b680f156d916a1a942abf2de06823dd02b7855d"
 dependencies = [
  "async-trait",
  "bytes",
- "http",
+ "http 1.3.1",
  "opentelemetry",
  "reqwest",
 ]
@@ -3016,7 +3062,7 @@ version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a2366db2dca4d2ad033cad11e6ee42844fd727007af5ad04a1730f4cb8163bf"
 dependencies = [
- "http",
+ "http 1.3.1",
  "opentelemetry",
  "opentelemetry-http",
  "opentelemetry-proto",
@@ -3165,7 +3211,7 @@ version = "3.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "serde_core",
 ]
 
@@ -3641,6 +3687,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
+name = "r2d2"
+version = "0.8.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51de85fb3fb6524929c8a2eb85e6b6d363de4e8c48f9e2c2eac4944abc181c93"
+dependencies = [
+ "log",
+ "parking_lot",
+ "scheduled-thread-pool",
+]
+
+[[package]]
 name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3799,14 +3856,14 @@ version = "0.12.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d0946410b9f7b082a427e4ef5c8ff541a88b357bc6c637c40db3a68ac70a36f"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "encoding_rs",
  "futures-channel",
  "futures-core",
  "futures-util",
  "h2",
- "http",
+ "http 1.3.1",
  "http-body",
  "http-body-util",
  "hyper",
@@ -3905,13 +3962,13 @@ checksum = "112bd2e51d1fadd16509be2b3d45bfa197725787627f6addcaffe57294f64e18"
 dependencies = [
  "as-any",
  "async-stream",
- "base64",
+ "base64 0.22.1",
  "bytes",
  "eventsource-stream",
  "futures",
  "futures-timer",
  "glob",
- "http",
+ "http 1.3.1",
  "mime_guess",
  "ordered-float 5.1.0",
  "pin-project-lite",
@@ -3946,11 +4003,11 @@ version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5947688160b56fb6c827e3c20a72c90392a1d7e9dec74749197aa1780ac42ca"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "chrono",
  "futures",
- "http",
+ "http 1.3.1",
  "http-body",
  "http-body-util",
  "paste",
@@ -4195,6 +4252,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "scheduled-thread-pool"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3cbc66816425a074528352f5789333ecff06ca41b36b0b0efdfbb29edc391a19"
+dependencies = [
+ "parking_lot",
+]
+
+[[package]]
 name = "schemars"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4430,6 +4496,17 @@ dependencies = [
  "ryu",
  "serde",
  "unsafe-libyaml",
+]
+
+[[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
 ]
 
 [[package]]
@@ -4867,12 +4944,12 @@ dependencies = [
 
 [[package]]
 name = "tiktoken-rs"
-version = "0.9.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a19830747d9034cd9da43a60eaa8e552dfda7712424aebf187b7a60126bae0d"
+checksum = "25563eeba904d770acf527e8b370fe9a5547bacd20ff84a0b6c3bc41288e5625"
 dependencies = [
  "anyhow",
- "base64",
+ "base64 0.22.1",
  "bstr",
  "fancy-regex",
  "lazy_static",
@@ -4944,6 +5021,29 @@ name = "tinyvec_macros"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
+name = "togaf-cli"
+version = "0.7.35"
+dependencies = [
+ "anyhow",
+ "clap",
+ "gremlin-client",
+ "serde",
+ "serde_json",
+ "togaf-dsl",
+ "tokio",
+]
+
+[[package]]
+name = "togaf-dsl"
+version = "0.7.35"
+dependencies = [
+ "gremlin-client",
+ "regex",
+ "serde",
+ "serde_json",
+]
 
 [[package]]
 name = "tokio"
@@ -5037,11 +5137,11 @@ version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f591660438b3038dd04d16c938271c79e7e06260ad2ea2885a4861bfb238605d"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-core",
  "futures-sink",
- "http",
+ "http 1.3.1",
  "httparse",
  "rand 0.8.5",
  "ring",
@@ -5100,11 +5200,11 @@ dependencies = [
  "async-stream",
  "async-trait",
  "axum 0.7.9",
- "base64",
+ "base64 0.22.1",
  "bytes",
  "flate2",
  "h2",
- "http",
+ "http 1.3.1",
  "http-body",
  "http-body-util",
  "hyper",
@@ -5132,9 +5232,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb7613188ce9f7df5bfe185db26c5814347d110db17920415cf2fbcad85e7203"
 dependencies = [
  "async-trait",
- "base64",
+ "base64 0.22.1",
  "bytes",
- "http",
+ "http 1.3.1",
  "http-body",
  "http-body-util",
  "percent-encoding",
@@ -5200,11 +5300,11 @@ version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adc82fd73de2a9722ac5da747f12383d2bfdb93591ee6c58486e0097890f05f2"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bitflags 2.10.0",
  "bytes",
  "futures-util",
- "http",
+ "http 1.3.1",
  "http-body",
  "iri-string",
  "mime",
@@ -5336,6 +5436,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "tungstenite"
+version = "0.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e3dac10fd62eaf6617d3a904ae222845979aec67c615d1c842b4002c7666fb9"
+dependencies = [
+ "byteorder",
+ "bytes",
+ "data-encoding",
+ "http 0.2.12",
+ "httparse",
+ "log",
+ "native-tls",
+ "rand 0.8.5",
+ "sha1",
+ "thiserror 1.0.69",
+ "url",
+ "utf-8",
+]
+
+[[package]]
 name = "typenum"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5400,6 +5520,12 @@ name = "urlencoding"
 version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
+
+[[package]]
+name = "utf-8"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
 name = "utf8_iter"
@@ -5637,6 +5763,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
 name = "winapi-util"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5644,6 +5786,12 @@ checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows"

--- a/b00t-cli/src/commands/lfmf.rs
+++ b/b00t-cli/src/commands/lfmf.rs
@@ -1,4 +1,4 @@
-use anyhow::{Context, Result};
+use anyhow::Result;
 use b00t_c0re_lib::LfmfSystem;
 use tiktoken_rs::o200k_base;
 

--- a/b00t-cli/src/datum_config.rs
+++ b/b00t-cli/src/datum_config.rs
@@ -316,7 +316,6 @@ impl ConfigDatum {
             protocol: None,
             implements: None,
             provides: None,
-            requires: None,
             learn: None,
             usage: None,
             lfmf_category: None,

--- a/b00t-cli/src/datum_job.rs
+++ b/b00t-cli/src/datum_job.rs
@@ -23,7 +23,6 @@
 //! command = "cargo test --all"
 //! ```
 
-use crate::BootDatum;
 use anyhow::Result;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;

--- a/b00t-cli/src/lib.rs
+++ b/b00t-cli/src/lib.rs
@@ -71,21 +71,6 @@ pub struct UnifiedConfig {
 }
 
 #[derive(Deserialize, Serialize, Debug, Clone, PartialEq, Default)]
-pub struct UsageExample {
-    pub description: String,
-    pub command: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub output: Option<String>,
-}
-
-#[derive(Deserialize, Serialize, Debug, Clone, PartialEq, Default)]
-pub struct LearnMeta {
-    pub topic: Option<String>,
-    pub inline: Option<String>,
-    pub auto_digest: Option<bool>,
-}
-
-#[derive(Deserialize, Serialize, Debug, Clone, PartialEq, Default)]
 pub struct BudgetConstraint {
     pub daily_limit: Option<f64>,
     pub cost_per_job: Option<f64>,
@@ -202,7 +187,7 @@ pub struct BootDatum {
     pub dsn: Option<String>,
 
     // RAG / learn metadata
-    pub learn: Option<LearnMeta>,
+    pub learn: Option<LearnMetadata>,
     pub lfmf_category: Option<String>,
     pub usage: Option<Vec<UsageExample>>,
 

--- a/b00t-cli/src/main.rs
+++ b/b00t-cli/src/main.rs
@@ -1,15 +1,12 @@
 use anyhow::Result;
 use clap::Parser;
 use duct::cmd;
-// use regex::Regex;
-// use semver::Version;
 use std::fs;
-// use std::io::{Read};
-// use std::path::PathBuf;
-// 🤓 cleaned up unused Tera import after switching to simple string replacement
-use b00t_cli::{commands, load_datum_providers, session_memory, AiConfig, BootDatum, SessionState, UnifiedConfig, handle_up_command, whoami};
+use b00t_cli::{AiConfig, BootDatum, SessionState, UnifiedConfig, whoami, load_datum_providers, handle_up_command};
 
+mod ansible;
 mod bootstrap;
+mod budget_controller;
 mod cloud_sync;
 mod commands;
 mod datum_ai;
@@ -19,16 +16,20 @@ mod datum_bash;
 mod datum_cli;
 mod datum_docker;
 mod datum_gemini;
+mod datum_job;
 mod datum_mcp;
+mod datum_stack;
 mod datum_utils;
 mod datum_vscode;
+mod dependency_resolver;
+mod job_state;
+mod model_manager;
 mod session_memory;
 mod test_cloud_integration;
 mod traits;
 mod utils;
 use utils::get_workspace_root;
 
-// 🦨 REMOVED unused K8sDatum import - not used in main.rs
 use datum_ai::AiDatum;
 use datum_ai_model::AiModelDatumEntry;
 use datum_apt::AptDatum;
@@ -41,32 +42,11 @@ use traits::*;
 
 use crate::commands::learn::{LearnArgs, handle_learn};
 use crate::commands::{
-    AiCommands, AppCommands, BootstrapCommands, ChatCommands, CliCommands, DatumCommands,
-    GrokCommands, InitCommands, InstallCommands, K8sCommands, McpCommands, ModelCommands,
+    AiCommands, AgentCommands, AnsibleCommands, AppCommands, BootstrapCommands, ChatCommands, CliCommands, DatumCommands,
+    GrokCommands, InitCommands, InstallCommands, JobCommands, K8sCommands, McpCommands, ModelCommands,
     SessionCommands, StackCommands, WhatismyCommands,
 };
-
-
-// 🦨 Module declarations removed - these are declared in lib.rs now
-// Import from b00t_cli:: instead
-use b00t_cli::datum_ai::AiDatum;
-use b00t_cli::datum_ai_model::AiModelDatumEntry;
-use b00t_cli::datum_apt::AptDatum;
-use b00t_cli::datum_bash::BashDatum;
-use b00t_cli::datum_cli::CliDatum;
-use b00t_cli::datum_docker::DockerDatum;
-use b00t_cli::datum_mcp::McpDatum;
-use b00t_cli::datum_vscode::VscodeDatum;
-use b00t_cli::traits::*;
-
-use b00t_cli::commands::learn::handle_learn;
-use b00t_cli::commands::{
-    AiCommands, AgentCommands, AnsibleCommands, AppCommands, ChatCommands, CliCommands,
-    DatumCommands, GrokCommands, InitCommands, InstallCommands, JobCommands, K8sCommands, McpCommands,
-    SessionCommands, StackCommands,  WhatismyCommands,
-};
-use b00t_cli::commands::learn::handle_learn;
-use b00t_cli::commands::install::{install_datum, run_just_install};
+use crate::commands::install::{install_datum, run_just_install};
 
 // Re-export commonly used functions for datum modules
 pub use b00t_cli::{
@@ -214,6 +194,7 @@ The system will:
     Ansible {
         #[clap(subcommand)]
         ansible_command: commands::ansible::AnsibleCommands,
+    },
     #[clap(
         about = "AI model datum management",
         long_about = "List, inspect, install, and activate AI model datums defined in the _b00t_ directory."
@@ -284,11 +265,6 @@ The system will:
         #[clap(subcommand)]
         k8s_command: K8sCommands,
     },
-    #[clap(about = "Run 'just install' to install b00t components")]
-    Install {
-        #[clap(subcommand)]
-        install_command: InstallCommands,
-    },
     #[clap(about = "Session management")]
     Session {
         #[clap(subcommand)]
@@ -313,17 +289,6 @@ The system will:
     // 🤓 ENTANGLED (synchronized): b00t-mcp/src/mcp_tools.rs LearnCommand now uses LearnArgs wrapper, matching CLI structure.
     // Unified knowledge command: LFMF lessons, learn docs, man pages, RAG
     Learn(LearnArgs),
-    #[clap(about = "Record a Lesson From My Failure (LFMF)")]
-    Lfmf {
-        #[clap(long, help = "Tool/category name")]
-        tool: Option<String>,
-        #[clap(long, help = "Lesson text")]
-        lesson: Option<String>,
-        #[clap(long, help = "Repository path for repo-scoped lessons")]
-        repo: Option<String>,
-        #[clap(long, help = "Store lesson globally instead of repo")]
-        global: bool,
-    },
     #[clap(about = "Datum management and inspection")]
     Datum {
         #[clap(subcommand)]
@@ -333,11 +298,6 @@ The system will:
     Grok {
         #[clap(subcommand)]
         grok_command: GrokCommands,
-    },
-    #[clap(about = "Run ansible playbooks via datum metadata or direct path")]
-    Ansible {
-        #[clap(subcommand)]
-        ansible_command: AnsibleCommands,
     },
     #[clap(about = "Install a datum (auto-resolves dependencies) or run bootstrap install when no name is provided")]
     Install {
@@ -421,57 +381,6 @@ fn datum_providers_to_tool_status(providers: Vec<Box<dyn DatumProvider>>) -> Vec
             }
         })
         .collect()
-}
-
-fn handle_up_command(_b00t_path: &str, yes: bool) -> Result<()> {
-    use b00t_cli::datum_config::B00tConfig;
-
-    // Load or create configuration
-    let (config, config_path) = B00tConfig::load_or_create()?;
-
-    if yes {
-        println!("🔄 Updating all datums from {}...", config_path.display());
-    } else {
-        println!(
-            "🔍 Checking all datums from {} (use --yes to update)...",
-            config_path.display()
-        );
-    }
-
-    // If config file doesn't exist yet, show helpful message
-    if !config_path.exists() {
-        println!("\n⚠️  No _b00t_.toml found at {}", config_path.display());
-        println!("   Create one to track your installed datums:\n");
-        println!("   Example _b00t_.toml:");
-        println!("   ---");
-        println!("   version = \"{}\"", b00t_c0re_lib::version::VERSION);
-        println!("   initialized = \"{}\"", chrono::Utc::now().to_rfc3339());
-        println!("   install_methods = [\"docker\", \"pkgx\", \"apt\", \"curl\"]");
-        println!("   datums = [");
-        println!("     \"git.cli\",");
-        println!("     \"docker.docker\",");
-        println!("     \"rust.*\",    # All rust-related datums");
-        println!("     \"ai.*\",      # All AI providers");
-        println!("   ]");
-        println!("   ---\n");
-        println!("💡 Run `b00t install` to auto-create and update this file.");
-        return Ok(());
-    }
-
-    println!("\n📋 Configuration loaded:");
-    println!("   Version: {}", config.version);
-    println!("   Datums: {:?}", config.datums);
-    println!("   Install methods: {:?}", config.install_methods);
-
-    // 🤓 TODO: Implement datum loading and updating
-    // Currently blocked by trait version conflicts - needs refactoring
-    println!("\n⚠️  Full datum checking not yet implemented");
-    println!("   Next steps:");
-    println!("   1. Load datums from _b00t_ path");
-    println!("   2. Match against configured patterns");
-    println!("   3. Check versions and update if --yes flag is set");
-
-    Ok(())
 }
 
 fn checkpoint(message: Option<&str>, skip_tests: bool) -> Result<()> {
@@ -578,17 +487,6 @@ fn checkpoint(message: Option<&str>, skip_tests: bool) -> Result<()> {
     }
 
     Ok(())
-}
-
-/// Generic function to load datum providers for a specific file extension
-/// Replaces the 7 duplicate get_*_tools_status functions
-fn load_datum_providers<T>(path: &str, extension: &str) -> Result<Vec<Box<dyn DatumProvider>>>
-where
-    T: DatumProvider + 'static,
-    T: for<'a> TryFrom<(&'a str, &'a str), Error = anyhow::Error>,
-{
-    // Delegate to the implementation provided by the library crate to avoid duplication.
-    b00t_cli::load_datum_providers::<T>(path, extension)
 }
 
 fn show_status(
@@ -1305,42 +1203,24 @@ async fn main() {
                 std::process::exit(1);
             }
         }
-        Some(Commands::Install { install_command }) => {
-            if let Err(e) = install_command.execute(&cli.path) {
-                eprintln!("Error: {}", e);
-                std::process::exit(1);
-            }
-        }
         Some(Commands::Session { session_command }) => {
             if let Err(e) = session_command.execute(&cli.path) {
                 eprintln!("Error: {}", e);
                 std::process::exit(1);
             }
         }
-        Some(Commands::Learn { args }) => {
+        Some(Commands::Learn(args)) => {
             if let Err(e) = handle_learn(&cli.path, args.clone()).await {
                 eprintln!("Error: {}", e);
                 std::process::exit(1);
             }
         }
         Some(Commands::Grok { grok_command }) => {
-            use b00t_cli::commands::grok::handle_grok_command;
+            use crate::commands::grok::handle_grok_command;
 
             // 🤓 No need for nested runtime - already in #[tokio::main]
             if let Err(e) = handle_grok_command(grok_command.clone()).await {
                 eprintln!("Error: {}", e);
-                std::process::exit(1);
-            }
-        }
-        Some(Commands::Lfmf {
-            tool,
-            lesson,
-            repo,
-            global,
-        }) => {
-        Some(Commands::Ansible { ansible_command }) => {
-            if let Err(e) = ansible_command.execute(&cli.path) {
-                eprintln!("Ansible Error: {}", e);
                 std::process::exit(1);
             }
         }
@@ -1384,14 +1264,8 @@ async fn main() {
                 std::process::exit(1);
             }
         }
-        Some(Commands::Up { yes }) => {
-            if let Err(e) = handle_up_command(&cli.path, *yes) {
-                eprintln!("Error: {}", e);
-                std::process::exit(1);
-            }
-        }
         Some(Commands::Bootstrap { bootstrap_command }) => {
-            use b00t_cli::commands::bootstrap::handle_bootstrap_command;
+            use crate::commands::bootstrap::handle_bootstrap_command;
 
             if let Err(e) = handle_bootstrap_command(bootstrap_command.clone()).await {
                 eprintln!("Error: {}", e);
@@ -1399,7 +1273,7 @@ async fn main() {
             }
         }
         Some(Commands::Script { script_command }) => {
-            use b00t_cli::commands::script::handle_script_command;
+            use crate::commands::script::handle_script_command;
 
             if let Err(e) = handle_script_command(script_command.clone()) {
                 eprintln!("Error: {}", e);


### PR DESCRIPTION
- Remove duplicate UsageExample definition (use b00t_c0re_lib export)
- Replace LearnMeta with LearnMetadata from b00t_c0re_lib
- Fix  field name to  in BootDatum
- Remove duplicate Lfmf, Ansible, Install command enum variants
- Remove duplicate match arms in main()
- Remove local load_datum_providers and handle_up_command wrappers
- Remove all b00t_cli:: imports that duplicate local mod declarations
- Add missing mod declarations: ansible, budget_controller, datum_job, datum_stack, dependency_resolver, job_state, model_manager
- Fix Commands::Learn from struct to tuple variant
- Fix missing closing brace in Ansible enum variant
- Remove unused imports (Context, BootDatum, Process)

Still TODO: Fix trait bound errors for DatumProvider implementations
