### PR TITLE
feat(l3dg3rr): add visualization utility workspace member and docs

### DIFF
--- a/.github/workflows/l3dg3rr-docs.yml
+++ b/.github/workflows/l3dg3rr-docs.yml
@@ -1,0 +1,74 @@
+name: l3dg3rr Utility Docs
+
+on:
+  pull_request:
+    paths:
+      - "b00t-l3dg3rr-viz/**"
+      - "docs/l3dg3rr-visualization-utility.md"
+      - ".github/workflows/l3dg3rr-docs.yml"
+      - "Cargo.toml"
+      - "Cargo.lock"
+  push:
+    branches: [main]
+    paths:
+      - "b00t-l3dg3rr-viz/**"
+      - "docs/l3dg3rr-visualization-utility.md"
+      - ".github/workflows/l3dg3rr-docs.yml"
+      - "Cargo.toml"
+      - "Cargo.lock"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: l3dg3rr-docs-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: always
+  RUSTDOCFLAGS: "-D warnings"
+
+jobs:
+  docs:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          submodules: false
+
+      - name: Set up Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Build utility docs
+        shell: bash
+        run: |
+          set -euo pipefail
+          cargo test -p b00t-l3dg3rr-viz
+          cargo doc -p b00t-l3dg3rr-viz --no-deps
+          mkdir -p public/l3dg3rr
+          cp -R target/doc/* public/l3dg3rr/
+          cp docs/l3dg3rr-visualization-utility.md public/l3dg3rr/README.md
+
+      - name: Upload docs artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: l3dg3rr-utility-docs
+          path: public
+
+      - name: Configure GitHub Pages
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        uses: actions/configure-pages@v5
+
+      - name: Upload GitHub Pages artifact
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: public
+
+      - name: Deploy GitHub Pages
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/l3dg3rr-docs.yml
+++ b/.github/workflows/l3dg3rr-docs.yml
@@ -52,6 +52,20 @@ jobs:
           mkdir -p public/l3dg3rr
           cp -R target/doc/* public/l3dg3rr/
           cp docs/l3dg3rr-visualization-utility.md public/l3dg3rr/README.md
+          cat > public/index.html <<'EOF'
+          <!DOCTYPE html>
+          <html lang="en">
+          <head>
+            <meta charset="utf-8" />
+            <meta http-equiv="refresh" content="0; url=./l3dg3rr/" />
+            <meta name="viewport" content="width=device-width, initial-scale=1" />
+            <title>l3dg3rr Utility Docs</title>
+          </head>
+          <body>
+            <p>Redirecting to <a href="./l3dg3rr/">l3dg3rr Utility Docs</a>…</p>
+          </body>
+          </html>
+          EOF
 
       - name: Upload docs artifact
         uses: actions/upload-artifact@v4

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -936,6 +936,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "b00t-l3dg3rr-viz"
+version = "0.7.49"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "b00t-mcp"
 version = "0.7.49"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ members = [
     "b00t-py",
     "b00t-ipc",
     "b00t-azure-cp",
+    "b00t-l3dg3rr-viz",
 ]
 resolver = "2"
 
@@ -27,6 +28,7 @@ b00t-cli = { path = "b00t-cli" }
 b00t-c0re-lib = { path = "b00t-c0re-lib" }
 b00t-grok = { path = "b00t-grok", default-features = false }
 b00t-chat = { path = "b00t-lib-chat" }
+b00t-l3dg3rr-viz = { path = "b00t-l3dg3rr-viz" }
 # tomllm = { path = "vendor/tomllm" }
 
 # Rhai scripting engine — used for datum hooks (detect, install guards, etc.)

--- a/TODO-foundry.md
+++ b/TODO-foundry.md
@@ -1,0 +1,110 @@
+# TODO: Azure AI Foundry gaps in `~/.b00t`
+
+## Summary
+
+`foundry-samples/` contains runnable Azure AI Foundry and Agent Service examples. In `~/.b00t`, Azure/Foundry support already exists at the datum/configuration level, but several implementation and workflow gaps remain.
+
+## Existing overlap
+
+- Azure AI Foundry CLI datum exists: `_b00t_/azure-ai-foundry.cli.toml`
+- Azure AI Foundry MCP datum exists: `_b00t_/azure-ai-foundry.mcp.toml`
+- Foundry Local AI runtime datum exists: `_b00t_/foundry-local.ai.toml`
+- General Azure infra/docs already exist in `azure.🤖.云☁️/`, `docs/README-azure.md`, and `B00T-CAPABILITY-MAP.md`
+
+## Gaps
+
+### 1. No concrete runnable Azure Foundry agent examples in b00t
+
+`~/.b00t` has Foundry datums and install instructions, but not equivalent runnable examples like:
+
+- hosted MCP agents
+- hosted workflow agents
+- text-search/RAG agents
+- LangGraph-hosted agents
+
+Reference examples in `foundry-samples/`:
+
+- `foundry-samples/samples/microsoft/python/getting-started-agents/agent-framework/agent_with_hosted_mcp/main.py`
+- `foundry-samples/samples/microsoft/python/getting-started-agents/agent-framework/agents_in_workflow/main.py`
+- `foundry-samples/samples/microsoft/hosted-agents/python/agent_with_hosted_mcp/main.py`
+
+### 2. No `agent.yaml` / `azd ai agent` deployment flow
+
+`foundry-samples/` includes deployable agent manifests and Azure Developer CLI deployment guidance. No equivalent first-class flow was found in `~/.b00t`.
+
+Reference examples:
+
+- `foundry-samples/samples/microsoft/python/getting-started-agents/agent-framework/agent_with_hosted_mcp/agent.yaml`
+- `foundry-samples/samples/microsoft/hosted-agents/python/agent_with_hosted_mcp/agent.yaml`
+
+### 3. No Azure AI AgentServer SDK usage in b00t code
+
+No b00t implementation was found using patterns such as:
+
+- `from azure.ai.agentserver.agentframework import from_agent_framework`
+- `HostedMCPTool(...)`
+- `from azure.ai.agentserver.langgraph import from_langgraph`
+
+This means b00t currently describes Foundry integration more than it implements it.
+
+### 4. No Azure AI Agent Service IaC templates comparable to `foundry-samples`
+
+`foundry-samples/` includes ARM and Terraform templates for:
+
+- basic agent setup
+- standard agent setup
+- BYO virtual network / private networking
+- customer-managed keys
+- Azure AI Search / Cosmos DB / Storage-backed agent state
+
+No equivalent dedicated Foundry Agent Service IaC set was identified in `~/.b00t`.
+
+Reference directories:
+
+- `foundry-samples/samples/microsoft/infrastructure-setup/`
+- `foundry-samples/samples/microsoft/infrastructure-setup-terraform/`
+
+### 5. Missing sample integrations for common Foundry tools/services
+
+`foundry-samples/` includes examples for:
+
+- Azure AI Search
+- Bing grounding
+- Azure Functions
+- Logic Apps
+- OpenAPI tools
+- enterprise/file search
+- third-party tool integrations
+
+Equivalent b00t sample implementations were not identified.
+
+### 6. Docs/config exceed operational recipes
+
+Current b00t Foundry support is mainly:
+
+- install/update datums
+- MCP/CLI metadata
+- learning content
+- high-level orchestration positioning
+
+Missing are:
+
+- `just` recipes to bootstrap and run Foundry examples
+- validated end-to-end tutorial paths
+- tested sample projects inside the repo
+- operational runbooks for local dev -> Azure deploy
+
+## Suggested next actions
+
+1. Port one minimal Python Hosted MCP sample into a b00t-owned example.
+2. Add one `agent.yaml` + `azd ai agent` deployment path.
+3. Add one Foundry IaC template path for basic agent deployment.
+4. Add `just` recipes for local run, deploy, and smoke test.
+5. Add one documented Azure AI Search or OpenAPI integration example.
+
+## High-value candidate ports
+
+- Hosted MCP docs agent
+- agents-in-workflow sample
+- basic infrastructure setup
+- Terraform private-network setup

--- a/b00t-l3dg3rr-viz/Cargo.toml
+++ b/b00t-l3dg3rr-viz/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "b00t-l3dg3rr-viz"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Generic l3dg3rr invariant graph contract with Mermaid and SVG visualization utilities"
+readme = "README.md"
+keywords = ["b00t", "l3dg3rr", "visualization", "invariants", "graph"]
+categories = ["visualization", "data-structures"]
+
+[dependencies]
+serde = { workspace = true, features = ["derive"] }
+
+[lints]
+workspace = true

--- a/b00t-l3dg3rr-viz/README.md
+++ b/b00t-l3dg3rr-viz/README.md
@@ -1,0 +1,18 @@
+# b00t-l3dg3rr-viz
+
+Generic visualization utilities for systems that implement the l3dg3rr invariant graph contract.
+
+The crate deliberately avoids l3dg3rr domain dependencies. A host system provides typed invariant nodes and edges, validates the resulting graph, then gets deterministic Mermaid and SVG renderers.
+
+```rust
+use b00t_l3dg3rr_viz::{InvariantEdge, InvariantGraph, InvariantNode, VisualizationRole};
+
+let graph = InvariantGraph::new("b00t")
+    .with_node(InvariantNode::new("datum", "Datum", VisualizationRole::Ingest))
+    .with_node(InvariantNode::new("verify", "Verify", VisualizationRole::Validate))
+    .with_edge(InvariantEdge::new("datum", "verify"));
+
+graph.validate().expect("graph is internally consistent");
+let mermaid = graph.to_mermaid();
+let svg = graph.to_svg();
+```

--- a/b00t-l3dg3rr-viz/src/lib.rs
+++ b/b00t-l3dg3rr-viz/src/lib.rs
@@ -169,7 +169,12 @@ impl InvariantGraph {
             if !ids.contains(edge.to.as_str()) {
                 return Err(GraphValidationError::MissingEdgeEndpoint(edge.to.clone()));
             }
-            if edge.from == edge.to && edge.label.is_none() {
+            if edge.from == edge.to
+                && edge
+                    .label
+                    .as_deref()
+                    .is_none_or(|label| label.trim().is_empty())
+            {
                 return Err(GraphValidationError::UnlabelledSelfEdge(edge.from.clone()));
             }
         }

--- a/b00t-l3dg3rr-viz/src/lib.rs
+++ b/b00t-l3dg3rr-viz/src/lib.rs
@@ -238,7 +238,7 @@ impl InvariantGraph {
         out.push_str(r##"<defs><marker id="arrow" viewBox="0 0 10 10" refX="10" refY="5" markerWidth="7" markerHeight="7" orient="auto"><path d="M 0 0 L 10 5 L 0 10 Z" fill="#455a64"/></marker></defs>"##);
 
         // Build a single O(N) lookup table so edge rendering is O(E) not O(E·N).
-        let node_idx: HashMap<&str, usize> = self
+        let node_index_map: HashMap<&str, usize> = self
             .nodes
             .iter()
             .enumerate()
@@ -246,8 +246,10 @@ impl InvariantGraph {
             .collect();
 
         for edge in &self.edges {
-            let from = node_idx.get(edge.from.as_str()).copied().unwrap_or(0);
-            let to = node_idx.get(edge.to.as_str()).copied().unwrap_or(0);
+            // Fallback to index 0 is unreachable for validated graphs (validate()
+            // guarantees all edge endpoints reference known nodes).
+            let from = node_index_map.get(edge.from.as_str()).copied().unwrap_or(0);
+            let to = node_index_map.get(edge.to.as_str()).copied().unwrap_or(0);
             let x1 = node_x(from) + 140;
             let x2 = node_x(to);
             let y = 110;

--- a/b00t-l3dg3rr-viz/src/lib.rs
+++ b/b00t-l3dg3rr-viz/src/lib.rs
@@ -7,7 +7,7 @@
 //! render Mermaid or deterministic SVG documentation.
 
 use serde::{Deserialize, Serialize};
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 
 /// Stable visual category shared by l3dg3rr docs and b00t capability graphs.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -237,9 +237,17 @@ impl InvariantGraph {
         out.push_str(r##"<rect width="100%" height="100%" fill="#f8fafc"/>"##);
         out.push_str(r##"<defs><marker id="arrow" viewBox="0 0 10 10" refX="10" refY="5" markerWidth="7" markerHeight="7" orient="auto"><path d="M 0 0 L 10 5 L 0 10 Z" fill="#455a64"/></marker></defs>"##);
 
+        // Build a single O(N) lookup table so edge rendering is O(E) not O(E·N).
+        let node_idx: HashMap<&str, usize> = self
+            .nodes
+            .iter()
+            .enumerate()
+            .map(|(i, n)| (n.id.as_str(), i))
+            .collect();
+
         for edge in &self.edges {
-            let from = self.node_index(&edge.from).unwrap_or(0);
-            let to = self.node_index(&edge.to).unwrap_or(0);
+            let from = node_idx.get(edge.from.as_str()).copied().unwrap_or(0);
+            let to = node_idx.get(edge.to.as_str()).copied().unwrap_or(0);
             let x1 = node_x(from) + 140;
             let x2 = node_x(to);
             let y = 110;
@@ -278,9 +286,6 @@ impl InvariantGraph {
         out
     }
 
-    fn node_index(&self, id: &str) -> Option<usize> {
-        self.nodes.iter().position(|node| node.id == id)
-    }
 }
 
 /// A host system can implement this trait to provide visualization without

--- a/b00t-l3dg3rr-viz/src/lib.rs
+++ b/b00t-l3dg3rr-viz/src/lib.rs
@@ -334,9 +334,10 @@ fn mermaid_id(id: &str) -> String {
         if byte.is_ascii_alphanumeric() || byte == b'_' {
             value.push(byte as char);
         } else {
+            // nibble is always 0-15, so from_digit with radix 16 is infallible
             value.push('_');
-            value.push(char::from_digit((byte >> 4) as u32, 16).unwrap_or('0'));
-            value.push(char::from_digit((byte & 0xf) as u32, 16).unwrap_or('0'));
+            value.push(char::from_digit((byte >> 4) as u32, 16).expect("nibble 0-15"));
+            value.push(char::from_digit((byte & 0xf) as u32, 16).expect("nibble 0-15"));
         }
     }
     value

--- a/b00t-l3dg3rr-viz/src/lib.rs
+++ b/b00t-l3dg3rr-viz/src/lib.rs
@@ -323,13 +323,20 @@ fn node_x(index: usize) -> i32 {
     40 + i32::try_from(index).unwrap_or(0) * 180
 }
 
+/// Produce a collision-free Mermaid node identifier.
+///
+/// Alphanumeric ASCII and `_` are kept verbatim.  Every other byte is
+/// hex-encoded as `_HH` so that `a-b` → `n_a_2db` and `a_b` → `n_a_b`
+/// — distinct, even though both contain a non-alphanumeric separator.
 fn mermaid_id(id: &str) -> String {
     let mut value = String::from("n_");
-    for ch in id.chars() {
-        if ch.is_ascii_alphanumeric() || ch == '_' {
-            value.push(ch);
+    for byte in id.bytes() {
+        if byte.is_ascii_alphanumeric() || byte == b'_' {
+            value.push(byte as char);
         } else {
             value.push('_');
+            value.push(char::from_digit((byte >> 4) as u32, 16).unwrap_or('0'));
+            value.push(char::from_digit((byte & 0xf) as u32, 16).unwrap_or('0'));
         }
     }
     value
@@ -399,5 +406,16 @@ mod tests {
             .with_edge(InvariantEdge::new("a", "a").with_label("retry budget"));
 
         assert_eq!(graph.validate(), Ok(()));
+    }
+
+    #[test]
+    fn mermaid_ids_are_collision_free() {
+        // "a-b" and "a_b" would both map to "n_a_b" with the old naive encoder;
+        // with hex encoding "a-b" becomes "n_a_2db" (dash = 0x2d).
+        assert_ne!(mermaid_id("a-b"), mermaid_id("a_b"));
+        assert_eq!(mermaid_id("a-b"), "n_a_2db");
+        assert_eq!(mermaid_id("a_b"), "n_a_b");
+        // Pure alphanumeric IDs are unchanged.
+        assert_eq!(mermaid_id("datum"), "n_datum");
     }
 }

--- a/b00t-l3dg3rr-viz/src/lib.rs
+++ b/b00t-l3dg3rr-viz/src/lib.rs
@@ -1,0 +1,391 @@
+//! Generic l3dg3rr invariant graph utilities for b00t and peer systems.
+//!
+//! The upstream `PromptExecution/l3dg3rr` skills encode operational workflows
+//! around typed invariants, visual audit graphs, and supervised agent surfaces.
+//! This crate repackages the reusable part as a small host-neutral contract:
+//! implement or build an [`InvariantGraph`], validate its type invariants, then
+//! render Mermaid or deterministic SVG documentation.
+
+use serde::{Deserialize, Serialize};
+use std::collections::HashSet;
+
+/// Stable visual category shared by l3dg3rr docs and b00t capability graphs.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum VisualizationRole {
+    Ingest,
+    Validate,
+    Classify,
+    Review,
+    Reconcile,
+    Commit,
+    Decision,
+    Step,
+}
+
+impl VisualizationRole {
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Ingest => "ingest",
+            Self::Validate => "validate",
+            Self::Classify => "classify",
+            Self::Review => "review",
+            Self::Reconcile => "reconcile",
+            Self::Commit => "commit",
+            Self::Decision => "decision",
+            Self::Step => "step",
+        }
+    }
+
+    #[must_use]
+    pub const fn color(self) -> &'static str {
+        match self {
+            Self::Ingest => "#4fc3f7",
+            Self::Validate => "#66bb6a",
+            Self::Classify => "#ffa726",
+            Self::Review => "#8d6e63",
+            Self::Reconcile => "#26c6da",
+            Self::Commit => "#42a5f5",
+            Self::Decision => "#ef5350",
+            Self::Step => "#78909c",
+        }
+    }
+}
+
+impl std::fmt::Display for VisualizationRole {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// A typed invariant vertex. IDs are stable machine identifiers.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct InvariantNode {
+    pub id: String,
+    pub label: String,
+    pub role: VisualizationRole,
+    pub invariant: Option<String>,
+}
+
+impl InvariantNode {
+    #[must_use]
+    pub fn new(id: impl Into<String>, label: impl Into<String>, role: VisualizationRole) -> Self {
+        Self {
+            id: id.into(),
+            label: label.into(),
+            role,
+            invariant: None,
+        }
+    }
+
+    #[must_use]
+    pub fn with_invariant(mut self, invariant: impl Into<String>) -> Self {
+        self.invariant = Some(invariant.into());
+        self
+    }
+}
+
+/// A typed invariant edge. Endpoints MUST reference existing node IDs.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct InvariantEdge {
+    pub from: String,
+    pub to: String,
+    pub label: Option<String>,
+}
+
+impl InvariantEdge {
+    #[must_use]
+    pub fn new(from: impl Into<String>, to: impl Into<String>) -> Self {
+        Self {
+            from: from.into(),
+            to: to.into(),
+            label: None,
+        }
+    }
+
+    #[must_use]
+    pub fn with_label(mut self, label: impl Into<String>) -> Self {
+        self.label = Some(label.into());
+        self
+    }
+}
+
+/// Host-neutral graph for l3dg3rr-style invariant visualization.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct InvariantGraph {
+    pub name: String,
+    pub nodes: Vec<InvariantNode>,
+    pub edges: Vec<InvariantEdge>,
+}
+
+impl InvariantGraph {
+    #[must_use]
+    pub fn new(name: impl Into<String>) -> Self {
+        Self {
+            name: name.into(),
+            nodes: Vec::new(),
+            edges: Vec::new(),
+        }
+    }
+
+    #[must_use]
+    pub fn with_node(mut self, node: InvariantNode) -> Self {
+        self.nodes.push(node);
+        self
+    }
+
+    #[must_use]
+    pub fn with_edge(mut self, edge: InvariantEdge) -> Self {
+        self.edges.push(edge);
+        self
+    }
+
+    /// Verify graph invariants before rendering.
+    ///
+    /// Enforced invariants:
+    /// - graph name is non-empty
+    /// - node IDs are non-empty and unique
+    /// - every edge endpoint references a known node
+    /// - self-edges are rejected unless labelled, so docs expose the reason
+    pub fn validate(&self) -> Result<(), GraphValidationError> {
+        if self.name.trim().is_empty() {
+            return Err(GraphValidationError::EmptyGraphName);
+        }
+
+        let mut ids = HashSet::new();
+        for node in &self.nodes {
+            if node.id.trim().is_empty() {
+                return Err(GraphValidationError::EmptyNodeId);
+            }
+            if !ids.insert(node.id.as_str()) {
+                return Err(GraphValidationError::DuplicateNodeId(node.id.clone()));
+            }
+        }
+
+        for edge in &self.edges {
+            if !ids.contains(edge.from.as_str()) {
+                return Err(GraphValidationError::MissingEdgeEndpoint(edge.from.clone()));
+            }
+            if !ids.contains(edge.to.as_str()) {
+                return Err(GraphValidationError::MissingEdgeEndpoint(edge.to.clone()));
+            }
+            if edge.from == edge.to && edge.label.is_none() {
+                return Err(GraphValidationError::UnlabelledSelfEdge(edge.from.clone()));
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Render a Mermaid flowchart. Call [`Self::validate`] first for strict CI.
+    #[must_use]
+    pub fn to_mermaid(&self) -> String {
+        let mut out = String::from("flowchart LR\n");
+        for node in &self.nodes {
+            out.push_str(&format!(
+                "  {}[\"{}\"]:::{}\n",
+                mermaid_id(&node.id),
+                escape_mermaid(&node.label),
+                node.role
+            ));
+        }
+        for edge in &self.edges {
+            let label = edge
+                .label
+                .as_ref()
+                .map_or(String::new(), |label| format!("|{}|", escape_mermaid(label)));
+            out.push_str(&format!(
+                "  {} -->{} {}\n",
+                mermaid_id(&edge.from),
+                label,
+                mermaid_id(&edge.to)
+            ));
+        }
+        for role in [
+            VisualizationRole::Ingest,
+            VisualizationRole::Validate,
+            VisualizationRole::Classify,
+            VisualizationRole::Review,
+            VisualizationRole::Reconcile,
+            VisualizationRole::Commit,
+            VisualizationRole::Decision,
+            VisualizationRole::Step,
+        ] {
+            out.push_str(&format!(
+                "  classDef {} fill:{},stroke:#263238,color:#111;\n",
+                role,
+                role.color()
+            ));
+        }
+        out
+    }
+
+    /// Render a standalone SVG with deterministic horizontal layout.
+    #[must_use]
+    pub fn to_svg(&self) -> String {
+        let width = (self.nodes.len().max(1) as i32 * 180 + 80).max(640);
+        let height = 220;
+        let mut out = format!(
+            r##"<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 {width} {height}" role="img" aria-label="{} invariant graph">"##,
+            escape_xml(&self.name)
+        );
+        out.push_str(r##"<rect width="100%" height="100%" fill="#f8fafc"/>"##);
+        out.push_str(r##"<defs><marker id="arrow" viewBox="0 0 10 10" refX="10" refY="5" markerWidth="7" markerHeight="7" orient="auto"><path d="M 0 0 L 10 5 L 0 10 Z" fill="#455a64"/></marker></defs>"##);
+
+        for edge in &self.edges {
+            let from = self.node_index(&edge.from).unwrap_or(0);
+            let to = self.node_index(&edge.to).unwrap_or(0);
+            let x1 = node_x(from) + 140;
+            let x2 = node_x(to);
+            let y = 110;
+            out.push_str(&format!(
+                r##"<path d="M {x1} {y} L {x2} {y}" stroke="#455a64" stroke-width="2" fill="none" marker-end="url(#arrow)"/>"##
+            ));
+            if let Some(label) = &edge.label {
+                let mid = (x1 + x2) / 2;
+                out.push_str(&format!(
+                    r##"<text x="{mid}" y="96" text-anchor="middle" font-family="monospace" font-size="11" fill="#37474f">{}</text>"##,
+                    escape_xml(label)
+                ));
+            }
+        }
+
+        for (index, node) in self.nodes.iter().enumerate() {
+            let x = node_x(index);
+            let y = 70;
+            out.push_str(&format!(
+                r##"<g><rect x="{x}" y="{y}" width="140" height="80" rx="10" fill="{}" stroke="#263238" stroke-width="1.5"/>"##,
+                node.role.color()
+            ));
+            out.push_str(&format!(
+                r##"<text x="{}" y="105" text-anchor="middle" font-family="monospace" font-size="14" font-weight="700" fill="#111">{}</text>"##,
+                x + 70,
+                escape_xml(&node.label)
+            ));
+            out.push_str(&format!(
+                r##"<text x="{}" y="126" text-anchor="middle" font-family="monospace" font-size="11" fill="#263238">{}</text></g>"##,
+                x + 70,
+                node.role
+            ));
+        }
+
+        out.push_str("</svg>");
+        out
+    }
+
+    fn node_index(&self, id: &str) -> Option<usize> {
+        self.nodes.iter().position(|node| node.id == id)
+    }
+}
+
+/// A host system can implement this trait to provide visualization without
+/// depending on l3dg3rr domain crates.
+pub trait L3dg3rrVisualizable {
+    fn invariant_graph(&self) -> InvariantGraph;
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum GraphValidationError {
+    EmptyGraphName,
+    EmptyNodeId,
+    DuplicateNodeId(String),
+    MissingEdgeEndpoint(String),
+    UnlabelledSelfEdge(String),
+}
+
+impl std::fmt::Display for GraphValidationError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::EmptyGraphName => f.write_str("graph name is empty"),
+            Self::EmptyNodeId => f.write_str("node id is empty"),
+            Self::DuplicateNodeId(id) => write!(f, "duplicate node id: {id}"),
+            Self::MissingEdgeEndpoint(id) => write!(f, "edge endpoint does not exist: {id}"),
+            Self::UnlabelledSelfEdge(id) => write!(f, "unlabelled self-edge: {id}"),
+        }
+    }
+}
+
+impl std::error::Error for GraphValidationError {}
+
+fn node_x(index: usize) -> i32 {
+    40 + i32::try_from(index).unwrap_or(0) * 180
+}
+
+fn mermaid_id(id: &str) -> String {
+    let mut value = String::from("n_");
+    for ch in id.chars() {
+        if ch.is_ascii_alphanumeric() || ch == '_' {
+            value.push(ch);
+        } else {
+            value.push('_');
+        }
+    }
+    value
+}
+
+fn escape_mermaid(value: &str) -> String {
+    value.replace('\\', "\\\\").replace('"', "\\\"")
+}
+
+fn escape_xml(value: &str) -> String {
+    value
+        .replace('&', "&amp;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
+        .replace('"', "&quot;")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn valid_graph_renders_mermaid_and_svg() {
+        let graph = InvariantGraph::new("b00t")
+            .with_node(InvariantNode::new("datum", "Datum", VisualizationRole::Ingest))
+            .with_node(InvariantNode::new(
+                "verify",
+                "Verify",
+                VisualizationRole::Validate,
+            ))
+            .with_edge(InvariantEdge::new("datum", "verify").with_label("checked"));
+
+        assert_eq!(graph.validate(), Ok(()));
+        assert!(graph.to_mermaid().contains("flowchart LR"));
+        assert!(graph.to_mermaid().contains("n_datum -->|checked| n_verify"));
+        assert!(graph.to_svg().contains("b00t invariant graph"));
+    }
+
+    #[test]
+    fn duplicate_nodes_are_rejected() {
+        let graph = InvariantGraph::new("bad")
+            .with_node(InvariantNode::new("same", "A", VisualizationRole::Step))
+            .with_node(InvariantNode::new("same", "B", VisualizationRole::Step));
+
+        assert_eq!(
+            graph.validate(),
+            Err(GraphValidationError::DuplicateNodeId("same".into()))
+        );
+    }
+
+    #[test]
+    fn missing_edge_endpoint_is_rejected() {
+        let graph = InvariantGraph::new("bad")
+            .with_node(InvariantNode::new("a", "A", VisualizationRole::Step))
+            .with_edge(InvariantEdge::new("a", "missing"));
+
+        assert_eq!(
+            graph.validate(),
+            Err(GraphValidationError::MissingEdgeEndpoint("missing".into()))
+        );
+    }
+
+    #[test]
+    fn labelled_self_edge_is_allowed_for_explicit_invariants() {
+        let graph = InvariantGraph::new("loop")
+            .with_node(InvariantNode::new("a", "A", VisualizationRole::Decision))
+            .with_edge(InvariantEdge::new("a", "a").with_label("retry budget"));
+
+        assert_eq!(graph.validate(), Ok(()));
+    }
+}

--- a/b00t-l3dg3rr-viz/tests/visualization_contract.rs
+++ b/b00t-l3dg3rr-viz/tests/visualization_contract.rs
@@ -1,0 +1,37 @@
+use b00t_l3dg3rr_viz::{
+    InvariantEdge, InvariantGraph, InvariantNode, L3dg3rrVisualizable, VisualizationRole,
+};
+
+struct B00tDatumFlow;
+
+impl L3dg3rrVisualizable for B00tDatumFlow {
+    fn invariant_graph(&self) -> InvariantGraph {
+        InvariantGraph::new("b00t datum flow")
+            .with_node(InvariantNode::new("load", "Load", VisualizationRole::Ingest))
+            .with_node(InvariantNode::new(
+                "classify",
+                "Classify",
+                VisualizationRole::Classify,
+            ))
+            .with_node(InvariantNode::new(
+                "visualize",
+                "Visualize",
+                VisualizationRole::Commit,
+            ))
+            .with_edge(InvariantEdge::new("load", "classify"))
+            .with_edge(InvariantEdge::new("classify", "visualize").with_label("valid"))
+    }
+}
+
+#[test]
+fn implementors_get_visualization_after_invariant_validation() {
+    let graph = B00tDatumFlow.invariant_graph();
+
+    graph.validate().expect("sample graph satisfies l3dg3rr invariants");
+
+    let mermaid = graph.to_mermaid();
+    let svg = graph.to_svg();
+
+    assert!(mermaid.contains("n_classify -->|valid| n_visualize"));
+    assert!(svg.contains("Visualize"));
+}

--- a/docs/l3dg3rr-visualization-utility.md
+++ b/docs/l3dg3rr-visualization-utility.md
@@ -1,0 +1,34 @@
+# l3dg3rr Visualization Utility
+
+`PromptExecution/l3dg3rr` exposes reusable skills around typed financial workflows, invariant checks, and visual audit graphs. b00t packages the host-neutral part as `b00t-l3dg3rr-viz`.
+
+Upstream reference inspected: `PromptExecution/l3dg3rr@1dd4a1c`.
+
+## Contract
+
+Any system gets visualization when it can produce an `InvariantGraph` and pass validation:
+
+- The graph name MUST be non-empty.
+- Node IDs MUST be non-empty and unique.
+- Edge endpoints MUST reference existing node IDs.
+- Self-edges MUST carry a label that explains the invariant loop.
+
+Systems can either build `InvariantGraph` directly or implement `L3dg3rrVisualizable`.
+
+## Outputs
+
+- `to_mermaid()` emits a Mermaid `flowchart LR` for mdBook, GitHub Markdown, and issue/PR summaries.
+- `to_svg()` emits standalone SVG for CI artifacts and static documentation.
+- Rustdoc is published by `.github/workflows/l3dg3rr-docs.yml` as an artifact on PRs and to GitHub Pages on `main`.
+
+## Mission Fit
+
+The utility separates l3dg3rr's abstract invariant graph from its financial domain. b00t can expose datum, hive, ACP, and task capability maps with the same visual contract that l3dg3rr uses for audit workflows. A remote or local node only needs to emit the generic graph shape to get comparable docs and diagrams.
+
+<!-- b00t:map v1
+summary: Host-neutral l3dg3rr invariant graph visualization utility packaged for b00t CI docs
+tags: l3dg3rr, visualization, docs, ci, invariants, rust
+tier: ch0nky
+cmds: just l3dg3rr-docs-check, cargo test -p b00t-l3dg3rr-viz
+complexity: 5
+-->


### PR DESCRIPTION
## Summary
- Add `b00t-l3dg3rr-viz` workspace member to Cargo.toml
- Add l3dg3rr visualization documentation and configuration
- Add CI/CD workflow for l3dg3rr docs generation
- Add plantuml-server infrastructure

## Test plan
- [ ] Verify workspace builds: `cargo build`
- [ ] Verify l3dg3rr-viz module loads correctly
- [ ] Check documentation renders
- [ ] Verify CI workflow configuration