### PR TITLE
fix: remove missing togaf workspace members

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,8 +8,8 @@ members = [
     "k0mmand3r",
     "b00t-py",
     "b00t-ipc",
-    "togaf-dsl",
-    "togaf-cli",
+    # "togaf-dsl",  # 🦨 Removed - directory does not exist
+    # "togaf-cli",  # 🦨 Removed - directory does not exist
 ]
 resolver = "2"
 


### PR DESCRIPTION
Fixes cargo workspace errors by commenting out references to non-existent `togaf-dsl` and `togaf-cli` directories.

This allows `just install` and other cargo workspace commands to run successfully.