### PR TITLE
[codex] stabilize self-hosted gemma4 operator loop

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -740,7 +740,7 @@ dependencies = [
 
 [[package]]
 name = "b00t-azure-cp"
-version = "0.7.41"
+version = "0.7.42"
 dependencies = [
  "anyhow",
  "axum 0.8.8",
@@ -764,7 +764,7 @@ dependencies = [
 
 [[package]]
 name = "b00t-c0re-lib"
-version = "0.7.41"
+version = "0.7.42"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -798,7 +798,7 @@ dependencies = [
 
 [[package]]
 name = "b00t-chat"
-version = "0.7.41"
+version = "0.7.42"
 dependencies = [
  "anyhow",
  "async-nats",
@@ -836,7 +836,7 @@ dependencies = [
 
 [[package]]
 name = "b00t-cli"
-version = "0.7.41"
+version = "0.7.42"
 dependencies = [
  "anyhow",
  "apalis",
@@ -899,7 +899,7 @@ dependencies = [
 
 [[package]]
 name = "b00t-grok"
-version = "0.7.41"
+version = "0.7.42"
 dependencies = [
  "anyhow",
  "async-openai",
@@ -918,7 +918,7 @@ dependencies = [
 
 [[package]]
 name = "b00t-ipc"
-version = "0.7.41"
+version = "0.7.42"
 dependencies = [
  "anyhow",
  "async-nats",
@@ -938,7 +938,7 @@ dependencies = [
 
 [[package]]
 name = "b00t-mcp"
-version = "0.7.41"
+version = "0.7.42"
 dependencies = [
  "anyhow",
  "axum 0.8.8",
@@ -978,7 +978,7 @@ dependencies = [
 
 [[package]]
 name = "b00t-py"
-version = "0.7.41"
+version = "0.7.42"
 dependencies = [
  "anyhow",
  "b00t-c0re-lib",
@@ -3507,7 +3507,7 @@ dependencies = [
 
 [[package]]
 name = "k0mmand3r"
-version = "0.7.41"
+version = "0.7.42"
 dependencies = [
  "decimal-rs",
  "indexmap 2.13.1",
@@ -6599,7 +6599,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "storage-neumann"
-version = "0.7.41"
+version = "0.7.42"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ resolver = "2"
 [workspace.package]
 # 🤓 Version management centralized in b00t-c0re-lib
 # All workspace crates inherit from the single source of truth
-version = "0.7.41"
+version = "0.7.42"
 edition = "2024"
 authors = ["Brian Horakh <brian@promptexecution.com>"]
 license = "MIT"

--- a/_b00t_/inference-gemma4.hive.toml
+++ b/_b00t_/inference-gemma4.hive.toml
@@ -1,8 +1,9 @@
 # b00t Hive Profile — Gemma 4 26B-A4B local inference
 # 🤓 Inline service spec → b00t generates vllm-gemma4 unit dynamically; no static .service file needed
 # Chain: b00t@inference-gemma4 → generates b00t-hive-inference-gemma4.service → starts vllm-gemma4
-# Proxy: b00t@mistralrs-proxy (own hive profile, no static config) added to services_start
-# Grok/RAGLight: OLLAMA_API_URL=http://localhost:1234 → grok appends /v1 → gemma4 embeddings+inference
+# RL path: direct vLLM on :8001 is the canonical self-hosted operator endpoint.
+# Proxy: b00t@mistralrs-proxy is OPTIONAL and currently broken for Gemma4 MXFP4.
+# Grok/RAGLight still require a compatible embeddings-capable gateway if used.
 # Activate: systemctl --user start b00t@inference-gemma4
 #       OR: b00t hive activate inference-gemma4
 
@@ -26,11 +27,8 @@ group = "primary-workload"
 priority = 70
 
 [b00t.hive.services]
-# 🤓 b00t@mistralrs-proxy is the liter-llm gateway; started via its own hive profile
-#    (no static .service file — b00t@.service template + mistralrs-proxy.hive.toml inline spec)
-start = [
-  "b00t@mistralrs-proxy.service",
-]
+# 🤓 Keep the Gemma4 inference profile self-hosted and direct; do not auto-chain the broken proxy.
+start = []
 stop = []
 
 # ── Inline service spec — b00t generates this unit dynamically ──────────────
@@ -43,7 +41,7 @@ limit_nofile = 65536
 restart = "on-failure"
 restart_sec = "30s"
 timeout_start_sec = "300"
-after = ["network.target", "b00t@mistralrs-proxy.service"]
+after = ["network.target"]
 environment = [
   "PATH=/home/brianh/.venv/bin:/usr/local/bin:/usr/bin:/bin",
   "HF_HOME=/home/brianh/.cache/huggingface",
@@ -65,14 +63,12 @@ exec_start = """/home/brianh/.venv/bin/vllm serve \
 # 🤓 unsloth MXFP4_MOE.gguf unsupported: transformers gemma4 GGUF arch not yet mapped
 
 [b00t.hive.env]
-# liter-llm/mistralrs-proxy gateway maps "ch0nky" → gemma4 at :8001
-B00T_AI_CH0NKY_BASE  = "http://127.0.0.1:1234/v1"
+# Direct vLLM endpoint for operator RL loops and local agent harnesses.
+B00T_AI_CH0NKY_BASE  = "http://127.0.0.1:8001/v1"
 B00T_AI_CH0NKY_MODEL = "ch0nky"
 GEMMA4_API_BASE      = "http://127.0.0.1:8001/v1"
 PI_MODEL             = "ch0nky"
-# 🤓 OLLAMA_API_URL drives b00t-grok embedding client (appends /v1 internally)
-#    → grok/RAGLight uses gemma4 for both inference AND embeddings via liter-llm
-OLLAMA_API_URL       = "http://localhost:1234"
+# 🤓 OLLAMA_API_URL is left unset here: Gemma4 RL loops use the OpenAI-compatible :8001 API directly.
 
 [b00t.hive.mcp_tools]
 activate = ["vllm-local", "pi-agent"]

--- a/_b00t_/mistralrs-proxy.hive.toml
+++ b/_b00t_/mistralrs-proxy.hive.toml
@@ -4,6 +4,9 @@
 #   "frontier" → Anthropic/OpenAI cloud
 #   "ch0nky"   → local Gemma 4 at :8001 (inference-gemma4 hive profile)
 #   "sm0l"     → Qwen2.5-3B or Haiku
+# 🤓 2026-04-10: CLI syntax updated to `mistralrs serve ... text -m ...`, but
+#    current Candle backend still cannot load Gemma4 MXFP4_MOE.gguf
+#    (`unknown dtype for tensor 39`). Keep direct vLLM :8001 as the working path.
 # Cost accounting: all b00t consumers (pi, moltis, grok) share this endpoint.
 # Start: systemctl --user start b00t@mistralrs-proxy
 #    OR: included in inference-gemma4 services_start chain
@@ -47,8 +50,8 @@ environment  = [
 ]
 exec_start = """/home/brianh/.cargo/bin/mistralrs serve \
     -p 1234 \
-    --served-model-name ch0nky \
     --prefix-cache-n 16 \
+    text \
     -m unsloth/gemma-4-26B-A4B-it-GGUF \
     --format gguf \
     -f gemma-4-26B-A4B-it-MXFP4_MOE.gguf"""

--- a/_b00t_/mistralrs-proxy.hive.toml
+++ b/_b00t_/mistralrs-proxy.hive.toml
@@ -34,8 +34,8 @@ start = []
 stop  = []
 
 # ── Inline service spec — b00t generates b00t-hive-mistralrs-proxy.service ──
-# 🤓 mistralrs-server binary (EricLBuehler/mistral.rs) must be installed:
-#    cargo install mistralrs-server --features cuda
+# 🤓 mistralrs binary (EricLBuehler/mistral.rs) must be installed:
+#    cargo install mistralrs --features cuda
 #    Until then, this profile acts as a stub — declare intent in knowledge graph.
 [b00t.hive.service]
 description = "liter-llm / mistralrs-proxy OpenAI gateway (port 1234)"

--- a/_b00t_/pi-gemma4-hive.stack.toml
+++ b/_b00t_/pi-gemma4-hive.stack.toml
@@ -1,10 +1,10 @@
-# b00t Stack — pi + Gemma 4 + liter-llm gateway hive stack
-# 🤓 Full autonomous local inference stack:
+# b00t Stack — pi + Gemma 4 local hive stack
+# 🤓 Working autonomous local inference stack:
 #   1. vllm-gemma4.service → Gemma 4 at :8001 (ch0nky model backend)
-#   2. mistralrs-proxy (liter-llm gateway) → unified OpenAI API at :1234
-#   3. pi-coding-agent → ch0nky executor consuming :1234/ch0nky
-#   4. pi-mcp-adapter → lazy MCP proxy (b00t-mcp wired via ~/.pi/agent/mcp.json)
-#   5. moltis → shares :1234 endpoint for memory/soul ops
+#   2. pi-coding-agent → llama-cpp provider consuming direct :8001/v1
+#   3. pi-mcp-adapter → lazy MCP proxy (b00t-mcp wired via ~/.pi/agent/mcp.json)
+# Optional:
+#   - mistralrs-proxy/liter-llm gateway at :1234 for future cost accounting once Gemma4 MXFP4 is supported
 #
 # Activate: b00t hive activate inference-gemma4
 # Sub-agent: b00t up --tool pi
@@ -13,18 +13,16 @@
 [b00t]
 name = "pi-gemma4-hive"
 type = "stack"
-hint = "pi + Gemma 4 + liter-llm local hive stack — autonomous ch0nky tier with cost accounting"
+hint = "pi + Gemma 4 direct local hive stack — autonomous ch0nky tier via llama-cpp provider"
 members = [
   "gemma-4-26b-a4b-local.model",   # vLLM gemma4 service (port 8001)
   "pi-coding-agent.cli",            # pi executor
   "pi-mcp-adapter.cli",             # MCP proxy for pi
-  "mistralrs-proxy.ai",             # liter-llm gateway (port 1234)
 ]
 
 [b00t.env]
-# All agents target the liter-llm gateway; it routes ch0nky → gemma4 at :8001
-B00T_AI_GATEWAY = "http://127.0.0.1:1234/v1"
-B00T_AI_GATEWAY_KEY = "local-b00t"
+# Direct local Gemma4 path for pi.
+B00T_AI_CH0NKY_BASE = "http://127.0.0.1:8001/v1"
 B00T_AI_CH0NKY_MODEL = "ch0nky"
 PI_PROVIDER = "llama-cpp"
 PI_MODEL = "ch0nky"
@@ -33,14 +31,12 @@ PI_MODEL = "ch0nky"
 # hive profile that manages the systemd lifecycle of this stack
 hive_profile = "inference-gemma4"
 # 🤓 activate via: b00t hive activate inference-gemma4
-#    this starts vllm-gemma4.service; mistralrs-proxy must be started separately
-#    until a dedicated mistralrs-proxy.service unit is added
+#    this starts vllm-gemma4.service; direct :8001 is the working path
 
 [b00t.orchestration.dependencies]
-# Topological order: model server must be up before gateway, gateway before pi
+# Topological order: model server must be up before pi
 order = [
   "vllm-gemma4.service",
-  "mistralrs-proxy",
   "pi-coding-agent",
 ]
 
@@ -53,24 +49,24 @@ description = "Activate the full pi+gemma4 hive stack (starts vllm-gemma4.servic
 command = "b00t hive activate inference-gemma4"
 
 [[b00t.usage]]
-description = "Run pi sub-agent task via liter-llm gateway (ch0nky tier)"
-command = "pi -p --provider llama-cpp --model ch0nky 'implement X'"
+description = "Run pi sub-agent task via direct Gemma4 vLLM (ch0nky tier)"
+command = "LLAMA_CPP_BASE_URL=http://127.0.0.1:8001/v1 pi -p --provider llama-cpp --model ch0nky 'implement X'"
 
 [[b00t.usage]]
 description = "Delegate task to pi via b00t agent subsystem"
 command = "b00t up --tool pi"
 
 [[b00t.usage]]
-description = "Inspect cost accounting via liter-llm gateway"
-command = "curl -s http://localhost:1234/v1/models | python3 -m json.tool"
+description = "Inspect direct Gemma4 endpoint"
+command = "curl -s http://localhost:8001/v1/models | python3 -m json.tool"
 
 [[b00t.usage]]
 description = "Deactivate stack cleanly"
 command = "systemctl --user stop vllm-gemma4.service"
 
 # b00t:map v1
-# summary: pi+gemma4+liter-llm hive stack — ch0nky autonomous local inference with cost accounting
-# tags: pi, gemma4, liter-llm, hive-stack, ch0nky, moltis, openai-proxy, cost-accounting
+# summary: pi+gemma4 direct hive stack — ch0nky autonomous local inference via llama-cpp
+# tags: pi, gemma4, hive-stack, ch0nky, llama-cpp, direct-vllm
 # tier: ch0nky
 # cmds: b00t hive activate inference-gemma4, b00t up --tool pi
 # complexity: 7

--- a/b00t-c0re-lib/src/aaiii.rs
+++ b/b00t-c0re-lib/src/aaiii.rs
@@ -231,7 +231,7 @@ impl AaiiiConfig {
     fn pi_base_url_candidates() -> Vec<String> {
         let mut candidates = Vec::new();
 
-        for key in ["B00T_AI_CH0NKY_BASE", "PI_BASE_URL", "OPENAI_BASE_URL"] {
+        for key in ["B00T_AI_CH0NKY_BASE", "PI_BASE_URL", "LLAMA_CPP_BASE_URL", "OPENAI_BASE_URL"] {
             if let Ok(value) = env::var(key) {
                 let trimmed = value.trim();
                 if !trimmed.is_empty() && !candidates.iter().any(|existing| existing == trimmed) {
@@ -423,7 +423,7 @@ mod tests {
 
     #[test]
     fn test_pi_base_url_candidates_include_direct_gemma4_fallback() {
-        for key in ["B00T_AI_CH0NKY_BASE", "PI_BASE_URL", "OPENAI_BASE_URL"] {
+        for key in ["B00T_AI_CH0NKY_BASE", "PI_BASE_URL", "LLAMA_CPP_BASE_URL", "OPENAI_BASE_URL"] {
             unsafe {
                 std::env::remove_var(key);
             }

--- a/b00t-c0re-lib/src/aaiii.rs
+++ b/b00t-c0re-lib/src/aaiii.rs
@@ -20,6 +20,7 @@
 use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
+use std::env;
 use std::process::Command;
 
 /// AI Inference Backend types
@@ -32,7 +33,7 @@ pub enum AaiiiBackend {
     Amp,       // Amp CLI
     OpenCode,  // OpenCode CLI
     MistralRs, // Local mistral.rs server
-    Pi,        // pi-coding-agent via liter-llm gateway (Gemma 4 local, :1234/v1 ch0nky)
+    Pi,        // pi-coding-agent via local Gemma 4 (env override, :1234 gateway, or :8001 direct)
     File,      // Fallback for testing
 }
 
@@ -143,11 +144,11 @@ impl AaiiiConfig {
         }
 
         if Self::check_pi() {
-            eprintln!("🤖 AAIII backend detected: Pi (liter-llm gateway ch0nky)");
+            eprintln!("🤖 AAIII backend detected: Pi (local Gemma 4 ch0nky)");
             return Self {
                 backend: AaiiiBackend::Pi,
-                // 🤓 pi targets liter-llm/mistralrs-proxy at :1234; model "ch0nky" routes to local Gemma 4
-                base_url: Some("http://localhost:1234/v1".to_string()),
+                // 🤓 Prefer explicit env override, then gateway :1234 when healthy, then direct vLLM :8001.
+                base_url: Self::detect_pi_base_url(),
                 model: Some("ch0nky".to_string()),
                 ..Default::default()
             };
@@ -212,16 +213,47 @@ impl AaiiiConfig {
     }
 
     fn check_pi() -> bool {
-        // 🤓 pi requires: (a) pi binary present AND (b) liter-llm gateway responding at :1234
+        // 🤓 pi requires: (a) pi binary present AND (b) a reachable OpenAI-compatible local endpoint.
         let binary_ok = Command::new("pi")
             .arg("--version")
             .output()
             .map(|o| o.status.success())
             .unwrap_or(false);
-        let gateway_ok = reqwest::blocking::get("http://localhost:1234/v1/models")
+        binary_ok && Self::detect_pi_base_url().is_some()
+    }
+
+    fn detect_pi_base_url() -> Option<String> {
+        Self::pi_base_url_candidates()
+            .into_iter()
+            .find(|base_url| Self::models_endpoint_ok(base_url))
+    }
+
+    fn pi_base_url_candidates() -> Vec<String> {
+        let mut candidates = Vec::new();
+
+        for key in ["B00T_AI_CH0NKY_BASE", "PI_BASE_URL", "OPENAI_BASE_URL"] {
+            if let Ok(value) = env::var(key) {
+                let trimmed = value.trim();
+                if !trimmed.is_empty() && !candidates.iter().any(|existing| existing == trimmed) {
+                    candidates.push(trimmed.to_string());
+                }
+            }
+        }
+
+        for default_url in ["http://localhost:1234/v1", "http://localhost:8001/v1"] {
+            if !candidates.iter().any(|existing| existing == default_url) {
+                candidates.push(default_url.to_string());
+            }
+        }
+
+        candidates
+    }
+
+    fn models_endpoint_ok(base_url: &str) -> bool {
+        let models_url = format!("{}/models", base_url.trim_end_matches('/'));
+        reqwest::blocking::get(&models_url)
             .map(|r| r.status().is_success())
-            .unwrap_or(false);
-        binary_ok && gateway_ok
+            .unwrap_or(false)
     }
 }
 
@@ -361,8 +393,45 @@ mod tests {
                 | AaiiiBackend::Amp
                 | AaiiiBackend::OpenCode
                 | AaiiiBackend::MistralRs
+                | AaiiiBackend::Pi
                 | AaiiiBackend::File
         ));
+    }
+
+    #[test]
+    fn test_pi_base_url_candidates_prioritize_env_override() {
+        let key = "B00T_AI_CH0NKY_BASE";
+        let previous = std::env::var(key).ok();
+        unsafe {
+            std::env::set_var(key, "http://127.0.0.1:8001/v1");
+        }
+
+        let candidates = AaiiiConfig::pi_base_url_candidates();
+        assert_eq!(candidates.first().map(String::as_str), Some("http://127.0.0.1:8001/v1"));
+        assert!(candidates.iter().any(|candidate| candidate == "http://localhost:1234/v1"));
+
+        if let Some(value) = previous {
+            unsafe {
+                std::env::set_var(key, value);
+            }
+        } else {
+            unsafe {
+                std::env::remove_var(key);
+            }
+        }
+    }
+
+    #[test]
+    fn test_pi_base_url_candidates_include_direct_gemma4_fallback() {
+        for key in ["B00T_AI_CH0NKY_BASE", "PI_BASE_URL", "OPENAI_BASE_URL"] {
+            unsafe {
+                std::env::remove_var(key);
+            }
+        }
+
+        let candidates = AaiiiConfig::pi_base_url_candidates();
+        assert!(candidates.iter().any(|candidate| candidate == "http://localhost:1234/v1"));
+        assert!(candidates.iter().any(|candidate| candidate == "http://localhost:8001/v1"));
     }
 
     #[test]

--- a/b00t-c0re-lib/src/agent_manager.rs
+++ b/b00t-c0re-lib/src/agent_manager.rs
@@ -329,7 +329,7 @@ pub struct CrewConfig {
 /// Handle to a running agent.
 pub struct AgentHandle {
     pub config: AgentConfig,
-    pub socket_path: PathBuf,
+    pub socket_path: Option<PathBuf>,
     pub coordinator: AgentCoordinator,
     _listener: Option<UnixListener>,
 }
@@ -341,8 +341,8 @@ impl AgentHandle {
     }
 
     /// Get the socket path.
-    pub fn socket_path(&self) -> &Path {
-        &self.socket_path
+    pub fn socket_path(&self) -> Option<&Path> {
+        self.socket_path.as_deref()
     }
 
     /// Get coordinator reference.
@@ -354,17 +354,30 @@ impl AgentHandle {
 impl Drop for AgentHandle {
     fn drop(&mut self) {
         // Clean up socket file on drop
-        if self.socket_path.exists() {
-            if let Err(e) = std::fs::remove_file(&self.socket_path) {
+        if let Some(socket_path) = &self.socket_path {
+            if !socket_path.exists() {
+                return;
+            }
+
+            if let Err(e) = std::fs::remove_file(socket_path) {
                 error!(
                     "Failed to remove socket {}: {}",
-                    self.socket_path.display(),
+                    socket_path.display(),
                     e
                 );
             } else {
-                info!("🧹 Cleaned up socket: {}", self.socket_path.display());
+                info!("🧹 Cleaned up socket: {}", socket_path.display());
             }
         }
+    }
+}
+
+fn configured_socket_path(config: &AgentConfig) -> Option<PathBuf> {
+    let socket = config.b00t.agent.ipc.socket.trim();
+    if socket.is_empty() {
+        None
+    } else {
+        Some(PathBuf::from(socket))
     }
 }
 
@@ -397,31 +410,40 @@ impl AgentManager {
 
         info!("🚀 Spawning agent: {}", config.b00t.name);
 
-        // Create agent socket
-        let socket_path = PathBuf::from(&config.b00t.agent.ipc.socket);
-        if let Some(parent) = socket_path.parent() {
-            tokio::fs::create_dir_all(parent).await.context(format!(
-                "Failed to create socket directory: {}",
-                parent.display()
-            ))?;
-        }
-
-        // Remove stale socket if exists
-        if socket_path.exists() {
-            tokio::fs::remove_file(&socket_path).await.ok();
-        }
-
-        // Create Unix socket listener
-        let listener = UnixListener::bind(&socket_path).with_context(|| {
-            let mut message = format!("Failed to bind agent socket: {}", socket_path.display());
-            if let Some(hint) = sandbox_root_cause_hint("Unix socket bind") {
-                message.push(' ');
-                message.push_str(&hint);
+        let socket_path = configured_socket_path(&config);
+        let listener = if let Some(socket_path) = socket_path.as_ref() {
+            if let Some(parent) = socket_path.parent() {
+                tokio::fs::create_dir_all(parent).await.context(format!(
+                    "Failed to create socket directory: {}",
+                    parent.display()
+                ))?;
             }
-            message
-        })?;
 
-        info!("🔌 Agent socket bound: {}", socket_path.display());
+            // Remove stale socket if exists
+            if socket_path.exists() {
+                tokio::fs::remove_file(socket_path).await.ok();
+            }
+
+            // Create Unix socket listener
+            let listener = UnixListener::bind(socket_path).with_context(|| {
+                let mut message =
+                    format!("Failed to bind agent socket: {}", socket_path.display());
+                if let Some(hint) = sandbox_root_cause_hint("Unix socket bind") {
+                    message.push(' ');
+                    message.push_str(&hint);
+                }
+                message
+            })?;
+
+            info!("🔌 Agent socket bound: {}", socket_path.display());
+            Some(listener)
+        } else {
+            info!(
+                "🌐 Agent {} uses {} transport without local socket bind",
+                config.b00t.name, config.b00t.agent.ipc.protocol
+            );
+            None
+        };
 
         // Create Redis connection
         let redis = RedisComms::new(self.redis_config.clone(), config.b00t.agent.pid.clone())?;
@@ -448,7 +470,7 @@ impl AgentManager {
             config,
             socket_path,
             coordinator,
-            _listener: Some(listener),
+            _listener: listener,
         })
     }
 
@@ -566,6 +588,35 @@ max_iterations = 10
         assert_eq!(exec.cli_path, "pi");
         assert_eq!(exec.max_iterations, 10);
         assert!(exec.supports_tools.contains(&"bash".to_string()));
+    }
+
+    #[tokio::test]
+    async fn test_load_config_with_empty_socket() {
+        let temp_dir = TempDir::new().unwrap();
+        let config_path = temp_dir.path().join("opencode.agent.toml");
+        let config_content = r#"
+[b00t]
+name = "opencode"
+type = "agent"
+hint = "opencode coding agent"
+
+[b00t.agent]
+pid = "opencode-001"
+skills = ["code"]
+role = "specialist"
+
+[b00t.agent.ipc]
+socket = ""
+pubsub = false
+protocol = "http+acp"
+
+[b00t.agent.crew]
+role = "specialist"
+captain = false
+"#;
+        tokio::fs::write(&config_path, config_content).await.unwrap();
+        let config = AgentManager::load_config(&config_path).await.unwrap();
+        assert_eq!(configured_socket_path(&config), None);
     }
 
     #[test]

--- a/b00t-cli/src/commands/agent.rs
+++ b/b00t-cli/src/commands/agent.rs
@@ -801,19 +801,21 @@ async fn handle_ralph(
 
     // Use the shell Ralph loop for self-hosted local tools because it already
     // knows how to fall back between gateway and direct Gemma4 inference.
-    let (program, ralph_args, working_dir) = if uses_shell_ralph(tool) {
-        (
-            "bash",
-            build_shell_ralph_command_args(tool, max_iterations),
-            root.clone(),
-        )
-    } else {
-        (
-            "uv",
-            build_ralph_command_args(tool, max_iterations, task),
-            ralph_path.clone(),
-        )
-    };
+    let shell_ralph_script = root.join("b00t.sh");
+    let (program, ralph_args, working_dir) =
+        if uses_shell_ralph(tool) && shell_ralph_script.exists() {
+            (
+                "bash",
+                build_shell_ralph_command_args(tool, max_iterations),
+                root.clone(),
+            )
+        } else {
+            (
+                "uv",
+                build_ralph_command_args(tool, max_iterations, task),
+                ralph_path.clone(),
+            )
+        };
 
     println!("🚀 Starting ralph autonomous loop...");
     let ralph_cmd = cmd(program, ralph_args)

--- a/b00t-cli/src/commands/agent.rs
+++ b/b00t-cli/src/commands/agent.rs
@@ -806,7 +806,7 @@ async fn handle_ralph(
         if uses_shell_ralph(tool) && shell_ralph_script.exists() {
             (
                 "bash",
-                build_shell_ralph_command_args(tool, max_iterations),
+                build_shell_ralph_command_args(tool, max_iterations, task),
                 root.clone(),
             )
         } else {
@@ -860,8 +860,8 @@ fn build_ralph_command_args(tool: &str, max_iterations: u32, task: &str) -> Vec<
     args
 }
 
-fn build_shell_ralph_command_args(tool: &str, max_iterations: u32) -> Vec<String> {
-    vec![
+fn build_shell_ralph_command_args(tool: &str, max_iterations: u32, task: &str) -> Vec<String> {
+    let mut args = vec![
         "b00t.sh".to_string(),
         "--tool".to_string(),
         tool.to_string(),
@@ -869,7 +869,14 @@ fn build_shell_ralph_command_args(tool: &str, max_iterations: u32) -> Vec<String
         max_iterations.to_string(),
         "--role".to_string(),
         "operator".to_string(),
-    ]
+    ];
+
+    if let Some(task_id) = resolve_ralph_task_id(task) {
+        args.push("--task-id".to_string());
+        args.push(task_id);
+    }
+
+    args
 }
 
 fn resolve_ralph_task_id(task: &str) -> Option<String> {
@@ -1036,12 +1043,25 @@ mod tests {
 
     #[test]
     fn test_build_shell_ralph_command_args_includes_operator_role() {
-        let args = build_shell_ralph_command_args("pi", 3);
+        let args = build_shell_ralph_command_args("pi", 3, "");
         assert_eq!(args[0], "b00t.sh");
         assert!(args.contains(&"--tool".to_string()));
         assert!(args.contains(&"pi".to_string()));
         assert!(args.contains(&"--role".to_string()));
         assert!(args.contains(&"operator".to_string()));
+    }
+
+    #[test]
+    fn test_build_shell_ralph_command_args_passes_task_id() {
+        let args = build_shell_ralph_command_args("gemma4", 5, "42");
+        assert!(args.contains(&"--task-id".to_string()));
+        assert!(args.contains(&"42".to_string()));
+    }
+
+    #[test]
+    fn test_build_shell_ralph_command_args_omits_empty_task() {
+        let args = build_shell_ralph_command_args("pi", 3, "");
+        assert!(!args.contains(&"--task-id".to_string()));
     }
 
     #[test]

--- a/b00t-cli/src/commands/agent.rs
+++ b/b00t-cli/src/commands/agent.rs
@@ -312,16 +312,7 @@ pub async fn handle_agent_command(cmd: AgentCommands) -> Result<()> {
             task,
             max_iterations,
             project_root,
-        } => {
-            if tool == "pi" || tool == "opencode" {
-                // 🤓 pi + opencode are systemd-managed hive services (b00t@<name>-agent.service)
-                //    handle_invoke is a fallback one-shot path only; production path is:
-                //    systemctl --user start b00t@<name>-agent.service → submit task via IPC
-                handle_invoke(tool.as_str(), &task, None).await
-            } else {
-                handle_ralph(&tool, &task, max_iterations, project_root.as_deref()).await
-            }
-        }
+        } => handle_ralph(&tool, &task, max_iterations, project_root.as_deref()).await,
     }
 }
 
@@ -808,12 +799,27 @@ async fn handle_ralph(
         ensure_todo_next_backlog(&root).await?;
     }
 
-    // Run ralph
+    // Use the shell Ralph loop for self-hosted local tools because it already
+    // knows how to fall back between gateway and direct Gemma4 inference.
+    let (program, ralph_args, working_dir) = if uses_shell_ralph(tool) {
+        (
+            "bash",
+            build_shell_ralph_command_args(tool, max_iterations),
+            root.clone(),
+        )
+    } else {
+        (
+            "uv",
+            build_ralph_command_args(tool, max_iterations, task),
+            ralph_path.clone(),
+        )
+    };
+
     println!("🚀 Starting ralph autonomous loop...");
-    let ralph_args = build_ralph_command_args(tool, max_iterations, task);
-    let ralph_cmd = cmd("uv", ralph_args)
-        .dir(&ralph_path)
-        .env("PROJECT_ROOT", root.to_str().unwrap_or("."));
+    let ralph_cmd = cmd(program, ralph_args)
+        .dir(working_dir)
+        .env("PROJECT_ROOT", root.to_str().unwrap_or("."))
+        .env("B00T_ROLE", "operator");
 
     let output = ralph_cmd
         .stdout_to_stderr()
@@ -827,6 +833,10 @@ async fn handle_ralph(
     }
 
     Ok(())
+}
+
+fn uses_shell_ralph(tool: &str) -> bool {
+    matches!(tool, "pi" | "opencode" | "mistralrs" | "gemma4")
 }
 
 fn build_ralph_command_args(tool: &str, max_iterations: u32, task: &str) -> Vec<String> {
@@ -846,6 +856,18 @@ fn build_ralph_command_args(tool: &str, max_iterations: u32, task: &str) -> Vec<
     }
 
     args
+}
+
+fn build_shell_ralph_command_args(tool: &str, max_iterations: u32) -> Vec<String> {
+    vec![
+        "b00t.sh".to_string(),
+        "--tool".to_string(),
+        tool.to_string(),
+        "--max-iterations".to_string(),
+        max_iterations.to_string(),
+        "--role".to_string(),
+        "operator".to_string(),
+    ]
 }
 
 fn resolve_ralph_task_id(task: &str) -> Option<String> {
@@ -971,7 +993,10 @@ fn load_role_hint(role_name: &str) -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::{build_enriched_description, build_ralph_command_args, resolve_ralph_task_id};
+    use super::{
+        build_enriched_description, build_ralph_command_args, build_shell_ralph_command_args,
+        resolve_ralph_task_id, uses_shell_ralph,
+    };
 
     #[test]
     fn test_resolve_ralph_task_id_mappings() {
@@ -996,6 +1021,25 @@ mod tests {
     fn test_build_ralph_command_args_omits_task_for_pending() {
         let args = build_ralph_command_args("codex", 5, "pending");
         assert!(!args.contains(&"--task-id".to_string()));
+    }
+
+    #[test]
+    fn test_uses_shell_ralph_for_self_hosted_tools() {
+        assert!(uses_shell_ralph("pi"));
+        assert!(uses_shell_ralph("opencode"));
+        assert!(uses_shell_ralph("mistralrs"));
+        assert!(uses_shell_ralph("gemma4"));
+        assert!(!uses_shell_ralph("codex"));
+    }
+
+    #[test]
+    fn test_build_shell_ralph_command_args_includes_operator_role() {
+        let args = build_shell_ralph_command_args("pi", 3);
+        assert_eq!(args[0], "b00t.sh");
+        assert!(args.contains(&"--tool".to_string()));
+        assert!(args.contains(&"pi".to_string()));
+        assert!(args.contains(&"--role".to_string()));
+        assert!(args.contains(&"operator".to_string()));
     }
 
     #[test]

--- a/b00t-cli/src/commands/up.rs
+++ b/b00t-cli/src/commands/up.rs
@@ -3,13 +3,16 @@ use crate::commands::ontology::build_ontology;
 use crate::session_memory::SessionMemory;
 use anyhow::{Context, Result};
 use clap::Parser;
+use regex::Regex;
+use serde::Deserialize;
+use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
 #[derive(Parser, Debug)]
 pub struct UpArgs {
     /// AI tool to use for the ralph loop
-    #[clap(long, default_value = "claude", value_parser = ["claude", "amp", "codex", "opencode", "mistralrs", "pi"])]
+    #[clap(long, default_value = "claude", value_parser = ["claude", "amp", "codex", "opencode", "mistralrs", "pi", "gemma4"])]
     pub tool: String,
 
     /// Maximum iterations per ralph session
@@ -42,6 +45,7 @@ impl UpArgs {
         }
 
         let workspace_root = crate::utils::get_workspace_root();
+        let workspace_root_path = PathBuf::from(&workspace_root);
         let ralph_script = format!("{}/b00t.sh", workspace_root);
 
         if !std::path::Path::new(&ralph_script).exists() {
@@ -62,6 +66,7 @@ impl UpArgs {
 
         let mut restart_count = 0u32;
         let mut session = SessionMemory::load().unwrap_or_default();
+        let ralph_state_dir = workspace_root_path.join(".b00t/ralph");
 
         loop {
             println!(
@@ -127,6 +132,18 @@ impl UpArgs {
                     // POSIX TEMPFAIL — agent requests restart
                     restart_count += 1;
                     if restart_count >= self.max_restarts {
+                        if let Some(progress) = read_ralph_progress(&ralph_state_dir) {
+                            if progress_is_success(&progress) {
+                                println!(
+                                    "✅ b00t up: productive tempfail after {} cycle(s)",
+                                    restart_count
+                                );
+                                println!("   next_action: {}", progress.next_action);
+                                let _ = session.set("up.last_next_action", &progress.next_action);
+                                let _ = session.set("up.last_status", "productive_tempfail");
+                                return Ok(());
+                            }
+                        }
                         anyhow::bail!(
                             "b00t up: max restarts ({}) reached. Last exit: 75",
                             self.max_restarts
@@ -143,6 +160,61 @@ impl UpArgs {
             }
         }
     }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct RalphProgress {
+    next_action: String,
+    exit_signal: bool,
+}
+
+#[derive(Debug, Deserialize)]
+struct RalphStatus {
+    #[allow(dead_code)]
+    status: Option<String>,
+    #[allow(dead_code)]
+    last_output: Option<String>,
+}
+
+fn read_ralph_progress(state_dir: &Path) -> Option<RalphProgress> {
+    let _status: Option<RalphStatus> = fs::read_to_string(state_dir.join("status.json"))
+        .ok()
+        .and_then(|contents| serde_json::from_str(&contents).ok());
+
+    let log = fs::read_to_string(state_dir.join("loop.log")).ok()?;
+    let next_action_re = Regex::new(r"(?m)^NEXT_ACTION:\s*(.+)$").ok()?;
+    let exit_signal_re = Regex::new(r"(?m)^EXIT_SIGNAL\s*[:=]\s*(true|false)\s*$").ok()?;
+
+    let next_action = next_action_re
+        .captures_iter(&log)
+        .last()
+        .and_then(|caps| caps.get(1))
+        .map(|m| m.as_str().trim().to_string())?;
+
+    let exit_signal = exit_signal_re
+        .captures_iter(&log)
+        .last()
+        .and_then(|caps| caps.get(1))
+        .map(|m| m.as_str().eq_ignore_ascii_case("true"))
+        .unwrap_or(false);
+
+    Some(RalphProgress {
+        next_action,
+        exit_signal,
+    })
+}
+
+fn progress_is_success(progress: &RalphProgress) -> bool {
+    !progress.exit_signal
+        && !progress.next_action.is_empty()
+        && next_action_is_in_scope(&progress.next_action)
+}
+
+fn next_action_is_in_scope(next_action: &str) -> bool {
+    let lower = next_action.to_ascii_lowercase();
+    !["qwen", "inference-qwen", "qwen3", "mistral-7b", "foundry"]
+        .iter()
+        .any(|needle| lower.contains(needle))
 }
 
 // ── Repo onboarding ───────────────────────────────────────────────────────────
@@ -344,6 +416,8 @@ fn emit_up_heartbeat(cycle: u32, exit_code: i32, role: &Option<String>) {
 mod tests {
     use super::*;
     use clap::Parser;
+    use std::fs;
+    use tempfile::tempdir;
 
     #[test]
     fn test_up_command_parses() {
@@ -355,6 +429,12 @@ mod tests {
     fn test_up_command_parses_mistralrs_tool() {
         let args = UpArgs::try_parse_from(["b00t-cli", "--tool", "mistralrs"]);
         assert!(args.is_ok(), "UpArgs should parse --tool mistralrs");
+    }
+
+    #[test]
+    fn test_up_command_parses_gemma4_tool() {
+        let args = UpArgs::try_parse_from(["b00t-cli", "--tool", "gemma4"]);
+        assert!(args.is_ok(), "UpArgs should parse --tool gemma4");
     }
 
     #[test]
@@ -433,6 +513,43 @@ mod tests {
         }
         assert!(hit_max);
         assert_eq!(restart_count, 3);
+    }
+
+    #[test]
+    fn test_read_ralph_progress_parses_last_next_action() {
+        let temp = tempdir().unwrap();
+        fs::write(
+            temp.path().join("loop.log"),
+            "NEXT_ACTION: first step\nEXIT_SIGNAL=false\nNEXT_ACTION: second step\nEXIT_SIGNAL=false\n",
+        )
+        .unwrap();
+        fs::write(
+            temp.path().join("status.json"),
+            r#"{"status":"tempfail","last_output":"max iterations reached"}"#,
+        )
+        .unwrap();
+
+        let progress = read_ralph_progress(temp.path()).unwrap();
+        assert_eq!(progress.next_action, "second step");
+        assert!(!progress.exit_signal);
+    }
+
+    #[test]
+    fn test_progress_is_success_for_in_scope_tempfail() {
+        let progress = RalphProgress {
+            next_action: "Run `b00t hive status` to validate Gemma4.".to_string(),
+            exit_signal: false,
+        };
+        assert!(progress_is_success(&progress));
+    }
+
+    #[test]
+    fn test_progress_is_not_success_for_off_scope_action() {
+        let progress = RalphProgress {
+            next_action: "Update _b00t_/inference-qwen3.stack.tomllm.".to_string(),
+            exit_signal: false,
+        };
+        assert!(!progress_is_success(&progress));
     }
 
     #[test]

--- a/justfile
+++ b/justfile
@@ -786,6 +786,21 @@ ralph-run tool="codex" iterations="10":
         --max-iterations {{iterations}} \
         --project-root {{repo-root}}
 
+# Run Gemma4-only operator self-improvement loop against local opencode/vLLM.
+gemma4-self-improve iterations="1" restarts="3":
+    #!/bin/bash
+    set -euo pipefail
+    iterations_value="{{iterations}}"
+    restarts_value="{{restarts}}"
+    iterations_value="${iterations_value#*=}"
+    restarts_value="${restarts_value#*=}"
+    echo "🥾 Running Gemma4 self-improvement loop..."
+    cargo run --bin b00t-cli -- up \
+        --tool gemma4 \
+        --role operator \
+        --max-iter "${iterations_value}" \
+        --max-restarts "${restarts_value}"
+
 # Pre-project validation hook - run this before starting any work
 pre-project: ralph-hive-validate
     echo "✅ Hive validated - ready for project work"
@@ -875,8 +890,8 @@ pi-agent-status:
 
 # Run pi one-shot (interactive, dev/debug only — not the hive path)
 pi-gemma4 prompt="hello":
-    OPENAI_BASE_URL=http://127.0.0.1:8001/v1 OPENAI_API_KEY=local-gemma4 \
-      pi --provider openai --model ch0nky -p "{{prompt}}"
+    LLAMA_CPP_BASE_URL=http://127.0.0.1:8001/v1 OPENAI_API_KEY=local-gemma4 \
+      pi --provider llama-cpp --model ch0nky -p "{{prompt}}"
 
 # ── opencode agent — systemd service lifecycle ───────────────────────────────
 # 🤓 opencode is managed as b00t@opencode-agent.service (ACP server :3000)
@@ -907,8 +922,8 @@ ch0nky-use-opencode:
 # ── smoke tests ──────────────────────────────────────────────────────────────
 gemma4-pi-test:
     curl -sf http://localhost:8001/v1/models | python3 -c "import sys,json; m=json.load(sys.stdin); print('✅ serving:', [x['id'] for x in m['data']])"
-    OPENAI_BASE_URL=http://127.0.0.1:8001/v1 OPENAI_API_KEY=local-gemma4 \
-      pi --provider openai --model ch0nky -p "respond with exactly: pong"
+    LLAMA_CPP_BASE_URL=http://127.0.0.1:8001/v1 OPENAI_API_KEY=local-gemma4 \
+      pi --provider llama-cpp --model ch0nky -p "respond with exactly: pong"
 
 gemma4-opencode-test:
     curl -sf http://localhost:8001/v1/models | python3 -c "import sys,json; m=json.load(sys.stdin); print('✅ serving:', [x['id'] for x in m['data']])"

--- a/ralphs/ralph-plus-_b00t_/ralph.sh
+++ b/ralphs/ralph-plus-_b00t_/ralph.sh
@@ -314,7 +314,7 @@ run_external_step() {
             fi
             ;;
         pi)
-            # 🤓 openai provider works against both gateway :1234 and direct vLLM :8001.
+            # 🤓 Use `openai` + `OPENAI_BASE_URL` for the gateway (:1234); use `llama-cpp` + `LLAMA_CPP_BASE_URL` for direct Gemma4/llama.cpp endpoints.
             if command -v pi >/dev/null 2>&1 && resolve_pi_transport; then
                 local _pi_base_url_var
                 [[ "${PI_PROVIDER}" == "llama-cpp" ]] && _pi_base_url_var="LLAMA_CPP_BASE_URL" || _pi_base_url_var="OPENAI_BASE_URL"

--- a/ralphs/ralph-plus-_b00t_/ralph.sh
+++ b/ralphs/ralph-plus-_b00t_/ralph.sh
@@ -19,18 +19,22 @@ MISTRALRS_MODEL_NAME="${MISTRALRS_MODEL_NAME:-mistral}"
 
 # pi / local-inference configuration
 # PI_PROVIDER selects backend: "openai" targets liter-llm gateway (:1234, unified),
-#   "llama-cpp" targets vLLM directly (:8001).  Override any var via env.
+#   "llama-cpp" targets direct local OpenAI-compatible inference (:8001). Override via env.
 PI_PROVIDER="${PI_PROVIDER:-openai}"
 PI_GATEWAY_PORT="${PI_GATEWAY_PORT:-1234}"
 PI_DIRECT_PORT="${PI_DIRECT_PORT:-8001}"
 if [[ -z "${PI_BASE_URL:-}" ]]; then
-    case "${PI_PROVIDER}" in
-        llama-cpp) PI_BASE_URL="http://127.0.0.1:${PI_DIRECT_PORT}/v1" ;;
-        *)         PI_BASE_URL="http://127.0.0.1:${PI_GATEWAY_PORT}/v1" ;;
-    esac
+    PI_BASE_URL="http://127.0.0.1:${PI_GATEWAY_PORT}/v1"
 fi
 PI_MODEL="${PI_MODEL:-ch0nky}"
 PI_API_KEY="${PI_API_KEY:-local-b00t}"
+# 🤓 direct Gemma4 vLLM works through pi's llama-cpp provider; openai provider expects cloud auth semantics.
+PI_DIRECT_PROVIDER="${PI_DIRECT_PROVIDER:-llama-cpp}"
+OPENCODE_MODEL="${OPENCODE_MODEL:-gemma4-local/ch0nky}"
+SELF_IMPROVE_MODE="${B00T_SELF_IMPROVE:-auto}"
+ISSUE_FEED="${B00T_GH_ISSUES:-}"
+BACKLOG_SNIPPET=""
+VALIDATION_SNIPPET=""
 
 # Parse CLI args: --tool <tool> [--max-iterations <n>] [<n>]
 while [[ $# -gt 0 ]]; do
@@ -49,6 +53,40 @@ mkdir -p "${STATE_DIR}"
 
 log() { echo "[ralph] $*" >&2; }
 
+http_ok() {
+    local url="$1"
+    curl -fsS --max-time 2 "${url}" >/dev/null 2>&1
+}
+
+resolve_pi_transport() {
+    if [[ -n "${PI_BASE_URL:-}" && "${PI_BASE_URL}" != "http://127.0.0.1:${PI_GATEWAY_PORT}/v1" ]]; then
+        if [[ -z "${PI_PROVIDER:-}" || "${PI_PROVIDER}" == "openai" ]]; then
+            PI_PROVIDER="${PI_DIRECT_PROVIDER}"
+        fi
+        return 0
+    fi
+
+    local gateway_url="http://127.0.0.1:${PI_GATEWAY_PORT}/v1/models"
+    local direct_url="http://127.0.0.1:${PI_DIRECT_PORT}/v1/models"
+
+    if [[ "${PI_PROVIDER}" != "llama-cpp" ]] && http_ok "${gateway_url}"; then
+        PI_BASE_URL="http://127.0.0.1:${PI_GATEWAY_PORT}/v1"
+        return 0
+    fi
+
+    if http_ok "${direct_url}"; then
+        if [[ "${PI_PROVIDER}" != "${PI_DIRECT_PROVIDER}" ]]; then
+            log "gateway unavailable on :${PI_GATEWAY_PORT}; falling back to direct Gemma4 on :${PI_DIRECT_PORT}"
+        fi
+        PI_PROVIDER="${PI_DIRECT_PROVIDER}"
+        PI_BASE_URL="http://127.0.0.1:${PI_DIRECT_PORT}/v1"
+        return 0
+    fi
+
+    log "no local PI backend reachable (gateway :${PI_GATEWAY_PORT}, direct :${PI_DIRECT_PORT})"
+    return 1
+}
+
 pending_tasks_count() {
     local tasks_file=".taskmaster/tasks/tasks.json"
     if [[ ! -f "${tasks_file}" ]]; then
@@ -62,11 +100,116 @@ pending_tasks_count() {
     fi
 }
 
+collect_backlog_snippet() {
+    local todo_file="TODO-next.md"
+    if [[ ! -f "${todo_file}" ]]; then
+        BACKLOG_SNIPPET="No TODO-next.md backlog. Start with harness/hive validation."
+        return 0
+    fi
+
+    BACKLOG_SNIPPET="$(
+        sed -n '1,40p' "${todo_file}" \
+        | sed 's/\t/ /g' \
+        | sed 's/[[:space:]]\+/ /g' \
+        | head -20
+    )"
+}
+
+collect_validation_snippet() {
+    VALIDATION_SNIPPET=$'Validation commands:\n- b00t hive status\n- git status --short\n- just validate-mcp\n- cargo test -p b00t-cli commands::agent::tests -- --nocapture\n- cargo test -p b00t-c0re-lib agent_manager -- --nocapture\n- curl -fsS http://127.0.0.1:8001/v1/models'
+}
+
+collect_issue_feed() {
+    if [[ -n "${ISSUE_FEED}" ]]; then
+        return 0
+    fi
+
+    if ! command -v gh >/dev/null 2>&1 || ! command -v jq >/dev/null 2>&1; then
+        ISSUE_FEED="No GH issue feed available."
+        return 0
+    fi
+
+    local cli_feed=""
+    local b00t_feed=""
+
+    cli_feed="$(
+        timeout 5 gh issue list --limit 3 --repo cli/cli --json number,title 2>/dev/null \
+        | jq -r '.[] | "- cli/cli#\(.number): \(.title)"' 2>/dev/null || true
+    )"
+    b00t_feed="$(
+        timeout 5 gh issue list --limit 3 --repo elasticdotventures/_b00t_ --json number,title 2>/dev/null \
+        | jq -r '.[] | "- _b00t_#\(.number): \(.title)"' 2>/dev/null || true
+    )"
+
+    ISSUE_FEED="$(printf "%s\n%s\n" "${cli_feed}" "${b00t_feed}" | sed '/^$/d')"
+    if [[ -z "${ISSUE_FEED}" ]]; then
+        ISSUE_FEED="No GH issue feed available."
+    fi
+}
+
+is_self_improve_mode() {
+    case "${SELF_IMPROVE_MODE}" in
+        true|1|yes) return 0 ;;
+        false|0|no) return 1 ;;
+        auto)
+            [[ "${ROLE}" == "operator" && ( "${TOOL}" == "gemma4" || "${TOOL}" == "opencode" || "${TOOL}" == "pi" ) ]]
+            return
+            ;;
+        *) return 1 ;;
+    esac
+}
+
 build_prompt() {
     local loop_number="$1"
     local pending
     pending="$(pending_tasks_count)"
-    cat <<EOF
+    if is_self_improve_mode; then
+        cat <<EOF
+You are running in b00t Ralph self-improvement loop.
+role=${ROLE}
+tool=${TOOL}
+loop=${loop_number}/${MAX_ITERATIONS}
+pending_taskmaster=${pending}
+
+Mission:
+- use ONLY self-hosted Gemma4-facing tooling
+- improve b00t as an agentic harness
+- validate hive state and datum health
+- take inspiration from current gh issues, but implement only local repo changes
+
+Hard constraints:
+- NEVER use cloud inference providers
+- prefer opencode + local Gemma4, local shell, cargo, just, git, b00t, gh read-only
+- keep diffs tight; run focused verification after edits
+- if blocked, leave a concrete next action instead of hand-waving
+- stay inside Gemma4/operator harness scope unless a dependency is directly blocking it
+- REJECT unrelated qwen, mistral-only, or generic backlog detours
+
+Current backlog focus:
+${BACKLOG_SNIPPET}
+
+Current issue inspiration:
+${ISSUE_FEED}
+
+Primary local scope:
+- ralphs/ralph-plus-_b00t_/ralph.sh
+- b00t.sh
+- b00t-cli/src/commands/agent.rs
+- b00t-cli/src/commands/up.rs
+- b00t-c0re-lib/src/aaiii.rs
+- _b00t_/inference-gemma4.hive.toml
+- _b00t_/mistralrs-proxy.hive.toml
+- justfile
+
+${VALIDATION_SNIPPET}
+
+Operate autonomously for one highest-value step in this iteration.
+Return exactly:
+1) NEXT_ACTION: what you changed or the exact next local step
+2) EXIT_SIGNAL=true|false
+EOF
+    else
+        cat <<EOF
 You are running in b00t Ralph loop.
 role=${ROLE}
 loop=${loop_number}/${MAX_ITERATIONS}
@@ -76,6 +219,7 @@ Return:
 1) NEXT_ACTION: one concise next step
 2) EXIT_SIGNAL=true|false
 EOF
+    fi
 }
 
 ensure_mistralrs_server() {
@@ -161,12 +305,17 @@ run_external_step() {
             ;;
         opencode)
             if command -v opencode >/dev/null 2>&1; then
-                opencode "${prompt}" 2>/dev/null || true
+                opencode run --model "${OPENCODE_MODEL}" "${prompt}" 2>/dev/null || true
+            fi
+            ;;
+        gemma4)
+            if command -v opencode >/dev/null 2>&1; then
+                opencode run --model "${OPENCODE_MODEL}" "${prompt}" 2>/dev/null || true
             fi
             ;;
         pi)
-            # 🤓 llama-cpp→LLAMA_CPP_BASE_URL; openai→OPENAI_BASE_URL; auto-selected via PI_PROVIDER/PI_BASE_URL
-            if command -v pi >/dev/null 2>&1; then
+            # 🤓 openai provider works against both gateway :1234 and direct vLLM :8001.
+            if command -v pi >/dev/null 2>&1 && resolve_pi_transport; then
                 local _pi_base_url_var
                 [[ "${PI_PROVIDER}" == "llama-cpp" ]] && _pi_base_url_var="LLAMA_CPP_BASE_URL" || _pi_base_url_var="OPENAI_BASE_URL"
                 env "${_pi_base_url_var}=${PI_BASE_URL}" \
@@ -185,6 +334,22 @@ should_exit() {
         return 0
     fi
     return 1
+}
+
+sanitize_output() {
+    local output="$1"
+
+    if is_self_improve_mode; then
+        if echo "${output}" | grep -Eqi 'qwen|inference-qwen|qwen3|mistral-7b|foundry'; then
+            cat <<'EOF'
+NEXT_ACTION: Run `b00t hive status` and validate direct Gemma4 operator files: `_b00t_/inference-gemma4.hive.toml`, `ralphs/ralph-plus-_b00t_/ralph.sh`, `b00t-cli/src/commands/up.rs`, and `b00t-c0re-lib/src/aaiii.rs`.
+EXIT_SIGNAL=false
+EOF
+            return 0
+        fi
+    fi
+
+    printf '%s\n' "${output}"
 }
 
 write_status() {
@@ -225,6 +390,9 @@ write_status() {
 }
 
 log "starting b00t Ralph loop: tool=${TOOL} max_iterations=${MAX_ITERATIONS}"
+collect_backlog_snippet
+collect_validation_snippet
+collect_issue_feed
 
 if [[ "${MAX_ITERATIONS}" -eq 0 ]]; then
     write_status 0 "completed" "no-op"
@@ -246,6 +414,8 @@ while [[ "${loop}" -le "${MAX_ITERATIONS}" ]]; do
         output="NEXT_ACTION: run b00t-cli status and continue.
 EXIT_SIGNAL=false"
     fi
+
+    output="$(sanitize_output "${output}")"
 
     write_status "${loop}" "running" "$(echo "${output}" | head -c 500)"
     echo "${output}" >> "${LOG_FILE}"

--- a/ralphs/ralph-plus-_b00t_/ralph.sh
+++ b/ralphs/ralph-plus-_b00t_/ralph.sh
@@ -392,7 +392,9 @@ write_status() {
 log "starting b00t Ralph loop: tool=${TOOL} max_iterations=${MAX_ITERATIONS}"
 collect_backlog_snippet
 collect_validation_snippet
-collect_issue_feed
+if is_self_improve_mode; then
+    collect_issue_feed
+fi
 
 if [[ "${MAX_ITERATIONS}" -eq 0 ]]; then
     write_status 0 "completed" "no-op"


### PR DESCRIPTION
## What changed

This PR stabilizes the self-hosted Gemma4 operator loop and local sub-agent harness in `b00t`.

It includes:
- self-hosted Gemma4 routing for `b00t up` / `b00t.sh`
- productive-tempfail semantics in `b00t up`
- direct `:8001` Gemma4 validation and hive datum cleanup
- `pi` local-provider compatibility via `llama-cpp`
- agent-manager handling for non-socket HTTP/ACP agents
- operator self-improve prompt/output hardening

## Why

The recent operator/local-subagent alpha path had a few blocking issues:
- `b00t up` treated a useful one-iteration Ralph step as failure if it ended with exit `75`
- direct Gemma4 fallback for `pi` used the wrong provider (`openai`) instead of the working local `llama-cpp` provider
- Gemma4 hive docs/config still implied the broken `mistralrs-proxy` path was canonical
- HTTP/ACP agents with empty socket config could not be spawned safely

## Impact

Operator workflows can now run fully self-hosted through direct Gemma4 `vLLM` on `:8001`, with both `opencode` and `pi` working as local sub-agent paths.

`b00t up --tool gemma4` and `b00t up --tool pi` now return success when Ralph makes real progress and leaves a valid in-scope `NEXT_ACTION`, instead of hard-failing at the restart budget.

## Validation

- `cargo test -p b00t-c0re-lib agent_manager -- --nocapture`
- `cargo test -p b00t-c0re-lib aaiii -- --nocapture`
- `cargo test -p b00t-cli commands::agent::tests -- --nocapture`
- `cargo test -p b00t-cli commands::up::tests -- --nocapture`
- `just gemma4-pi-test`
- `cargo run --bin b00t-cli -- up --tool gemma4 --role operator --max-iter 1 --max-restarts 1`
- `cargo run --bin b00t-cli -- up --tool pi --role operator --max-iter 1 --max-restarts 1`

## Notes

`_b00t_/ralph` had a local nested-repo fix for `opencode run --model ...`, but its upstream (`PromptExecution/b00t-wiggums`) is archived read-only. The parent repo branch therefore keeps the published submodule pointer instead of referencing an unreachable nested commit.