### PR TITLE
chore: rebase on upstream main + update l3dg3rr submodule to e9da669 (PR #69)

### DIFF
--- a/.github/workflows/l3dg3rr-docs.yml
+++ b/.github/workflows/l3dg3rr-docs.yml
@@ -1,0 +1,57 @@
+name: l3dg3rr Docs
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'vendor/l3dg3rr/**'
+      - '.github/workflows/l3dg3rr-docs.yml'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'vendor/l3dg3rr/**'
+      - '.github/workflows/l3dg3rr-docs.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  build-docs:
+    name: Build l3dg3rr docs
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install just
+        run: cargo install just --locked
+
+      - name: Setup mdBook
+        uses: jontze/action-mdbook@v3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          use-mermaid: true
+
+      - name: Install mdBook plugins
+        run: |
+          cd vendor/l3dg3rr
+          cargo install mdbook mdbook-mermaid mdbook-admonish --locked
+          cargo install --path crates/mdbook-rhai-mermaid
+
+      - name: Build l3dg3rr docs
+        run: |
+          cd vendor/l3dg3rr
+          just docgen
+
+      - name: Verify output
+        run: |
+          cd vendor/l3dg3rr
+          test -d book/book && echo "✓ book/book directory exists" || { echo "✗ docs build failed"; exit 1; }
+          test -f book/book/theory.html && echo "✓ theory.html generated" || { echo "✗ theory.html missing"; exit 1; }
+          test -f book/book/index.html && echo "✓ index.html generated" || { echo "✗ index.html missing"; exit 1; }

--- a/.gitmodules
+++ b/.gitmodules
@@ -37,3 +37,6 @@
 [submodule "vendor/tomllm"]
 	path = vendor/tomllm
 	url = https://github.com/PromptExecution/tomllm.git
+[submodule "vendor/l3dg3rr"]
+	path = vendor/l3dg3rr
+	url = https://github.com/PromptExecution/l3dg3rr.git

--- a/_b00t_.bashrc
+++ b/_b00t_.bashrc
@@ -841,6 +841,7 @@ fi
 # 🤓 https://github.com/pixelb/crudini/blob/master/EXAMPLES
 # CRUDINI is used to store b00t config:
 
+: "${SUDO_CMD:=}"
 if n0ta_xfile_📁_好不好 "/usr/bin/crudini" ; then 
     log_📢_记录 "🥳 need crudini to save data, installing now"  
     $SUDO_CMD apt-get install -y crudini bc

--- a/_b00t_.bashrc
+++ b/_b00t_.bashrc
@@ -937,7 +937,7 @@ function has_sudo() {
         # https://stackoverflow.com/questions/18215973/how-to-check-if-running-as-root-in-a-bash-script
         log_📢_记录 "👹 please don't b00t as r00t"
         SUDO_CMD=""
-    elif [ -f "./dockerenv" ] ; then
+    elif [ -f "/.dockerenv" ] || [ -f "./dockerenv" ] ; then
         # https://stackoverflow.com/questions/23513045/how-to-check-if-a-process-is-running-inside-docker-container#:~:text=To%20check%20inside%20a%20Docker,%2Fproc%2F1%2Fcgroup%20.
         log_📢_记录 "🐳😁 found DOCKER"  
     elif [ -f "$SUDO_CMD" ] ; then 


### PR DESCRIPTION
## Changes

- Rebased `l3dg3rr-upstream-follow` onto `upstream/main` (strategy: ours — dropped 18 commits already upstream, retained 128 unique commits)
- Re-added `vendor/l3dg3rr` submodule (lost during `--strategy=ours` rebase)
- Updated l3dg3rr to `e9da669` — PR #69 `feat/wrkflw-docgen-pipeline`
- Added `l3dg3rr-docs.yml` CI workflow for mdBook build with rhai-mermaid injection

## Commits (14 ahead of upstream/main)

$(git log --oneline upstream/main..HEAD)

## Verification

$(cd vendor/l3dg3rr && git log --oneline -3)
