### PR TITLE
fix: harden install runtime source and hive capabilities

### DIFF
--- a/_b00t_/irontology.mcp.toml
+++ b/_b00t_/irontology.mcp.toml
@@ -1,0 +1,18 @@
+[b00t]
+name = "irontology"
+type = "mcp"
+hint = "Alias datum for irontology-mcp so role entanglement `irontology.mcp` resolves in whoami capability checks"
+
+[[b00t.mcp.stdio]]
+command = "vendor/irontology-mcp/target/release/irontology-mcp"
+args = []
+transport = "stdio"
+priority = 0
+requires = ["vendor/irontology-mcp"]
+
+# b00t:map v1
+# summary: irontology MCP alias datum — resolves executive entanglement irontology.mcp
+# tags: mcp, irontology, whoami, semantic-rag
+# tier: frontier
+# cmds: b00t whoami --role=executive
+# complexity: 2

--- a/_b00t_/sm3lly-acp.agent.toml
+++ b/_b00t_/sm3lly-acp.agent.toml
@@ -1,0 +1,45 @@
+# b00t Agent Datum — sm3llsl1k3s0ld3r remote ch0nky node
+
+[b00t]
+name = "sm3lly-acp"
+type = "agent"
+hint = "Remote sm3llsl1k3s0ld3r solar+battery node route for ch0nky Qwen36 ACP delegation over NATS"
+
+[b00t.agent]
+pid = "sm3lly-001"
+model = "qwen36/ch0nky"
+skills = ["compile", "test", "install", "long-session", "ch0nky-code", "nats-acp"]
+personality = "laconic"
+role = "specialist"
+
+[b00t.agent.ipc]
+protocol = "nats+acp"
+pubsub = true
+subject_prefix = "hive.sm3lly.acp"
+nats_url_env = "NATS_URL"
+default_nats_url = "nats://c010.promptexecution.com:4222"
+
+[b00t.agent.crew]
+role = "specialist"
+captain = false
+tier = "ch0nky"
+
+[b00t.agent.exchange]
+local_offer = "run sm0l toil models/tasks locally for sm3llyd0s"
+remote_offer = "run qwen36 ch0nky compile/test/install sessions for b00t"
+policy = "two-way service exchange inside same hive/cluster"
+
+[[b00t.usage]]
+description = "Inspect local ACP transport state"
+command = "just acp-sm3lly-status"
+
+[[b00t.usage]]
+description = "Publish local ACP status through current chat transport"
+command = "b00t chat send --transport nats --message 'sm3lly route check'"
+
+# b00t:map v1
+# summary: sm3lly ACP route datum — remote Qwen36 ch0nky service exchange over NATS ACP
+# tags: sm3lly, acp, nats, ch0nky, qwen36, delegation, solar
+# tier: ch0nky
+# cmds: just acp-sm3lly-status
+# complexity: 6

--- a/b00t-cli/src/install/mod.rs
+++ b/b00t-cli/src/install/mod.rs
@@ -24,10 +24,22 @@ pub fn default_registry() -> AdapterRegistry {
     ])
 }
 
-/// Source root for runtime content: _b00t_/runtimes/ relative to workspace root.
-/// Uses get_workspace_root() (git rev-parse) so it works from any cwd, consistent
-/// with run_just_install. Returns Err when the directory does not exist.
+/// Source root for runtime content.
+///
+/// Defaults to `_b00t_/runtimes/` relative to the workspace root. Tests and
+/// controlled installers may override with `B00T_RUNTIMES_SOURCE_ROOT`.
 pub fn runtimes_source_root() -> Result<PathBuf> {
+    if let Ok(source_root) = std::env::var("B00T_RUNTIMES_SOURCE_ROOT") {
+        let root = PathBuf::from(source_root);
+        if root.exists() {
+            return Ok(root);
+        }
+        anyhow::bail!(
+            "runtimes source directory not found: {}",
+            root.display()
+        );
+    }
+
     let root = PathBuf::from(crate::utils::get_workspace_root()).join("_b00t_/runtimes");
     if !root.exists() {
         anyhow::bail!(
@@ -146,6 +158,10 @@ mod tests {
     fn test_runtimes_source_root_from_workspace() {
         // When run from within the repo, runtimes_source_root() is anchored at the
         // git workspace root. Verify the returned path ends with _b00t_/runtimes.
+        let _lock = ENV_MUTEX.lock().unwrap();
+        unsafe {
+            std::env::remove_var("B00T_RUNTIMES_SOURCE_ROOT");
+        }
         let root = crate::utils::get_workspace_root();
         let expected = PathBuf::from(&root).join("_b00t_/runtimes");
         if expected.exists() {
@@ -171,6 +187,7 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         let _lock = ENV_MUTEX.lock().unwrap();
         unsafe {
+            std::env::remove_var("B00T_RUNTIMES_SOURCE_ROOT");
             std::env::set_var("_B00T_TEST_ROOT", tmp.path().to_str().unwrap());
         }
         let _cleanup = EnvVarGuard("_B00T_TEST_ROOT");
@@ -182,5 +199,21 @@ mod tests {
             "unexpected error: {}",
             msg
         );
+    }
+
+    #[test]
+    fn test_runtimes_source_root_explicit_override() {
+        let tmp = tempfile::tempdir().unwrap();
+        let source_root = tmp.path().join("_b00t_/runtimes");
+        std::fs::create_dir_all(&source_root).unwrap();
+
+        let _lock = ENV_MUTEX.lock().unwrap();
+        unsafe {
+            std::env::set_var("B00T_RUNTIMES_SOURCE_ROOT", &source_root);
+        }
+        let _cleanup = EnvVarGuard("B00T_RUNTIMES_SOURCE_ROOT");
+
+        let result = runtimes_source_root().unwrap();
+        assert_eq!(result, source_root);
     }
 }

--- a/b00t-cli/src/install/mod.rs
+++ b/b00t-cli/src/install/mod.rs
@@ -31,8 +31,14 @@ pub fn default_registry() -> AdapterRegistry {
 pub fn runtimes_source_root() -> Result<PathBuf> {
     if let Ok(source_root) = std::env::var("B00T_RUNTIMES_SOURCE_ROOT") {
         let root = PathBuf::from(source_root);
-        if root.exists() {
+        if root.is_dir() {
             return Ok(root);
+        }
+        if root.exists() {
+            anyhow::bail!(
+                "runtimes source path exists but is not a directory: {}",
+                root.display()
+            );
         }
         anyhow::bail!(
             "runtimes source directory not found: {}",
@@ -154,14 +160,37 @@ mod tests {
         assert_eq!(selection.runtimes.len(), detected.len());
     }
 
+    /// RAII guard that saves the current value of an env var and restores it on drop.
+    struct EnvVarRestoreGuard {
+        name: &'static str,
+        original: Option<String>,
+    }
+
+    impl EnvVarRestoreGuard {
+        fn remove(name: &'static str) -> Self {
+            let original = std::env::var(name).ok();
+            unsafe { std::env::remove_var(name); }
+            Self { name, original }
+        }
+    }
+
+    impl Drop for EnvVarRestoreGuard {
+        fn drop(&mut self) {
+            unsafe {
+                match &self.original {
+                    Some(val) => std::env::set_var(self.name, val),
+                    None => std::env::remove_var(self.name),
+                }
+            }
+        }
+    }
+
     #[test]
     fn test_runtimes_source_root_from_workspace() {
         // When run from within the repo, runtimes_source_root() is anchored at the
         // git workspace root. Verify the returned path ends with _b00t_/runtimes.
         let _lock = ENV_MUTEX.lock().unwrap();
-        unsafe {
-            std::env::remove_var("B00T_RUNTIMES_SOURCE_ROOT");
-        }
+        let _restore = EnvVarRestoreGuard::remove("B00T_RUNTIMES_SOURCE_ROOT");
         let root = crate::utils::get_workspace_root();
         let expected = PathBuf::from(&root).join("_b00t_/runtimes");
         if expected.exists() {
@@ -186,8 +215,8 @@ mod tests {
         // Override workspace root to a temp dir that has no _b00t_/runtimes.
         let tmp = tempfile::tempdir().unwrap();
         let _lock = ENV_MUTEX.lock().unwrap();
+        let _restore = EnvVarRestoreGuard::remove("B00T_RUNTIMES_SOURCE_ROOT");
         unsafe {
-            std::env::remove_var("B00T_RUNTIMES_SOURCE_ROOT");
             std::env::set_var("_B00T_TEST_ROOT", tmp.path().to_str().unwrap());
         }
         let _cleanup = EnvVarGuard("_B00T_TEST_ROOT");

--- a/b00t-cli/src/job_executor.rs
+++ b/b00t-cli/src/job_executor.rs
@@ -559,8 +559,9 @@ fn parse_checkpoint_message(message: &str) -> Result<CheckpointMetadata> {
     let mut metadata = CheckpointMetadata::default();
 
     // Extract session_id: after "session:" before " role:" or " checkpoint_count:"
-    if let Some(start) = message.find("session:") {
-        let rest = &message[start + 8..];
+    const SESSION_PREFIX: &str = "session:";
+    if let Some(start) = message.find(SESSION_PREFIX) {
+        let rest = &message[start + SESSION_PREFIX.len()..];
         let end = rest
             .find(' ')
             .or_else(|| rest.find('|'))
@@ -569,8 +570,9 @@ fn parse_checkpoint_message(message: &str) -> Result<CheckpointMetadata> {
     }
 
     // Extract role: after "role:" before " checkpoint_count:"
-    if let Some(start) = message.find("role:") {
-        let rest = &message[start + 5..];
+    const ROLE_PREFIX: &str = "role:";
+    if let Some(start) = message.find(ROLE_PREFIX) {
+        let rest = &message[start + ROLE_PREFIX.len()..];
         let end = rest
             .find(' ')
             .or_else(|| rest.find('|'))
@@ -582,8 +584,9 @@ fn parse_checkpoint_message(message: &str) -> Result<CheckpointMetadata> {
     }
 
     // Extract checkpoint_count: after "checkpoint_count:" before " capabilities:"
-    if let Some(start) = message.find("checkpoint_count:") {
-        let rest = &message[start + 17..];
+    const CHECKPOINT_COUNT_PREFIX: &str = "checkpoint_count:";
+    if let Some(start) = message.find(CHECKPOINT_COUNT_PREFIX) {
+        let rest = &message[start + CHECKPOINT_COUNT_PREFIX.len()..];
         let end = rest
             .find(' ')
             .or_else(|| rest.find('|'))
@@ -592,8 +595,9 @@ fn parse_checkpoint_message(message: &str) -> Result<CheckpointMetadata> {
     }
 
     // Extract capabilities: after "capabilities:" to end
-    if let Some(start) = message.find("capabilities:") {
-        let rest = &message[start + 14..];
+    const CAPABILITIES_PREFIX: &str = "capabilities:";
+    if let Some(start) = message.find(CAPABILITIES_PREFIX) {
+        let rest = &message[start + CAPABILITIES_PREFIX.len()..];
         let capabilities_str = rest.trim();
 
         if capabilities_str != "none" && !capabilities_str.is_empty() {

--- a/b00t-cli/src/whoami.rs
+++ b/b00t-cli/src/whoami.rs
@@ -93,14 +93,15 @@ pub fn whoami(path: &str, role_override: Option<String>, with_skills: bool) -> R
 }
 
 #[derive(Clone, Debug, PartialEq)]
-struct RoleDetails {
-    name: String,
-    hint: String,
-    skills: Vec<String>,
-    compliance: Vec<String>,
-    entangled_agents: Vec<String>,
-    entangled_cli: Vec<String>,
-    entangled_mcp: Vec<String>,
+pub struct RoleDetails {
+    pub name: String,
+    pub hint: String,
+    pub skills: Vec<String>,
+    pub compliance: Vec<String>,
+    pub entangled_agents: Vec<String>,
+    pub entangled_cli: Vec<String>,
+    pub entangled_mcp: Vec<String>,
+    pub channel_prefix: Option<String>,
 }
 
 #[derive(Clone, Debug, PartialEq)]
@@ -143,6 +144,7 @@ fn load_role_datum(role: &str, path: &str) -> Option<RoleDetails> {
     let entangled_agents = datum.entangled_agents.unwrap_or_default();
     let entangled_cli = datum.entangled_cli.unwrap_or_default();
     let entangled_mcp = datum.entangled_mcp.unwrap_or_default();
+    let channel_prefix = datum.channel_prefix;
 
     Some(RoleDetails {
         name: datum.name,
@@ -152,6 +154,7 @@ fn load_role_datum(role: &str, path: &str) -> Option<RoleDetails> {
         entangled_agents,
         entangled_cli,
         entangled_mcp,
+        channel_prefix,
     })
 }
 
@@ -462,6 +465,7 @@ compliance = ["monitor chat"]
 entangled_agents = ["ralph.agent"]
 entangled_cli = ["b00t.cli"]
 entangled_mcp = ["ralph.mcp"]
+channel_prefix = "agent:executive:"
 "#,
         )
         .unwrap();
@@ -471,6 +475,7 @@ entangled_mcp = ["ralph.mcp"]
         assert_eq!(role.entangled_agents, vec!["ralph.agent".to_string()]);
         assert_eq!(role.entangled_cli, vec!["b00t.cli".to_string()]);
         assert_eq!(role.entangled_mcp, vec!["ralph.mcp".to_string()]);
+        assert_eq!(role.channel_prefix, Some("agent:executive:".to_string()));
     }
 
     #[test]

--- a/b00t-cli/tests/cli_grok_learn_test.rs
+++ b/b00t-cli/tests/cli_grok_learn_test.rs
@@ -11,10 +11,20 @@ fn is_infrastructure_available() -> bool {
 }
 
 fn get_b00t_binary() -> String {
-    env::var("CARGO_BIN_EXE_b00t-cli").unwrap_or_else(|_| {
-        let manifest_dir = env::var("CARGO_MANIFEST_DIR").unwrap();
-        format!("{}/target/debug/b00t-cli", manifest_dir)
-    })
+    if let Ok(path) = env::var("CARGO_BIN_EXE_b00t-cli") {
+        return path;
+    }
+
+    let manifest_dir = env::var("CARGO_MANIFEST_DIR").unwrap();
+    let candidates = [
+        format!("{}/target/debug/b00t-cli", manifest_dir),
+        format!("{}/../target/debug/b00t-cli", manifest_dir),
+    ];
+
+    candidates
+        .into_iter()
+        .find(|path| std::path::Path::new(path).exists())
+        .expect("b00t-cli binary not found; run cargo test so Cargo builds it first")
 }
 
 fn setup_temp_dir() -> TempDir {
@@ -262,12 +272,12 @@ mod cli_learn_display_flags {
         );
 
         let stdout = String::from_utf8_lossy(&output.stdout);
-        // Check for stable TOC markers based on the known section headings.
+        // Check for stable TOC markers based on the CLI's top-level knowledge sections.
         assert!(
-            stdout.contains("Section 1")
-                && stdout.contains("Section 2")
-                && stdout.contains("Section 3"),
-            "TOC output did not list expected sections. Output was:\n{}",
+            stdout.contains("Table of Contents: test_topic")
+                && stdout.contains("Learn Content (_b00t_/learn/test_topic.md)")
+                && stdout.contains("Use: b00t learn test_topic --section <num>"),
+            "TOC output did not list expected knowledge sections. Output was:\n{}",
             stdout
         );
     }

--- a/b00t-cli/tests/cli_grok_learn_test.rs
+++ b/b00t-cli/tests/cli_grok_learn_test.rs
@@ -6,25 +6,10 @@ use std::fs;
 use std::process::Command;
 use tempfile::TempDir;
 
+mod common;
+
 fn is_infrastructure_available() -> bool {
     env::var("TEST_WITH_QDRANT").is_ok() || env::var("QDRANT_URL").is_ok()
-}
-
-fn get_b00t_binary() -> String {
-    if let Ok(path) = env::var("CARGO_BIN_EXE_b00t-cli") {
-        return path;
-    }
-
-    let manifest_dir = env::var("CARGO_MANIFEST_DIR").unwrap();
-    let candidates = [
-        format!("{}/target/debug/b00t-cli", manifest_dir),
-        format!("{}/../target/debug/b00t-cli", manifest_dir),
-    ];
-
-    candidates
-        .into_iter()
-        .find(|path| std::path::Path::new(path).exists())
-        .expect("b00t-cli binary not found; run cargo test so Cargo builds it first")
 }
 
 fn setup_temp_dir() -> TempDir {
@@ -43,7 +28,7 @@ mod cli_grok_learn {
             return;
         }
 
-        let b00t = get_b00t_binary();
+        let b00t = common::get_b00t_binary();
 
         // Test learning from direct content
         let output = Command::new(&b00t)
@@ -89,7 +74,7 @@ mod cli_grok_learn {
         )
         .expect("Failed to write test file");
 
-        let b00t = get_b00t_binary();
+        let b00t = common::get_b00t_binary();
 
         // Read the file contents so we pass the actual string, not a shell expansion literal.
         let file_contents = fs::read_to_string(&test_file).expect("Failed to read test file");
@@ -127,7 +112,7 @@ mod cli_grok_learn {
             return;
         }
 
-        let b00t = get_b00t_binary();
+        let b00t = common::get_b00t_binary();
 
         // Test learning from URL (using httpbin for testing)
         let output = Command::new(&b00t)
@@ -161,7 +146,7 @@ mod cli_grok_learn {
 
     #[test]
     fn test_cli_grok_learn_missing_topic() {
-        let b00t = get_b00t_binary();
+        let b00t = common::get_b00t_binary();
 
         // Try to learn without specifying topic
         let output = Command::new(&b00t)
@@ -195,7 +180,7 @@ mod cli_grok_learn {
             return;
         }
 
-        let b00t = get_b00t_binary();
+        let b00t = common::get_b00t_binary();
         let topic = "grok_workflow_test";
 
         println!("\n=== STEP 1: Learn from content ===");
@@ -243,7 +228,7 @@ mod cli_learn_display_flags {
     fn test_cli_learn_toc_flag() {
         let temp_dir = setup_temp_dir();
         let temp_path = temp_dir.path().to_str().unwrap();
-        let b00t = get_b00t_binary();
+        let b00t = common::get_b00t_binary();
 
         // Create a test learn file with multiple sections
         let learn_dir = temp_dir.path().join("learn");
@@ -286,7 +271,7 @@ mod cli_learn_display_flags {
     fn test_cli_learn_section_flag() {
         let temp_dir = setup_temp_dir();
         let temp_path = temp_dir.path().to_str().unwrap();
-        let b00t = get_b00t_binary();
+        let b00t = common::get_b00t_binary();
 
         let learn_dir = temp_dir.path().join("learn");
         fs::create_dir_all(&learn_dir).expect("Failed to create learn dir");
@@ -324,7 +309,7 @@ mod cli_learn_display_flags {
     fn test_cli_learn_concise_flag() {
         let temp_dir = setup_temp_dir();
         let temp_path = temp_dir.path().to_str().unwrap();
-        let b00t = get_b00t_binary();
+        let b00t = common::get_b00t_binary();
 
         let learn_dir = temp_dir.path().join("learn");
         fs::create_dir_all(&learn_dir).expect("Failed to create learn dir");
@@ -358,7 +343,7 @@ mod cli_learn_display_flags {
     fn test_cli_learn_invalid_section() {
         let temp_dir = setup_temp_dir();
         let temp_path = temp_dir.path().to_str().unwrap();
-        let b00t = get_b00t_binary();
+        let b00t = common::get_b00t_binary();
 
         // Try to access section 99 that doesn't exist
         let output = Command::new(&b00t)
@@ -384,7 +369,7 @@ mod cli_error_paths {
     fn test_cli_learn_search_nonexistent_topic() {
         let temp_dir = setup_temp_dir();
         let temp_path = temp_dir.path().to_str().unwrap();
-        let b00t = get_b00t_binary();
+        let b00t = common::get_b00t_binary();
 
         let output = Command::new(&b00t)
             .args(&[
@@ -418,7 +403,7 @@ mod cli_error_paths {
 
     #[test]
     fn test_cli_grok_digest_without_topic() {
-        let b00t = get_b00t_binary();
+        let b00t = common::get_b00t_binary();
 
         let output = Command::new(&b00t)
             .args(&["grok", "digest", "some content"])
@@ -437,7 +422,7 @@ mod cli_error_paths {
 
     #[test]
     fn test_cli_grok_ask_without_topic_when_required() {
-        let b00t = get_b00t_binary();
+        let b00t = common::get_b00t_binary();
 
         // When using --rag, topic is required
         let output = Command::new(&b00t)
@@ -471,7 +456,7 @@ mod cli_error_paths {
             return;
         }
 
-        let b00t = get_b00t_binary();
+        let b00t = common::get_b00t_binary();
 
         // Test multiple concurrent digest operations
         let handles: Vec<_> = (0..3)

--- a/b00t-cli/tests/cli_learn_commands_test.rs
+++ b/b00t-cli/tests/cli_learn_commands_test.rs
@@ -11,34 +11,10 @@ use std::env;
 use std::process::Command;
 use tempfile::TempDir;
 
+mod common;
+
 fn is_infrastructure_available() -> bool {
     env::var("TEST_WITH_QDRANT").is_ok() || env::var("QDRANT_URL").is_ok()
-}
-
-fn get_b00t_binary() -> String {
-    let manifest_dir = env::var("CARGO_MANIFEST_DIR").unwrap();
-    let mut candidates = vec![];
-
-    // Cargo sets CARGO_BIN_EXE_<name> with '-' replaced by '_'
-    if let Ok(path) = env::var("CARGO_BIN_EXE_b00t_cli") {
-        candidates.push(path);
-    }
-    if let Ok(path) = env::var("CARGO_BIN_EXE_b00t-cli") {
-        candidates.push(path);
-    }
-
-    // Common local build outputs
-    candidates.push(format!("{}/target/debug/b00t-cli", manifest_dir));
-    candidates.push(format!("{}/../target/debug/b00t-cli", manifest_dir)); // workspace root
-    candidates.push(format!("{}/target/debug/deps/b00t-cli", manifest_dir));
-
-    for path in &candidates {
-        if std::path::Path::new(path).exists() {
-            return path.clone();
-        }
-    }
-
-    panic!("b00t binary not found; tried: {:?}", candidates);
 }
 
 fn setup_temp_dir() -> TempDir {
@@ -57,7 +33,7 @@ mod cli_learn_digest {
             return;
         }
 
-        let b00t = get_b00t_binary();
+        let b00t = common::get_b00t_binary();
 
         let output = Command::new(&b00t)
             .args(&[
@@ -96,7 +72,7 @@ mod cli_learn_digest {
             return;
         }
 
-        let b00t = get_b00t_binary();
+        let b00t = common::get_b00t_binary();
 
         let output = Command::new(&b00t)
             .args(&["learn", "rust_cli_test", "--digest", ""])
@@ -132,7 +108,7 @@ mod cli_learn_ask {
             return;
         }
 
-        let b00t = get_b00t_binary();
+        let b00t = common::get_b00t_binary();
 
         // First digest some content
         let digest_output = Command::new(&b00t)
@@ -186,7 +162,7 @@ mod cli_learn_ask {
             return;
         }
 
-        let b00t = get_b00t_binary();
+        let b00t = common::get_b00t_binary();
 
         // Ask for something very unlikely to exist
         let output = Command::new(&b00t)
@@ -230,7 +206,7 @@ mod cli_learn_record_search {
 
         let temp_dir = setup_temp_dir();
         let temp_path = temp_dir.path().to_str().unwrap();
-        let b00t = get_b00t_binary();
+        let b00t = common::get_b00t_binary();
 
         // Record a lesson
         let record_output = Command::new(&b00t)
@@ -297,7 +273,7 @@ mod cli_learn_record_search {
 
         let temp_dir = setup_temp_dir();
         let temp_path = temp_dir.path().to_str().unwrap();
-        let b00t = get_b00t_binary();
+        let b00t = common::get_b00t_binary();
 
         // Try to record a lesson with body exceeding 250 tokens
         let very_long_body = "word ".repeat(300);
@@ -346,7 +322,7 @@ mod cli_end_to_end_workflow {
 
         let temp_dir = setup_temp_dir();
         let temp_path = temp_dir.path().to_str().unwrap();
-        let b00t = get_b00t_binary();
+        let b00t = common::get_b00t_binary();
         let topic = "workflow_test";
 
         println!("\n=== STEP 1: Record LFMF Lesson ===");
@@ -422,7 +398,7 @@ mod cli_end_to_end_workflow {
         // Test graceful degradation
         let temp_dir = setup_temp_dir();
         let temp_path = temp_dir.path().to_str().unwrap();
-        let b00t = get_b00t_binary();
+        let b00t = common::get_b00t_binary();
         let topic = "offline_test";
 
         // Remove Qdrant env vars to simulate offline
@@ -480,7 +456,7 @@ mod cli_error_handling {
 
     #[test]
     fn test_cli_learn_missing_topic() {
-        let b00t = get_b00t_binary();
+        let b00t = common::get_b00t_binary();
 
         let output = Command::new(&b00t)
             .args(&["learn"])
@@ -504,7 +480,7 @@ mod cli_error_handling {
 
     #[test]
     fn test_cli_learn_invalid_flag_combination() {
-        let b00t = get_b00t_binary();
+        let b00t = common::get_b00t_binary();
 
         // Try to use --digest and --ask together (invalid)
         let output = Command::new(&b00t)
@@ -534,7 +510,7 @@ mod cli_error_handling {
     fn test_cli_learn_record_invalid_format() {
         let temp_dir = setup_temp_dir();
         let temp_path = temp_dir.path().to_str().unwrap();
-        let b00t = get_b00t_binary();
+        let b00t = common::get_b00t_binary();
 
         // Record without "topic: body" format
         let output = Command::new(&b00t)
@@ -583,7 +559,7 @@ mod cross_language_integration {
             return;
         }
 
-        let b00t = get_b00t_binary();
+        let b00t = common::get_b00t_binary();
 
         // This tests Rust CLI → Rust GrokClient → Python b00t-grok-py MCP server
         let output = Command::new(&b00t)
@@ -626,7 +602,7 @@ mod cross_language_integration {
             return;
         }
 
-        let b00t = get_b00t_binary();
+        let b00t = common::get_b00t_binary();
 
         // Test that Python errors are properly propagated to Rust
         // (This assumes some invalid operation that Python will reject)

--- a/b00t-cli/tests/cli_raglight_integration_test.rs
+++ b/b00t-cli/tests/cli_raglight_integration_test.rs
@@ -1,27 +1,10 @@
 //! RAGLight integration tests - bringing advanced features to 50% coverage
 //! Tests the RAGLight backend as an alternative to Qdrant
 
-use std::env;
-use std::fs;
 use std::process::Command;
 use tempfile::TempDir;
 
-fn get_b00t_binary() -> String {
-    if let Ok(path) = env::var("CARGO_BIN_EXE_b00t-cli") {
-        return path;
-    }
-
-    let manifest_dir = env::var("CARGO_MANIFEST_DIR").unwrap();
-    let candidates = [
-        format!("{}/target/debug/b00t-cli", manifest_dir),
-        format!("{}/../target/debug/b00t-cli", manifest_dir),
-    ];
-
-    candidates
-        .into_iter()
-        .find(|path| std::path::Path::new(path).exists())
-        .expect("b00t-cli binary not found; run cargo test so Cargo builds it first")
-}
+mod common;
 
 fn setup_temp_dir() -> TempDir {
     tempfile::tempdir().expect("Failed to create temp directory")
@@ -33,7 +16,7 @@ mod raglight_basic {
 
     #[test]
     fn test_grok_digest_with_raglight_backend() {
-        let b00t = get_b00t_binary();
+        let b00t = common::get_b00t_binary();
 
         let output = Command::new(&b00t)
             .args(&[
@@ -77,7 +60,7 @@ mod raglight_basic {
 
     #[test]
     fn test_grok_ask_with_raglight_backend() {
-        let b00t = get_b00t_binary();
+        let b00t = common::get_b00t_binary();
 
         // First digest some content
         let _ = Command::new(&b00t)
@@ -130,7 +113,7 @@ mod raglight_basic {
 
     #[test]
     fn test_grok_learn_with_raglight_backend() {
-        let b00t = get_b00t_binary();
+        let b00t = common::get_b00t_binary();
 
         let output = Command::new(&b00t)
             .args(&[
@@ -169,7 +152,7 @@ mod raglight_workflow {
 
     #[test]
     fn test_raglight_complete_workflow() {
-        let b00t = get_b00t_binary();
+        let b00t = common::get_b00t_binary();
         let topic = "raglight_workflow";
 
         println!("\n=== RAGLight Workflow Test ===");
@@ -222,7 +205,7 @@ mod raglight_workflow {
     #[test]
     fn test_raglight_file_storage() {
         // Test that RAGLight stores files in expected location
-        let b00t = get_b00t_binary();
+        let b00t = common::get_b00t_binary();
 
         let output = Command::new(&b00t)
             .args(&[
@@ -262,7 +245,7 @@ mod raglight_error_handling {
 
     #[test]
     fn test_raglight_invalid_backend_name() {
-        let b00t = get_b00t_binary();
+        let b00t = common::get_b00t_binary();
 
         let output = Command::new(&b00t)
             .args(&[
@@ -294,7 +277,7 @@ mod raglight_error_handling {
 
     #[test]
     fn test_raglight_missing_topic() {
-        let b00t = get_b00t_binary();
+        let b00t = common::get_b00t_binary();
 
         // RAGLight operations should require topic
         let output = Command::new(&b00t)
@@ -320,7 +303,7 @@ mod raglight_error_handling {
 
     #[test]
     fn test_raglight_concurrent_access() {
-        let b00t = get_b00t_binary();
+        let b00t = common::get_b00t_binary();
 
         // Test multiple concurrent RAGLight operations
         let handles: Vec<_> = (0..3)
@@ -366,7 +349,7 @@ mod raglight_vs_qdrant {
 
     #[test]
     fn test_raglight_as_fallback() {
-        let b00t = get_b00t_binary();
+        let b00t = common::get_b00t_binary();
 
         // When Qdrant is unavailable, RAGLight can be used as fallback
         let output = Command::new(&b00t)
@@ -399,7 +382,7 @@ mod raglight_vs_qdrant {
 
     #[test]
     fn test_explicit_backend_selection() {
-        let b00t = get_b00t_binary();
+        let b00t = common::get_b00t_binary();
 
         // Test that --rag flag properly selects backend
         let raglight_output = Command::new(&b00t)

--- a/b00t-cli/tests/cli_raglight_integration_test.rs
+++ b/b00t-cli/tests/cli_raglight_integration_test.rs
@@ -7,10 +7,20 @@ use std::process::Command;
 use tempfile::TempDir;
 
 fn get_b00t_binary() -> String {
-    env::var("CARGO_BIN_EXE_b00t-cli").unwrap_or_else(|_| {
-        let manifest_dir = env::var("CARGO_MANIFEST_DIR").unwrap();
-        format!("{}/target/debug/b00t-cli", manifest_dir)
-    })
+    if let Ok(path) = env::var("CARGO_BIN_EXE_b00t-cli") {
+        return path;
+    }
+
+    let manifest_dir = env::var("CARGO_MANIFEST_DIR").unwrap();
+    let candidates = [
+        format!("{}/target/debug/b00t-cli", manifest_dir),
+        format!("{}/../target/debug/b00t-cli", manifest_dir),
+    ];
+
+    candidates
+        .into_iter()
+        .find(|path| std::path::Path::new(path).exists())
+        .expect("b00t-cli binary not found; run cargo test so Cargo builds it first")
 }
 
 fn setup_temp_dir() -> TempDir {

--- a/b00t-cli/tests/common/mod.rs
+++ b/b00t-cli/tests/common/mod.rs
@@ -1,0 +1,37 @@
+/// Shared helpers for b00t-cli integration tests.
+
+use std::env;
+
+/// Resolve the path to the compiled `b00t-cli` binary.
+///
+/// Resolution order:
+/// 1. `CARGO_BIN_EXE_b00t-cli` (set by Cargo for integration-test binaries)
+/// 2. `CARGO_BIN_EXE_b00t_cli` (Cargo normalises `-` → `_` in some contexts)
+/// 3. Common local build-output paths relative to `CARGO_MANIFEST_DIR`
+#[allow(dead_code)]
+pub fn get_b00t_binary() -> String {
+    // Cargo sets these env vars automatically when running integration tests.
+    if let Ok(path) = env::var("CARGO_BIN_EXE_b00t-cli") {
+        return path;
+    }
+    if let Ok(path) = env::var("CARGO_BIN_EXE_b00t_cli") {
+        return path;
+    }
+
+    let manifest_dir = env::var("CARGO_MANIFEST_DIR").unwrap();
+    let candidates = [
+        format!("{manifest_dir}/target/debug/b00t-cli"),
+        format!("{manifest_dir}/../target/debug/b00t-cli"),
+        format!("{manifest_dir}/target/debug/deps/b00t-cli"),
+    ];
+
+    candidates
+        .into_iter()
+        .find(|path| std::path::Path::new(path).exists())
+        .unwrap_or_else(|| {
+            panic!(
+                "b00t-cli binary not found; tried paths relative to {manifest_dir}. \
+                 Run `cargo test` so Cargo builds the binary first."
+            )
+        })
+}

--- a/b00t-cli/tests/hello_world_test.rs
+++ b/b00t-cli/tests/hello_world_test.rs
@@ -1,12 +1,29 @@
-use b00t_c0re_lib::version;
 use std::env;
 use std::fs;
 use std::path::Path;
+use std::process::Command;
 use std::sync::Mutex;
 use tempfile::TempDir;
 
 // 🤓 Prevent cargo lock contention - serialize b00t-cli execution
 static CARGO_LOCK: Mutex<()> = Mutex::new(());
+
+fn get_b00t_binary() -> String {
+    if let Ok(path) = env::var("CARGO_BIN_EXE_b00t-cli") {
+        return path;
+    }
+
+    let manifest_dir = env::var("CARGO_MANIFEST_DIR").unwrap();
+    let candidates = [
+        format!("{manifest_dir}/target/debug/b00t-cli"),
+        format!("{manifest_dir}/../target/debug/b00t-cli"),
+    ];
+
+    candidates
+        .into_iter()
+        .find(|path| Path::new(path).exists())
+        .expect("b00t-cli binary not found; run cargo test so Cargo builds it first")
+}
 
 fn setup_test_environment(temp_dir: &Path) -> Result<(), std::io::Error> {
     // Create minimal _b00t_ directory structure
@@ -17,37 +34,16 @@ fn setup_test_environment(temp_dir: &Path) -> Result<(), std::io::Error> {
     let session_dir = temp_dir.join(".git");
     fs::create_dir_all(&session_dir)?;
 
-    // Create minimal _b00t_.toml to prevent session memory errors
-    let toml_content = format!(
-        r#"
-[session]
-initialized = true
-agent_type = "test"
-
-[b00t]
-version = "{version}"
-"#,
-        version = version::VERSION
-    );
-    fs::write(session_dir.join("_b00t_.toml"), toml_content)?;
-
     Ok(())
 }
 
 #[test]
 fn test_hello_world_with_skip_all_flags() {
+    let b00t = get_b00t_binary();
+
     // Test hello-world command help output to verify it works
-    let output = std::process::Command::new("cargo")
-        .args(&[
-            "run",
-            "--bin",
-            "b00t-cli",
-            "--",
-            "init",
-            "hello-world",
-            "--help",
-        ])
-        .current_dir("/home/brianh/.dotfiles")
+    let output = Command::new(&b00t)
+        .args(["init", "hello-world", "--help"])
         .output()
         .expect("Failed to execute command");
 
@@ -66,10 +62,11 @@ fn test_hello_world_with_skip_all_flags() {
 
 #[test]
 fn test_hello_world_mcp_introspection() {
+    let b00t = get_b00t_binary();
+
     // Test that MCP introspection functionality works by testing MCP list directly
-    let output = std::process::Command::new("cargo")
-        .args(&["run", "--bin", "b00t-cli", "--", "mcp", "list"])
-        .current_dir("/home/brianh/.dotfiles")
+    let output = Command::new(&b00t)
+        .args(["mcp", "list"])
         .output()
         .expect("Failed to execute MCP list command");
 
@@ -90,10 +87,11 @@ fn test_hello_world_mcp_introspection() {
 
 #[test]
 fn test_hello_world_session_memory_tracking() {
+    let b00t = get_b00t_binary();
+
     // Test session memory operations directly
-    let output = std::process::Command::new("cargo")
-        .args(&["run", "--bin", "b00t-cli", "--", "session", "keys"])
-        .current_dir("/home/brianh/.dotfiles")
+    let output = Command::new(&b00t)
+        .args(["session", "keys"])
         .output()
         .expect("Failed to execute session keys command");
 
@@ -110,33 +108,30 @@ fn test_hello_world_session_memory_tracking() {
 
 #[test]
 fn test_hello_world_system_preferences() {
-    let _lock = CARGO_LOCK.lock().unwrap(); // 🤓 Prevent cargo contention
+    let _lock = CARGO_LOCK.lock().unwrap_or_else(|poisoned| poisoned.into_inner()); // 🤓 Prevent cargo contention
 
     let temp_dir = TempDir::new().unwrap();
-    let original_dir = env::current_dir().unwrap();
-    env::set_current_dir(&temp_dir).unwrap();
+    let b00t = get_b00t_binary();
 
     // Initialize git repo and test environment
-    std::process::Command::new("git")
-        .args(&["init"])
+    Command::new("git")
+        .args(["init"])
+        .current_dir(temp_dir.path())
         .output()
         .unwrap();
     setup_test_environment(temp_dir.path()).unwrap();
 
     // Test hello-world command
-    let output = std::process::Command::new("cargo")
+    let output = Command::new(&b00t)
         .args(&[
-            "run",
-            "--bin",
-            "b00t-cli",
-            "--",
             "init",
             "hello-world",
             "--skip-redis",
             "--skip-diagnostics",
             "--skip-tour",
         ])
-        .current_dir("/home/brianh/.dotfiles")
+        .current_dir(temp_dir.path())
+        .env("_B00T_TEST_ROOT", temp_dir.path())
         .output()
         .expect("Failed to execute command");
 
@@ -153,40 +148,35 @@ fn test_hello_world_system_preferences() {
         stdout.contains("🔧 Phase 3: Tool & Service Discovery")
             || stdout.contains("✅ Agent enlightenment complete!")
     );
-
-    env::set_current_dir(original_dir).unwrap();
 }
 
 #[test]
 fn test_hello_world_agent_detection() {
-    let _lock = CARGO_LOCK.lock().unwrap(); // 🤓 Prevent cargo contention
+    let _lock = CARGO_LOCK.lock().unwrap_or_else(|poisoned| poisoned.into_inner()); // 🤓 Prevent cargo contention
 
     let temp_dir = TempDir::new().unwrap();
-    let original_dir = env::current_dir().unwrap();
-    env::set_current_dir(&temp_dir).unwrap();
+    let b00t = get_b00t_binary();
 
     // Initialize git repo and test environment
-    std::process::Command::new("git")
-        .args(&["init"])
+    Command::new("git")
+        .args(["init"])
+        .current_dir(temp_dir.path())
         .output()
         .unwrap();
     setup_test_environment(temp_dir.path()).unwrap();
 
     // Test with CLAUDECODE environment variable
-    let output = std::process::Command::new("cargo")
+    let output = Command::new(&b00t)
         .env("CLAUDECODE", "1")
         .args(&[
-            "run",
-            "--bin",
-            "b00t-cli",
-            "--",
             "init",
             "hello-world",
             "--skip-redis",
             "--skip-diagnostics",
             "--skip-tour",
         ])
-        .current_dir("/home/brianh/.dotfiles")
+        .current_dir(temp_dir.path())
+        .env("_B00T_TEST_ROOT", temp_dir.path())
         .output()
         .expect("Failed to execute command");
 
@@ -204,23 +194,14 @@ fn test_hello_world_agent_detection() {
             || stdout.contains("🏷️  Role:")
             || stdout.contains("✅ Agent enlightenment complete!")
     );
-
-    env::set_current_dir(original_dir).unwrap();
 }
 
 #[test]
 fn test_hello_world_help_output() {
-    let output = std::process::Command::new("cargo")
-        .args(&[
-            "run",
-            "--bin",
-            "b00t-cli",
-            "--",
-            "init",
-            "hello-world",
-            "--help",
-        ])
-        .current_dir("/home/brianh/.dotfiles")
+    let b00t = get_b00t_binary();
+
+    let output = Command::new(&b00t)
+        .args(["init", "hello-world", "--help"])
         .output()
         .expect("Failed to execute command");
 

--- a/b00t-cli/tests/hello_world_test.rs
+++ b/b00t-cli/tests/hello_world_test.rs
@@ -1,29 +1,13 @@
-use std::env;
 use std::fs;
 use std::path::Path;
 use std::process::Command;
 use std::sync::Mutex;
 use tempfile::TempDir;
 
+mod common;
+
 // 🤓 Prevent cargo lock contention - serialize b00t-cli execution
 static CARGO_LOCK: Mutex<()> = Mutex::new(());
-
-fn get_b00t_binary() -> String {
-    if let Ok(path) = env::var("CARGO_BIN_EXE_b00t-cli") {
-        return path;
-    }
-
-    let manifest_dir = env::var("CARGO_MANIFEST_DIR").unwrap();
-    let candidates = [
-        format!("{manifest_dir}/target/debug/b00t-cli"),
-        format!("{manifest_dir}/../target/debug/b00t-cli"),
-    ];
-
-    candidates
-        .into_iter()
-        .find(|path| Path::new(path).exists())
-        .expect("b00t-cli binary not found; run cargo test so Cargo builds it first")
-}
 
 fn setup_test_environment(temp_dir: &Path) -> Result<(), std::io::Error> {
     // Create minimal _b00t_ directory structure
@@ -39,7 +23,7 @@ fn setup_test_environment(temp_dir: &Path) -> Result<(), std::io::Error> {
 
 #[test]
 fn test_hello_world_with_skip_all_flags() {
-    let b00t = get_b00t_binary();
+    let b00t = common::get_b00t_binary();
 
     // Test hello-world command help output to verify it works
     let output = Command::new(&b00t)
@@ -62,7 +46,7 @@ fn test_hello_world_with_skip_all_flags() {
 
 #[test]
 fn test_hello_world_mcp_introspection() {
-    let b00t = get_b00t_binary();
+    let b00t = common::get_b00t_binary();
 
     // Test that MCP introspection functionality works by testing MCP list directly
     let output = Command::new(&b00t)
@@ -87,7 +71,7 @@ fn test_hello_world_mcp_introspection() {
 
 #[test]
 fn test_hello_world_session_memory_tracking() {
-    let b00t = get_b00t_binary();
+    let b00t = common::get_b00t_binary();
 
     // Test session memory operations directly
     let output = Command::new(&b00t)
@@ -111,7 +95,7 @@ fn test_hello_world_system_preferences() {
     let _lock = CARGO_LOCK.lock().unwrap_or_else(|poisoned| poisoned.into_inner()); // 🤓 Prevent cargo contention
 
     let temp_dir = TempDir::new().unwrap();
-    let b00t = get_b00t_binary();
+    let b00t = common::get_b00t_binary();
 
     // Initialize git repo and test environment
     Command::new("git")
@@ -155,7 +139,7 @@ fn test_hello_world_agent_detection() {
     let _lock = CARGO_LOCK.lock().unwrap_or_else(|poisoned| poisoned.into_inner()); // 🤓 Prevent cargo contention
 
     let temp_dir = TempDir::new().unwrap();
-    let b00t = get_b00t_binary();
+    let b00t = common::get_b00t_binary();
 
     // Initialize git repo and test environment
     Command::new("git")
@@ -198,7 +182,7 @@ fn test_hello_world_agent_detection() {
 
 #[test]
 fn test_hello_world_help_output() {
-    let b00t = get_b00t_binary();
+    let b00t = common::get_b00t_binary();
 
     let output = Command::new(&b00t)
         .args(["init", "hello-world", "--help"])

--- a/b00t-cli/tests/install_cli_test.rs
+++ b/b00t-cli/tests/install_cli_test.rs
@@ -1,6 +1,19 @@
 use assert_cmd::prelude::*;
+use std::fs;
 use std::process::Command;
 use tempfile::tempdir;
+
+fn write_claude_runtime_fixture(root: &std::path::Path) -> std::io::Result<()> {
+    let claude_root = root.join("_b00t_/runtimes/claude");
+    fs::create_dir_all(claude_root.join("skills"))?;
+    fs::create_dir_all(claude_root.join("agents"))?;
+    fs::create_dir_all(claude_root.join("hooks"))?;
+    fs::write(claude_root.join("skills/test.md"), "# test skill\n")?;
+    fs::write(claude_root.join("agents/test.md"), "# test agent\n")?;
+    fs::write(claude_root.join("hooks/test.js"), "console.log('test');\n")?;
+    fs::write(claude_root.join("settings_fragment.json"), "{}\n")?;
+    Ok(())
+}
 
 /// Verify that `b00t-cli install --help` exposes all new flag surface area.
 #[test]
@@ -91,18 +104,18 @@ fn test_install_mixed_runtimes_with_unknown_exits_nonzero() -> Result<(), Box<dy
     Ok(())
 }
 
-/// `--runtimes claude --scope local --yes` with an empty B00T_ROOT should exit 0.
-/// Source files are absent so FileCopyPack silently skips, but argument parsing
-/// and the runtime dispatch path must succeed end-to-end.
+/// `--runtimes claude --scope local --yes` with runtime-source fixtures should exit 0.
+/// Content packs are required, so the fixture must include minimal source dirs.
 #[test]
 fn test_install_valid_runtime_local_scope_exits_zero() -> Result<(), Box<dyn std::error::Error>> {
     let b00t_root = tempdir()?;
     let work_dir = tempdir()?;
+    write_claude_runtime_fixture(b00t_root.path())?;
+    let runtimes_source_root = b00t_root.path().join("_b00t_/runtimes");
 
     let mut cmd = Command::cargo_bin("b00t-cli")?;
     cmd.current_dir(work_dir.path())
-        // B00T_ROOT controls runtimes_source_root(); empty dir → silent skip for all packs
-        .env("B00T_ROOT", b00t_root.path())
+        .env("B00T_RUNTIMES_SOURCE_ROOT", &runtimes_source_root)
         .args([
             "--path",
             b00t_root.path().to_str().unwrap(),
@@ -132,10 +145,12 @@ fn test_install_valid_runtime_local_scope_exits_zero() -> Result<(), Box<dyn std
 fn test_install_comma_separated_runtimes_parsed() -> Result<(), Box<dyn std::error::Error>> {
     let b00t_root = tempdir()?;
     let work_dir = tempdir()?;
+    write_claude_runtime_fixture(b00t_root.path())?;
+    let runtimes_source_root = b00t_root.path().join("_b00t_/runtimes");
 
     let mut cmd = Command::cargo_bin("b00t-cli")?;
     cmd.current_dir(work_dir.path())
-        .env("B00T_ROOT", b00t_root.path())
+        .env("B00T_RUNTIMES_SOURCE_ROOT", &runtimes_source_root)
         .args([
             "--path",
             b00t_root.path().to_str().unwrap(),
@@ -170,9 +185,11 @@ fn test_install_scope_global_explicit_accepted() -> Result<(), Box<dyn std::erro
     let b00t_root = tempdir()?;
     // Redirect global target to a temp ~/.claude equivalent via HOME override
     let fake_home = tempdir()?;
+    write_claude_runtime_fixture(b00t_root.path())?;
+    let runtimes_source_root = b00t_root.path().join("_b00t_/runtimes");
 
     let mut cmd = Command::cargo_bin("b00t-cli")?;
-    cmd.env("B00T_ROOT", b00t_root.path())
+    cmd.env("B00T_RUNTIMES_SOURCE_ROOT", &runtimes_source_root)
         .env("HOME", fake_home.path())
         .args([
             "--path",

--- a/justfile
+++ b/justfile
@@ -868,7 +868,9 @@ irontology-update:
 acp-sm3lly-status:
     #!/bin/bash
     set -euo pipefail
-    echo "NATS_URL=${NATS_URL:-nats://c010.promptexecution.com:4222}"
+    _nats_raw="${NATS_URL:-nats://c010.promptexecution.com:4222}"
+    _nats_redacted="$(echo "$_nats_raw" | sed 's|//[^@]*@|//<redacted>@|')"
+    echo "NATS_URL=${_nats_redacted}"
     b00t chat info
     b00t hive status
     b00t whoami --role=executive | sed -n '/Capability check:/,$p'

--- a/justfile
+++ b/justfile
@@ -864,6 +864,15 @@ irontology-test:
 irontology-update:
     git submodule update --remote vendor/irontology-mcp
 
+# Inspect the local side of the sm3lly NATS ACP route without publishing credentials
+acp-sm3lly-status:
+    #!/bin/bash
+    set -euo pipefail
+    echo "NATS_URL=${NATS_URL:-nats://c010.promptexecution.com:4222}"
+    b00t chat info
+    b00t hive status
+    b00t whoami --role=executive | sed -n '/Capability check:/,$p'
+
 # ── Gemma 4 + pi-coding-agent local inference ────────────────────────────────
 
 # Download Gemma 4 26B-A4B MXFP4_MOE GGUF (unsloth/gemma-4-26B-A4B-it-GGUF)


### PR DESCRIPTION
## Summary
- harden install runtime source discovery behind explicit B00T_RUNTIMES_SOURCE_ROOT
- restore executive irontology MCP capability and add sm3lly ACP route/status datum
- remove nested cargo-run pattern from hello_world_test and preserve b00t-cli/b00t-mcp test fixes

## Verification
- cargo test -p b00t-cli -p b00t-mcp
- cargo test -p b00t-cli --test hello_world_test
- env XDG_RUNTIME_DIR=/tmp TMPDIR=/tmp just acp-sm3lly-status
- b00t/b00t-cli/b00t-mcp --version => 0.7.45