### PR TITLE
feat: add tomllmd ledg3rr integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -371,5 +371,7 @@ venv/
 ralph/
 .b00t/tasks.json
 .b00t/ralph/
+.b00t/cmdb/
 # nested .b00t dirs inside crates (runtime state)
 b00t-cli/.b00t/
+vendor/l3dg3rr/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -794,10 +794,10 @@ dependencies = [
  "ts-rs",
  "uuid",
 ]
- 
+
 [[package]]
 name = "b00t-chat"
- version = "0.7.48"
+version = "0.7.48"
 dependencies = [
  "anyhow",
  "async-nats",
@@ -6522,22 +6522,6 @@ name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
-
-[[package]]
-name = "storage-neumann"
-version = "0.7.45"
-dependencies = [
- "anyhow",
- "async-trait",
- "base64 0.22.1",
- "rio_api",
- "rio_turtle",
- "serde",
- "serde_json",
- "sled",
- "tempfile",
- "tokio",
-]
 
 [[package]]
 name = "stringprep"

--- a/_b00t_/l3dg3rr.cli.toml
+++ b/_b00t_/l3dg3rr.cli.toml
@@ -1,0 +1,72 @@
+[b00t]
+name = "l3dg3rr"
+type = "cli"
+hint = """
+Authoritative local source library for `.tomllmd` validation and visualization rules.
+
+`b00t` treats `.tomllmd` as a richer superset of `.tomllm` and downgrades it to the
+generic `.tomllm` path in core parsing. Advanced diagram/DSL/structured-markdown
+semantics should be validated and visualized against `l3dg3rr`.
+"""
+
+[b00t.cli]
+command = "just"
+detect = """
+if [ -f vendor/l3dg3rr/Cargo.toml ]; then
+  echo "vendor/l3dg3rr"
+elif command -v ledgerr-mcp-server >/dev/null 2>&1; then
+  echo "ledgerr-mcp-server"
+else
+  exit 1
+fi
+"""
+version_cmd = """
+if [ -f vendor/l3dg3rr/Cargo.toml ]; then
+  awk -F'"' '/^version = / { print $2; exit }' vendor/l3dg3rr/Cargo.toml
+else
+  ledgerr-mcp-server --version
+fi
+"""
+version_regex = '(\\d+\\.\\d+\\.\\d+)'
+install = "echo 'l3dg3rr is authoritative but intentionally kept as an external/local source library; clone PromptExecution/l3dg3rr into vendor/l3dg3rr if needed.'"
+desires = "local-authority"
+
+[b00t.capabilities]
+features = [
+  "tomllmd-validation",
+  "tomllmd-visualization",
+  "diagram-dsl",
+  "structured-markdown",
+  "lsp-asp-shapes",
+]
+requires = ["just", "rust"]
+
+[b00t.authority]
+scope = [".tomllmd"]
+fallback = ".tomllm"
+validation_source = "vendor/l3dg3rr"
+visualization_source = "vendor/l3dg3rr"
+notes = [
+  "Use generic b00t TOML parsing for baseline compatibility.",
+  "Use l3dg3rr as the authoritative source for advanced validation and visualization semantics.",
+]
+
+[[b00t.usage]]
+description = "Validate docs/diagram semantics in local l3dg3rr checkout"
+command = "cd vendor/l3dg3rr && just docgen-check"
+
+[[b00t.usage]]
+description = "Run local authoritative tests for validation and visualization flows"
+command = "cd vendor/l3dg3rr && just test"
+
+[[b00t.usage]]
+description = "Start the ledgerr MCP surface for supervised local tooling"
+command = "cd vendor/l3dg3rr && just mcp-start"
+
+[[b00t.references]]
+name = "PromptExecution/l3dg3rr"
+url = "https://github.com/PromptExecution/l3dg3rr"
+
+[[b00t.references]]
+name = "l3dg3rr live documentation"
+url = "https://promptexecution.github.io/l3dg3rr/"

--- a/_b00t_/l3dg3rr.cli.toml
+++ b/_b00t_/l3dg3rr.cli.toml
@@ -8,10 +8,11 @@ Authoritative local source library for `.tomllmd` validation and visualization r
 generic `.tomllm` path in core parsing. Advanced diagram/DSL/structured-markdown
 semantics should be validated and visualized against `l3dg3rr`.
 """
-
-[b00t.cli]
+# 🤓 All operational fields MUST be at [b00t] level — UnifiedConfig only deserializes
+# [b00t] into BootDatum; sub-tables like [b00t.cli] are not part of the schema.
+# hook_detect (not "detect") and version (not "version_cmd") match the BootDatum field names.
 command = "just"
-detect = """
+hook_detect = """
 if [ -f vendor/l3dg3rr/Cargo.toml ]; then
   echo "vendor/l3dg3rr"
 elif command -v ledgerr-mcp-server >/dev/null 2>&1; then
@@ -20,7 +21,7 @@ else
   exit 1
 fi
 """
-version_cmd = """
+version = """
 if [ -f vendor/l3dg3rr/Cargo.toml ]; then
   awk -F'"' '/^version = / { print $2; exit }' vendor/l3dg3rr/Cargo.toml
 else

--- a/b00t-c0re-lib/src/bin/b00t-lsp.rs
+++ b/b00t-c0re-lib/src/bin/b00t-lsp.rs
@@ -6,7 +6,7 @@
 //! VS Code settings.json:
 //! ```json
 //! {
-//!   "languages": [{"id": "toml", "extensions": [".toml", ".tomllm"]}],
+//!   "languages": [{"id": "toml", "extensions": [".toml", ".tomllm", ".tomllmd"]}],
 //!   "server": {"command": "b00t-lsp", "args": ["--stdio"]}
 //! }
 //! ```

--- a/b00t-c0re-lib/src/lsp_proxy.rs
+++ b/b00t-c0re-lib/src/lsp_proxy.rs
@@ -3,7 +3,7 @@
 //! 🤓 Proxies existing LSP servers (just-mcp, datum-lsp, etc.)
 //! with unified interface for:
 //! - IaC serialization with variable pipelines
-//! - Feature-flagged .tomllm LSP (macro-generated from AST)
+//! - Feature-flagged .tomllm/.tomllmd LSP (macro-generated from AST)
 //! - Dynamic option population via jpath/tomllm-path
 //! - SLO/SLI budget enforcement (time/cost)
 //! - Sandbox lifetime management
@@ -25,7 +25,7 @@ pub struct LspProxyConfig {
     pub command: String,
     /// Command arguments
     pub args: Vec<String>,
-    /// Feature flags (e.g., "tomllm-ast", "slo-enforcement")
+    /// Feature flags (e.g., "tomllm-ast", "tomllmd-diagram-dsl", "slo-enforcement")
     pub features: Vec<String>,
     /// SLO/SLI budgets
     pub budgets: SloBudgets,
@@ -245,7 +245,7 @@ pub struct BudgetStatus {
 /// TOMLLM LSP configuration (feature-flagged)
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TomllmLspConfig {
-    /// Enable .tomllm LSP
+    /// Enable .tomllm / downgraded .tomllmd LSP
     pub enabled: bool,
     /// Generate LSP from TOMLLM AST
     pub generate_from_ast: bool,

--- a/b00t-cli/src/commands/agent.rs
+++ b/b00t-cli/src/commands/agent.rs
@@ -4,14 +4,14 @@
 //! agent coordination infrastructure.
 
 use anyhow::Result;
-use b00t_c0re_lib::AgentManager;
 use b00t_c0re_lib::agent_coordination::{
     AgentCoordinator, AgentMetadata, MessageFilter, RequestUrgency, TaskCompletionStatus,
     TaskPriority,
 };
 use b00t_c0re_lib::redis::{AgentStatus, RedisComms, RedisConfig};
+use b00t_c0re_lib::AgentManager;
 use clap::Parser;
-use std::collections::{HashMap, BTreeMap};
+use std::collections::{BTreeMap, HashMap};
 use std::path::PathBuf;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
@@ -736,7 +736,7 @@ async fn handle_invoke(
     prompt: &str,
     config_override: Option<&std::path::Path>,
 ) -> Result<()> {
-    use b00t_c0re_lib::agent_manager::{AgentManager, invoke_agent_executor};
+    use b00t_c0re_lib::agent_manager::{invoke_agent_executor, AgentManager};
 
     // Resolve config path: override → _b00t_/<agent>.agent.toml → cwd search
     let config_path = if let Some(p) = config_override {
@@ -1003,7 +1003,7 @@ fn load_role_hint(role_name: &str) -> String {
     .collect();
 
     for dir in &b00t_dirs {
-        for ext in &["role.tomllm", "role.toml"] {
+        for ext in &["role.tomllmd", "role.tomllm", "role.toml"] {
             let path = dir.join(format!("{}.{}", role_name, ext));
             if path.exists() {
                 if let Ok(content) = std::fs::read_to_string(&path) {
@@ -1122,9 +1122,11 @@ pub async fn setup_entangled_channels(
 ) -> Result<BTreeMap<String, String>> {
     let mut channels = BTreeMap::new();
     let role = &role_datum.name;
-    
+
     // Get channel_prefix from role datum, default to "agent:{role}:"
-    let prefix = role_datum.channel_prefix.clone()
+    let prefix = role_datum
+        .channel_prefix
+        .clone()
         .unwrap_or_else(|| format!("agent:{}:", role));
 
     for agent_name in &role_datum.entangled_agents {
@@ -1147,7 +1149,7 @@ fn get_delegation_channel(
     if let Some(channel) = entangled_channels.get(worker) {
         return channel.clone();
     }
-    
+
     // Fallback to default global channel
     format!("agent:captain:{}", worker)
 }
@@ -1176,29 +1178,33 @@ async fn resolve_role_channels(
                 if let Ok(content) = std::fs::read_to_string(&role_path) {
                     if let Ok(value) = toml::from_str::<toml::Value>(&content) {
                         let datum = value.get("b00t");
-                        let entangled = datum.and_then(|d| d.get("entangled_agents"))
+                        let entangled = datum
+                            .and_then(|d| d.get("entangled_agents"))
                             .and_then(|a| a.as_array())
                             .map(|arr| {
                                 arr.iter()
                                     .filter_map(|v| v.as_str().map(|s| s.to_string()))
                                     .collect::<Vec<_>>()
                             });
-                        
-                        let prefix = datum.and_then(|d| d.get("channel_prefix"))
+
+                        let prefix = datum
+                            .and_then(|d| d.get("channel_prefix"))
                             .and_then(|p| p.as_str())
                             .map(|s| s.to_string());
-                        
-                        let prefix = prefix.clone();  // Clone for later use
-                        
+
+                        let prefix = prefix.clone(); // Clone for later use
+
                         if let Some(agents) = entangled {
-                            let prefix = prefix.as_ref().map(|p| p.to_string())
+                            let prefix = prefix
+                                .as_ref()
+                                .map(|p| p.to_string())
                                 .unwrap_or_else(|| format!("agent:{}:", role));
                             for agent_name in agents {
                                 let channel = format!("{}{}", prefix, agent_name);
                                 channels.insert(agent_name.clone(), channel);
                             }
                         }
-                        
+
                         return Ok((prefix, channels));
                     }
                 }

--- a/b00t-cli/src/commands/skill.rs
+++ b/b00t-cli/src/commands/skill.rs
@@ -187,8 +187,8 @@ fn build_resolver(path: &str) -> SkillResolver {
 /// Load skill names declared by a role datum from _b00t_/*.role.toml(l)
 fn load_role_skill_list(role_name: &str, base_path: &str) -> Result<Vec<String>> {
     let b00t_dir = find_b00t_dir_for(base_path)?;
-    // Try <role>.role.tomllm, <role>.role.toml
-    for ext in &["role.tomllm", "role.toml"] {
+    // Try <role>.role.tomllmd, <role>.role.tomllm, <role>.role.toml
+    for ext in &["role.tomllmd", "role.tomllm", "role.toml"] {
         let path = b00t_dir.join(format!("{}.{}", role_name, ext));
         if path.exists() {
             let content = std::fs::read_to_string(&path)?;
@@ -223,7 +223,7 @@ fn load_role_skill_list(role_name: &str, base_path: &str) -> Result<Vec<String>>
 fn load_role_context_summary(role_name: &str) -> Result<String> {
     let b00t_dir = find_b00t_dir()?;
 
-    for ext in &["role.tomllm", "role.toml"] {
+    for ext in &["role.tomllmd", "role.tomllm", "role.toml"] {
         let path = b00t_dir.join(format!("{}.{}", role_name, ext));
         if path.exists() {
             let content = std::fs::read_to_string(&path)?;

--- a/b00t-cli/src/commands/up.rs
+++ b/b00t-cli/src/commands/up.rs
@@ -92,7 +92,11 @@ impl UpArgs {
             providers
         };
 
-        ResolvedUpTarget { tool, model, providers }
+        ResolvedUpTarget {
+            tool,
+            model,
+            providers,
+        }
     }
 
     pub fn execute(&self) -> Result<()> {
@@ -242,7 +246,9 @@ impl UpArgs {
 fn canonical_model_alias(model: &str) -> String {
     match model.trim().to_ascii_lowercase().as_str() {
         "gemma4" | "gemma-4" | "gemma-local" | "gemma-4-26b-a4b-local" => "ch0nky".to_string(),
-        "qwen3" | "qwen3-coder" | "qwen-local" | "qwen3-coder-local" | "sm0l" => "ch1nky".to_string(),
+        "qwen3" | "qwen3-coder" | "qwen-local" | "qwen3-coder-local" | "sm0l" => {
+            "ch1nky".to_string()
+        }
         other => other.to_string(),
     }
 }
@@ -448,7 +454,7 @@ fn up_repo(path: &str, dry_run: bool) -> Result<()> {
         println!("   mode      : dry-run (no changes written)");
     }
 
-    // 4. Find all .tomllm files in the datum dir
+    // 4. Find all .tomllmd / .tomllm files in the datum dir
     let entries = std::fs::read_dir(&datum_dir)
         .with_context(|| format!("Cannot read {}", datum_dir.display()))?;
 
@@ -456,13 +462,19 @@ fn up_repo(path: &str, dry_run: bool) -> Result<()> {
         .filter_map(|e| e.ok())
         .map(|e| e.path())
         .filter(|p| {
-            p.extension().map(|x| x == "tomllm").unwrap_or(false)
+            p.extension()
+                .map(|x| x == "tomllm" || x == "tomllmd")
+                .unwrap_or(false)
+                || p.to_string_lossy().ends_with(".tomllmd")
                 || p.to_string_lossy().ends_with(".tomllm")
         })
         .collect();
 
     if tomllm_files.is_empty() {
-        println!("   ⚠️  no .tomllm files found in {}", datum_dir.display());
+        println!(
+            "   ⚠️  no .tomllmd/.tomllm files found in {}",
+            datum_dir.display()
+        );
         return Ok(());
     }
 
@@ -625,14 +637,8 @@ mod tests {
 
     #[test]
     fn test_resolved_target_normalizes_qwen_alias_to_ch1nky() {
-        let args = UpArgs::try_parse_from([
-            "b00t-cli",
-            "--tool",
-            "pi",
-            "--model",
-            "qwen3-coder",
-        ])
-        .unwrap();
+        let args =
+            UpArgs::try_parse_from(["b00t-cli", "--tool", "pi", "--model", "qwen3-coder"]).unwrap();
         let target = args.resolved_target();
         assert_eq!(target.tool, "pi");
         assert_eq!(target.model.as_deref(), Some("ch1nky"));

--- a/b00t-cli/src/commands/whatismy.rs
+++ b/b00t-cli/src/commands/whatismy.rs
@@ -352,7 +352,11 @@ fn get_parent_pid() -> Option<u32> {
     {
         unsafe {
             let ppid = libc::getppid();
-            if ppid > 0 { Some(ppid as u32) } else { None }
+            if ppid > 0 {
+                Some(ppid as u32)
+            } else {
+                None
+            }
         }
     }
     #[cfg(not(unix))]
@@ -540,10 +544,16 @@ fn load_role_datum_skills(role: &str) -> Vec<String> {
     let candidates = [
         dirs::home_dir()
             .unwrap_or_default()
+            .join(format!(".dotfiles/_b00t_/{}.role.tomllmd", role)),
+        dirs::home_dir()
+            .unwrap_or_default()
             .join(format!(".dotfiles/_b00t_/{}.role.tomllm", role)),
         dirs::home_dir()
             .unwrap_or_default()
             .join(format!(".dotfiles/_b00t_/{}.role.toml", role)),
+        dirs::home_dir()
+            .unwrap_or_default()
+            .join(format!(".b00t/_b00t_/{}.role.tomllmd", role)),
         dirs::home_dir()
             .unwrap_or_default()
             .join(format!(".b00t/_b00t_/{}.role.tomllm", role)),

--- a/b00t-cli/src/datum_utils.rs
+++ b/b00t-cli/src/datum_utils.rs
@@ -1066,4 +1066,60 @@ output = "Building..."
         assert_eq!(usage[0].command, "just -l");
         assert_eq!(usage[1].output, Some("Building...".to_string()));
     }
+
+    // ── tomllmd precedence tests ──────────────────────────────────────────────
+
+    #[test]
+    fn test_tomllmd_wins_over_tomllm_and_toml_same_key() {
+        // .tomllmd > .tomllm > .toml for the same datum key
+        let temp_dir = TempDir::new().unwrap();
+        let b00t_path = temp_dir.path().to_str().unwrap();
+
+        // All three variants present for the same key "tool.cli"
+        create_test_datum_file(
+            temp_dir.path(),
+            "tool.cli.toml",
+            "[b00t]\nname = \"tool-toml\"\ntype = \"cli\"\nhint = \"toml variant\"\n",
+        );
+        create_test_datum_file(
+            temp_dir.path(),
+            "tool.cli.tomllm",
+            "[b00t]\nname = \"tool-tomllm\"\ntype = \"cli\"\nhint = \"tomllm variant\"\n",
+        );
+        create_test_datum_file(
+            temp_dir.path(),
+            "tool.cli.tomllmd",
+            "[b00t]\nname = \"tool-tomllmd\"\ntype = \"cli\"\nhint = \"tomllmd variant\"\n",
+        );
+
+        let datums = get_all_datums_with_paths(b00t_path, Some(0)).unwrap();
+        // The key strips the outer extension, so all three map to "tool.cli"
+        assert!(datums.contains_key("tool.cli"), "key tool.cli must exist");
+        let (datum, path) = datums.get("tool.cli").unwrap();
+        assert_eq!(datum.name, "tool-tomllmd", ".tomllmd must win");
+        assert!(path.ends_with(".tomllmd"), "path must end with .tomllmd");
+    }
+
+    #[test]
+    fn test_tomllm_wins_over_toml_same_key() {
+        let temp_dir = TempDir::new().unwrap();
+        let b00t_path = temp_dir.path().to_str().unwrap();
+
+        create_test_datum_file(
+            temp_dir.path(),
+            "tool.cli.toml",
+            "[b00t]\nname = \"tool-toml\"\ntype = \"cli\"\nhint = \"toml variant\"\n",
+        );
+        create_test_datum_file(
+            temp_dir.path(),
+            "tool.cli.tomllm",
+            "[b00t]\nname = \"tool-tomllm\"\ntype = \"cli\"\nhint = \"tomllm variant\"\n",
+        );
+
+        let datums = get_all_datums_with_paths(b00t_path, Some(0)).unwrap();
+        assert!(datums.contains_key("tool.cli"));
+        let (datum, path) = datums.get("tool.cli").unwrap();
+        assert_eq!(datum.name, "tool-tomllm", ".tomllm must win over .toml");
+        assert!(path.ends_with(".tomllm"));
+    }
 }

--- a/b00t-cli/src/datum_utils.rs
+++ b/b00t-cli/src/datum_utils.rs
@@ -160,7 +160,7 @@ fn scan_datums_recursive(
             scan_datums_recursive(&entry_path, datums, current_depth + 1, max_depth)?;
         } else if matches!(
             entry_path.extension().and_then(|s| s.to_str()),
-            Some("toml") | Some("tomllm") // 🤓 .tomllm = .toml + # comment annotations; TOML parses identically
+            Some("toml") | Some("tomllm") | Some("tomllmd") // 🤓 .tomllmd currently downgrades to the generic .tomllm parser path
         ) {
             if let Some(filename) = entry_path.file_name().and_then(|s| s.to_str()) {
                 // Skip non-datum files
@@ -174,16 +174,35 @@ fn scan_datums_recursive(
                 // Try to parse as unified config
                 if let Ok(content) = fs::read_to_string(&entry_path) {
                     if let Ok(config) = toml::from_str::<UnifiedConfig>(&content) {
-                        // Strip outer extension (.tomllm or .toml) for datum key
-                        // 🤓 .tomllm wins over .toml on key collision (richer tribal context)
-                        let ext = if filename.ends_with(".tomllm") {
+                        // Strip outer extension (.tomllmd / .tomllm / .toml) for datum key.
+                        // 🤓 precedence: .tomllmd > .tomllm > .toml.
+                        let ext = if filename.ends_with(".tomllmd") {
+                            ".tomllmd"
+                        } else if filename.ends_with(".tomllm") {
                             ".tomllm"
                         } else {
                             ".toml"
                         };
                         let datum_key = filename.trim_end_matches(ext).to_string();
                         let path_str = entry_path.to_string_lossy().to_string();
-                        if ext == ".tomllm" || !datums.contains_key(&datum_key) {
+                        let new_rank = match ext {
+                            ".tomllmd" => 3,
+                            ".tomllm" => 2,
+                            _ => 1,
+                        };
+                        let current_rank = datums
+                            .get(&datum_key)
+                            .map(|(_, existing_path)| {
+                                if existing_path.ends_with(".tomllmd") {
+                                    3
+                                } else if existing_path.ends_with(".tomllm") {
+                                    2
+                                } else {
+                                    1
+                                }
+                            })
+                            .unwrap_or(0);
+                        if new_rank >= current_rank {
                             datums.insert(datum_key, (config.b00t, path_str));
                         }
                     }

--- a/b00t-cli/src/hive.rs
+++ b/b00t-cli/src/hive.rs
@@ -1043,4 +1043,75 @@ working_directory = "/tmp/test"
         assert_eq!(spec.limit_nofile, Some(1024));
         assert_eq!(spec.working_directory.as_deref(), Some("/tmp/test"));
     }
+
+    // ── load_profile precedence tests ─────────────────────────────────────────
+
+    fn minimal_hive_content(name: &str, hint: &str) -> String {
+        format!(
+            "[b00t]\nname = \"{}\"\ntype = \"hive_profile\"\nhint = \"{}\"\n",
+            name, hint
+        )
+    }
+
+    fn write_profile_file(dir: &std::path::Path, name: &str, ext: &str, hint: &str) {
+        std::fs::write(
+            dir.join(format!("{}{}", name, ext)),
+            minimal_hive_content(name, hint),
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn test_load_profile_prefers_hive_tomllmd() {
+        let dir = tempfile::tempdir().unwrap();
+        let name = "myprofile";
+
+        // All five candidates present
+        write_profile_file(dir.path(), name, ".hive.toml", "hive-toml");
+        write_profile_file(dir.path(), name, ".hive.tomllm", "hive-tomllm");
+        write_profile_file(dir.path(), name, ".stack.tomllm", "stack-tomllm");
+        write_profile_file(dir.path(), name, ".stack.tomllmd", "stack-tomllmd");
+        write_profile_file(dir.path(), name, ".hive.tomllmd", "hive-tomllmd");
+
+        let profile = load_profile(name, dir.path()).unwrap();
+        assert_eq!(profile.hint, "hive-tomllmd", ".hive.tomllmd must win");
+    }
+
+    #[test]
+    fn test_load_profile_prefers_hive_tomllm_over_stack_and_toml() {
+        let dir = tempfile::tempdir().unwrap();
+        let name = "myprofile";
+
+        write_profile_file(dir.path(), name, ".hive.toml", "hive-toml");
+        write_profile_file(dir.path(), name, ".hive.tomllm", "hive-tomllm");
+        write_profile_file(dir.path(), name, ".stack.tomllm", "stack-tomllm");
+
+        let profile = load_profile(name, dir.path()).unwrap();
+        assert_eq!(profile.hint, "hive-tomllm");
+    }
+
+    #[test]
+    fn test_load_profile_prefers_stack_tomllmd_over_stack_tomllm_and_hive_toml() {
+        let dir = tempfile::tempdir().unwrap();
+        let name = "myprofile";
+
+        write_profile_file(dir.path(), name, ".hive.toml", "hive-toml");
+        write_profile_file(dir.path(), name, ".stack.tomllm", "stack-tomllm");
+        write_profile_file(dir.path(), name, ".stack.tomllmd", "stack-tomllmd");
+
+        let profile = load_profile(name, dir.path()).unwrap();
+        assert_eq!(profile.hint, "stack-tomllmd");
+    }
+
+    #[test]
+    fn test_load_profile_not_found_error_lists_tried_extensions() {
+        let dir = tempfile::tempdir().unwrap();
+        let err = load_profile("ghost", dir.path()).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains(".hive.tomllmd"), "error must mention .hive.tomllmd");
+        assert!(msg.contains(".hive.tomllm"), "error must mention .hive.tomllm");
+        assert!(msg.contains(".stack.tomllmd"), "error must mention .stack.tomllmd");
+        assert!(msg.contains(".stack.tomllm"), "error must mention .stack.tomllm");
+        assert!(msg.contains(".hive.toml"), "error must mention .hive.toml");
+    }
 }

--- a/b00t-cli/src/hive.rs
+++ b/b00t-cli/src/hive.rs
@@ -3,10 +3,11 @@
 //! Reads real system resources (RAM, GPU, systemd services) and manages
 //! hive profile transitions (download-mode ↔ inference-qwen3 ↔ inference-sm0l).
 //!
-//! Profile datums: _b00t_/*.hive.toml  OR  _b00t_/*.hive.tomllm  (.tomllm wins)
+//! Profile datums: _b00t_/*.hive.toml OR *.hive.tomllm OR *.hive.tomllmd
+//! precedence: .hive.tomllmd > .hive.tomllm > .stack.tomllmd > .stack.tomllm > .hive.toml
 //! State file: /tmp/b00t/hive-state.json (volatile; reset on reboot)
 
-use anyhow::{Context, Result, bail};
+use anyhow::{bail, Context, Result};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::fs;
@@ -355,22 +356,49 @@ impl HiveProfile {
 
 // ─── Profile Discovery ────────────────────────────────────────────────────────
 
-/// Find all .hive.toml / .hive.tomllm / .stack.tomllm datums; priority: .hive.tomllm > .stack.tomllm > .hive.toml
+/// Find all .hive.toml / .hive.tomllm / .hive.tomllmd / .stack.tomllm / .stack.tomllmd
+/// datums; priority: .hive.tomllmd > .hive.tomllm > .stack.tomllmd > .stack.tomllm > .hive.toml
 pub fn discover_profiles(datum_dir: &Path) -> Vec<(String, PathBuf)> {
     let mut profiles: HashMap<String, PathBuf> = HashMap::new();
     if let Ok(entries) = fs::read_dir(datum_dir) {
         for entry in entries.flatten() {
             let path = entry.path();
             if let Some(name) = path.file_name().and_then(|n| n.to_str()) {
-                if name.ends_with(".hive.tomllm") {
-                    let profile_name = name.trim_end_matches(".hive.tomllm").to_string();
-                    profiles.insert(profile_name, path); // .hive.tomllm wins
+                let profile = if name.ends_with(".hive.tomllmd") {
+                    Some((name.trim_end_matches(".hive.tomllmd").to_string(), 5))
+                } else if name.ends_with(".hive.tomllm") {
+                    Some((name.trim_end_matches(".hive.tomllm").to_string(), 4))
+                } else if name.ends_with(".stack.tomllmd") {
+                    Some((name.trim_end_matches(".stack.tomllmd").to_string(), 3))
                 } else if name.ends_with(".stack.tomllm") {
-                    let profile_name = name.trim_end_matches(".stack.tomllm").to_string();
-                    profiles.entry(profile_name).or_insert(path); // .stack.tomllm only if no .hive.tomllm
+                    Some((name.trim_end_matches(".stack.tomllm").to_string(), 2))
                 } else if name.ends_with(".hive.toml") {
-                    let profile_name = name.trim_end_matches(".hive.toml").to_string();
-                    profiles.entry(profile_name).or_insert(path); // .toml only if no .tomllm variants
+                    Some((name.trim_end_matches(".hive.toml").to_string(), 1))
+                } else {
+                    None
+                };
+
+                if let Some((profile_name, new_rank)) = profile {
+                    let current_rank = profiles
+                        .get(&profile_name)
+                        .and_then(|existing| existing.file_name().and_then(|n| n.to_str()))
+                        .map(|existing_name| {
+                            if existing_name.ends_with(".hive.tomllmd") {
+                                5
+                            } else if existing_name.ends_with(".hive.tomllm") {
+                                4
+                            } else if existing_name.ends_with(".stack.tomllmd") {
+                                3
+                            } else if existing_name.ends_with(".stack.tomllm") {
+                                2
+                            } else {
+                                1
+                            }
+                        })
+                        .unwrap_or(0);
+                    if new_rank >= current_rank {
+                        profiles.insert(profile_name, path);
+                    }
                 }
             }
         }
@@ -380,22 +408,29 @@ pub fn discover_profiles(datum_dir: &Path) -> Vec<(String, PathBuf)> {
     result
 }
 
-/// Load a named profile from datum dir — prefers .hive.tomllm > .stack.tomllm > .hive.toml
+/// Load a named profile from datum dir — prefers
+/// .hive.tomllmd > .hive.tomllm > .stack.tomllmd > .stack.tomllm > .hive.toml
 pub fn load_profile(name: &str, datum_dir: &Path) -> Result<HiveProfile> {
-    // 🤓 priority: .hive.tomllm (explicit hive) > .stack.tomllm (sysconfig profile with inline service spec) > .hive.toml (fallback)
+    // 🤓 .tomllmd currently downgrades to the generic .tomllm/TOML handling path.
+    let hive_tomllmd_path = datum_dir.join(format!("{}.hive.tomllmd", name));
     let hive_tomllm_path = datum_dir.join(format!("{}.hive.tomllm", name));
+    let stack_tomllmd_path = datum_dir.join(format!("{}.stack.tomllmd", name));
     let stack_tomllm_path = datum_dir.join(format!("{}.stack.tomllm", name));
     let hive_toml_path = datum_dir.join(format!("{}.hive.toml", name));
 
-    let path = if hive_tomllm_path.exists() {
+    let path = if hive_tomllmd_path.exists() {
+        hive_tomllmd_path
+    } else if hive_tomllm_path.exists() {
         hive_tomllm_path
+    } else if stack_tomllmd_path.exists() {
+        stack_tomllmd_path
     } else if stack_tomllm_path.exists() {
         stack_tomllm_path
     } else if hive_toml_path.exists() {
         hive_toml_path
     } else {
         bail!(
-            "profile '{}' not found (tried .hive.tomllm, .stack.tomllm, .hive.toml)",
+            "profile '{}' not found (tried .hive.tomllmd, .hive.tomllm, .stack.tomllmd, .stack.tomllm, .hive.toml)",
             name
         );
     };

--- a/b00t-cli/src/lib.rs
+++ b/b00t-cli/src/lib.rs
@@ -2202,4 +2202,54 @@ hint = "containers"
         assert!(config.b00t.uninstall.is_none());
         assert!(config.b00t.hook_uninstall.is_none());
     }
+
+    // ── get_config tomllmd precedence ─────────────────────────────────────────
+
+    #[test]
+    fn test_get_config_prefers_tomllmd_over_tomllm_and_toml() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().to_str().unwrap();
+
+        // Write all three extension variants for the same datum
+        std::fs::write(
+            dir.path().join("mytool.cli.toml"),
+            "[b00t]\nname = \"mytool-toml\"\ntype = \"cli\"\nhint = \"toml\"\n",
+        )
+        .unwrap();
+        std::fs::write(
+            dir.path().join("mytool.cli.tomllm"),
+            "[b00t]\nname = \"mytool-tomllm\"\ntype = \"cli\"\nhint = \"tomllm\"\n",
+        )
+        .unwrap();
+        std::fs::write(
+            dir.path().join("mytool.cli.tomllmd"),
+            "[b00t]\nname = \"mytool-tomllmd\"\ntype = \"cli\"\nhint = \"tomllmd\"\n",
+        )
+        .unwrap();
+
+        let (config, filename) = crate::get_config("mytool", path).unwrap();
+        assert_eq!(config.b00t.name, "mytool-tomllmd", ".tomllmd must be returned first");
+        assert!(filename.ends_with(".tomllmd"), "filename must end with .tomllmd, got {}", filename);
+    }
+
+    #[test]
+    fn test_get_config_falls_back_to_tomllm_when_no_tomllmd() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().to_str().unwrap();
+
+        std::fs::write(
+            dir.path().join("mytool.cli.toml"),
+            "[b00t]\nname = \"mytool-toml\"\ntype = \"cli\"\nhint = \"toml\"\n",
+        )
+        .unwrap();
+        std::fs::write(
+            dir.path().join("mytool.cli.tomllm"),
+            "[b00t]\nname = \"mytool-tomllm\"\ntype = \"cli\"\nhint = \"tomllm\"\n",
+        )
+        .unwrap();
+
+        let (config, filename) = crate::get_config("mytool", path).unwrap();
+        assert_eq!(config.b00t.name, "mytool-tomllm");
+        assert!(filename.ends_with(".tomllm"), "got {}", filename);
+    }
 }

--- a/b00t-cli/src/lib.rs
+++ b/b00t-cli/src/lib.rs
@@ -371,9 +371,27 @@ pub enum DatumType {
 impl DatumType {
     pub fn all_base_suffixes() -> Vec<&'static str> {
         vec![
-            ".database", ".hive", ".agent", ".config", ".docker", ".skill", ".stack",
-            ".repo", ".role", ".bash", ".vscode", ".k8s", ".apt", ".nix",
-            ".mcp", ".cli", ".api", ".job", ".ai_model", ".ai", ".justfile",
+            ".database",
+            ".hive",
+            ".agent",
+            ".config",
+            ".docker",
+            ".skill",
+            ".stack",
+            ".repo",
+            ".role",
+            ".bash",
+            ".vscode",
+            ".k8s",
+            ".apt",
+            ".nix",
+            ".mcp",
+            ".cli",
+            ".api",
+            ".job",
+            ".ai_model",
+            ".ai",
+            ".justfile",
         ]
     }
 
@@ -431,6 +449,7 @@ impl DatumType {
             let base = t.base_suffix();
             if filename.ends_with(base)
                 || filename.ends_with(&format!("{base}.toml"))
+                || filename.ends_with(&format!("{base}.tomllmd"))
                 || filename.ends_with(&format!("{base}.tomllm"))
             {
                 return *t;
@@ -631,14 +650,12 @@ fn create_mcp_datum_from_json(
             }),
         // Convert legacy command/args to new multi-method format
         mcp: Some(McpMethods {
-            stdio: Some(vec![
-                cli_method
-                    .as_object()
-                    .unwrap()
-                    .iter()
-                    .map(|(k, v)| (k.clone(), v.clone()))
-                    .collect(),
-            ]),
+            stdio: Some(vec![cli_method
+                .as_object()
+                .unwrap()
+                .iter()
+                .map(|(k, v)| (k.clone(), v.clone()))
+                .collect()]),
             httpstream: None,
         }),
         ..BootDatum::default()
@@ -820,8 +837,8 @@ pub fn create_unified_toml_config(datum: &BootDatum, path: &str) -> Result<()> {
         DatumType::Skill => ".skill.toml",
         DatumType::HiveProfile => ".hive.toml",
         DatumType::Justfile => ".justfile",
-        // 🤓 .tomllm = valid TOML + # comment annotations for tribal knowledge
-        // tomllm crate strips comments for data pipelines; tail-map enables fast executive scanning
+        // 🤓 .tomllmd currently degrades to .tomllm semantics in b00t core:
+        // valid TOML + richer comment/diagram/markdown affordances handled by external tooling.
         DatumType::Unknown => ".toml",
     };
 
@@ -919,20 +936,22 @@ pub fn get_config(
     let dir = std::path::Path::new(expanded.as_ref());
 
     for base in DatumType::all_base_suffixes() {
-        let toml_path = dir.join(format!("{}{}.toml", command, base));
-        if toml_path.exists() {
-            let filename = toml_path
-                .file_name()
-                .and_then(|s| s.to_str())
-                .unwrap_or("")
-                .to_string();
-            let content = std::fs::read_to_string(&toml_path)?;
-            let config: UnifiedConfig = toml::from_str(&content)?;
-            return Ok((config, filename));
+        for ext in [".tomllmd", ".tomllm", ".toml"] {
+            let path = dir.join(format!("{}{}{}", command, base, ext));
+            if path.exists() {
+                let filename = path
+                    .file_name()
+                    .and_then(|s| s.to_str())
+                    .unwrap_or("")
+                    .to_string();
+                let content = std::fs::read_to_string(&path)?;
+                let config: UnifiedConfig = toml::from_str(&content)?;
+                return Ok((config, filename));
+            }
         }
     }
-    // fallback: plain .tomllm then .toml (Unknown type — no typed suffix)
-    for ext in [".tomllm", ".toml"] {
+    // fallback: plain .tomllmd then .tomllm then .toml (Unknown type — no typed suffix)
+    for ext in [".tomllmd", ".tomllm", ".toml"] {
         let plain = dir.join(format!("{}{}", command, ext));
         if plain.exists() {
             let filename = format!("{}{}", command, ext);
@@ -2123,11 +2142,30 @@ pub mod test_env {
 mod tests {
     #[test]
     fn test_datum_type_from_filename_accepts_typed_toml_extensions() {
-        assert_eq!(crate::DatumType::from_filename("b00t.cli"), crate::DatumType::Cli);
-        assert_eq!(crate::DatumType::from_filename("b00t.cli.toml"), crate::DatumType::Cli);
-        assert_eq!(crate::DatumType::from_filename("executive.role.tomllm"), crate::DatumType::Role);
-        assert_eq!(crate::DatumType::from_filename("irontology.mcp.toml"), crate::DatumType::Mcp);
-        assert_eq!(crate::DatumType::from_filename("unknown.toml"), crate::DatumType::Unknown);
+        assert_eq!(
+            crate::DatumType::from_filename("b00t.cli"),
+            crate::DatumType::Cli
+        );
+        assert_eq!(
+            crate::DatumType::from_filename("b00t.cli.toml"),
+            crate::DatumType::Cli
+        );
+        assert_eq!(
+            crate::DatumType::from_filename("executive.role.tomllmd"),
+            crate::DatumType::Role
+        );
+        assert_eq!(
+            crate::DatumType::from_filename("executive.role.tomllm"),
+            crate::DatumType::Role
+        );
+        assert_eq!(
+            crate::DatumType::from_filename("irontology.mcp.toml"),
+            crate::DatumType::Mcp
+        );
+        assert_eq!(
+            crate::DatumType::from_filename("unknown.toml"),
+            crate::DatumType::Unknown
+        );
     }
 
     #[test]

--- a/b00t-cli/src/whoami.rs
+++ b/b00t-cli/src/whoami.rs
@@ -1,6 +1,6 @@
 use crate::entanglement::parse_entanglement_ref;
 use crate::skill_resolver::SkillResolver;
-use crate::{DatumType, UnifiedConfig, get_config, get_expanded_path};
+use crate::{get_config, get_expanded_path, DatumType, UnifiedConfig};
 use anyhow::{Context, Result};
 use b00t_c0re_lib::TemplateRenderer;
 use std::fs;
@@ -75,9 +75,10 @@ pub fn whoami(path: &str, role_override: Option<String>, with_skills: bool) -> R
         }
     }
 
-    // Append role summary from .role.tomllm / .role.toml / .agent.tomllm / .agent.toml datum
+    // Append role summary from .role.tomllmd / .role.tomllm / .role.toml
+    // and .agent.tomllmd / .agent.tomllm / .agent.toml datum.
     // 🤓 role datums are executable + introspectable: skills, capabilities, entanglements
-    // .tomllm extension: TOML + #comment tribal knowledge; toml parser handles it identically
+    // .tomllmd currently downgrades to the generic .tomllm/TOML path.
     if let Some(role) = resolve_role(role_override) {
         if let Some(role_details) = load_role_datum(&role, path) {
             print_role_summary(&role_details, path, with_skills);
@@ -127,7 +128,7 @@ fn resolve_role(role_override: Option<String>) -> Option<String> {
 }
 
 fn load_role_datum(role: &str, path: &str) -> Option<RoleDetails> {
-    // 🤓 prefer .role.tomllm / .role.toml over other typed datums with same name
+    // 🤓 prefer .role.tomllmd / .role.tomllm / .role.toml over other typed datums with same name
     let (config, _) = get_config_with_type_preference(role, &DatumType::Role, path).ok()?;
     let datum = config.b00t;
 
@@ -243,14 +244,14 @@ fn get_config_with_type_preference(
     get_config(name, path)
 }
 
-/// Try typed extensions for `name` — .tomllm first, then .toml.
+/// Try typed extensions for `name` — .tomllmd first, then .tomllm, then .toml.
 /// Returns the first match, or falls back to generic get_config.
 fn get_config_typed<'a>(
     name: &str,
     base: &str,
     expanded_path: &std::path::Path,
 ) -> Option<(UnifiedConfig, String)> {
-    for ext in [".tomllm", ".toml"] {
+    for ext in [".tomllmd", ".tomllm", ".toml"] {
         let filename = format!("{}{}{}", name, base, ext);
         let config_path = expanded_path.join(&filename);
         if config_path.exists() {

--- a/docs/NAMING_CONVENTIONS.md
+++ b/docs/NAMING_CONVENTIONS.md
@@ -56,13 +56,13 @@ alias = "sm0l"
 
 ---
 
-### 4. `.toml` vs `.tomllm` extension inconsistency
+### 4. `.toml` vs `.tomllm` / `.tomllmd` extension inconsistency
 
 **Current:** `orchestrator.role.toml` and `executive.role.tomllm` — same type, different extension.
 
-**Problem:** `.tomllm` is the enriched format with `# @tribal:` annotations and `b00t:map` blocks. `.toml` is plain. But they're not consistently applied — `orchestrator.role` didn't get upgraded.
+**Problem:** `.tomllm` is the enriched format with `# @tribal:` annotations and `b00t:map` blocks. `.tomllmd` is the theorized superset for diagram/DSL/structured-markdown affordances and currently downgrades to generic `.tomllm` handling in b00t core. `.toml` is plain. But they're not consistently applied — `orchestrator.role` didn't get upgraded.
 
-**Fix:** Migration rule — any datum with `# @tribal:` or `# b00t:map` annotations SHOULD use `.tomllm`. Plain config-only datums use `.toml`. Add to CLAUDE.md.
+**Fix:** Migration rule — any datum with `# @tribal:` or `# b00t:map` annotations SHOULD use `.tomllm`. Any datum that also needs diagram/DSL/structured-markdown affordances MAY use `.tomllmd`, but MUST remain compatible with downgrade to `.tomllm` until specialized parser support is enabled. Plain config-only datums use `.toml`.
 
 ---
 


### PR DESCRIPTION
## Summary
- add downgrade-compatible `.tomllmd` handling alongside `.tomllm` in b00t datum discovery and typed lookup paths
- register `l3dg3rr` as the authoritative local source for advanced `.tomllmd` validation and visualization semantics
- ignore local `.b00t/cmdb/` state and `vendor/l3dg3rr/` checkout paths

## Notes
- `.tomllmd` currently uses the generic `.tomllm` implementation path and degrades cleanly to `.tomllm`
- advanced diagram/DSL/structured-markdown semantics are delegated to `l3dg3rr`

## Testing
- rustfmt --edition 2021 on edited Rust files
- attempted cargo check --offline for `b00t-cli` and `b00t-c0re-lib` (long-running dependency build; no edit-specific compile errors surfaced before stop)