### PR TITLE
chore: sunset deprecated b00t-wiggums

### DIFF
--- a/.roo/skills-orchestrator/b00t/SKILL.md
+++ b/.roo/skills-orchestrator/b00t/SKILL.md
@@ -2,7 +2,7 @@
 name: b00t
 description: Identify integration points, data flow via redis, suggest how to bridge VSCode plugin to b00t jobs, and outline k0s/podman/docker-agnostic redis interface. Include how ralph should be wrapped as b00t job with redis exchange + Azure access, and call out where integration tests are required. ONLY do this analysis. Reply with attempt_completion summarizing plan and any questions to operator. These instructions supersede any conflicting mode defaults.  another agent is working concurrently to bring redis online and fixing issues in b00t.  establish an agent to agent channel using redis once it is online.  
 
-Scope: produce architecture analysis and integration plan for MS AI Toolkit for VSCode + b00t-vscode plugin + redis job bridge (ralph/b00t-wiggums). Context: repo has VSCode plugin in b00t-vscode/, apalis MVP PRD in .taskmaster/docs/prd.txt, job executor in b00t-cli/src/job_executor.rs. Require: MUST NOT edit files.
+Scope: produce architecture analysis and integration plan for MS AI Toolkit for VSCode + b00t-vscode plugin + redis job bridge. Treat `b00t-wiggums`/Ralph as a sunset prototype whose useful loop patterns have been absorbed into `b00t.sh` and adjacent research tooling. Context: repo has VSCode plugin in b00t-vscode/, apalis MVP PRD in .taskmaster/docs/prd.txt, job executor in b00t-cli/src/job_executor.rs. Require: MUST NOT edit files.
 ---
 
 # B00t

--- a/README.md
+++ b/README.md
@@ -89,9 +89,9 @@ b00t acp hive ready mission-id 2   # signal readiness for step 2
 
 ---
 
-## 🔁 Ralph — OODA Loop Runner
+## 🔁 Next Loop Interface
 
-`b00t.sh` implements the Ralph autonomous task loop (Observe→Orient→Decide→Act):
+`b00t.sh` carries forward the useful Ralph/OODA loop lessons, but the standalone `b00t-wiggums` repo is sunset. The loop interface is now treated as a commodity execution surface, with higher-level research/orchestration living in `b00t.sh` and `karpathy/autoresearch`.
 
 ```bash
 # Run with default claude tool, 10 iterations

--- a/_b00t_/ralph-stack.stack.toml
+++ b/_b00t_/ralph-stack.stack.toml
@@ -1,10 +1,10 @@
 [b00t]
 name = "ralph-stack"
 type = "stack"
-hint = "Complete autonomous agent workflow stack with Ralph, TODO-next backlog, and b00t jobs"
+hint = "Complete agent workflow stack with commodity next-loop execution, TODO-next backlog, and b00t jobs"
 
 [b00t.stack]
-description = "Ralph autonomous agent loop with TODO-next backlog and b00t job integration"
+description = "Legacy Ralph-inspired loop stack now folded into b00t.sh with TODO-next backlog and b00t job integration"
 category = "agent-workflow"
 
 [b00t.stack.components]

--- a/docs/TASK-TRACKING-DESIGN.md
+++ b/docs/TASK-TRACKING-DESIGN.md
@@ -275,7 +275,7 @@ prompt = "Validate all TOML files in _b00t_/ have required fields and valid synt
 
 ## Migration Path
 
-**From**: taskmaster-ai (b00t-wiggums dependency)
+**From**: taskmaster-ai via the now-sunset `b00t-wiggums` experiment
 ```
 PRD → taskmaster init → tasks.json → ralph loop
 ```


### PR DESCRIPTION
## Summary
- remove the deprecated `b00t-wiggums` nested repo from the parent repository
- update parent docs and stack metadata to treat Ralph as sunset/legacy
- point loop orchestration toward `b00t.sh` and adjacent research tooling

## Testing
- not run (docs and gitlink cleanup only)