### PR TITLE
chore: rebase on upstream main + update l3dg3rr submodule to e9da669 (PR #69)

### DIFF
--- a/.github/workflows/l3dg3rr-docs.yml
+++ b/.github/workflows/l3dg3rr-docs.yml
@@ -4,12 +4,16 @@ on:
   push:
     branches: [main]
     paths:
+      - 'vendor/l3dg3rr'
       - 'vendor/l3dg3rr/**'
+      - '.gitmodules'
       - '.github/workflows/l3dg3rr-docs.yml'
   pull_request:
     branches: [main]
     paths:
+      - 'vendor/l3dg3rr'
       - 'vendor/l3dg3rr/**'
+      - '.gitmodules'
       - '.github/workflows/l3dg3rr-docs.yml'
   workflow_dispatch:
 

--- a/.github/workflows/l3dg3rr-docs.yml
+++ b/.github/workflows/l3dg3rr-docs.yml
@@ -36,8 +36,13 @@ jobs:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
 
+      - name: Cache Rust/cargo
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: vendor/l3dg3rr
+
       - name: Install just
-        run: cargo install just --locked
+        uses: extractions/setup-just@v1
 
       - name: Setup mdBook
         uses: jontze/action-mdbook@v3

--- a/.github/workflows/l3dg3rr-docs.yml
+++ b/.github/workflows/l3dg3rr-docs.yml
@@ -1,0 +1,57 @@
+name: l3dg3rr Docs
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'vendor/l3dg3rr/**'
+      - '.github/workflows/l3dg3rr-docs.yml'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'vendor/l3dg3rr/**'
+      - '.github/workflows/l3dg3rr-docs.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  build-docs:
+    name: Build l3dg3rr docs
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install just
+        run: cargo install just --locked
+
+      - name: Setup mdBook
+        uses: jontze/action-mdbook@v3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          use-mermaid: true
+
+      - name: Install mdBook plugins
+        run: |
+          cd vendor/l3dg3rr
+          cargo install mdbook mdbook-mermaid mdbook-admonish --locked
+          cargo install --path crates/mdbook-rhai-mermaid
+
+      - name: Build l3dg3rr docs
+        run: |
+          cd vendor/l3dg3rr
+          just docgen
+
+      - name: Verify output
+        run: |
+          cd vendor/l3dg3rr
+          test -d book/book && echo "✓ book/book directory exists" || { echo "✗ docs build failed"; exit 1; }
+          test -f book/book/theory.html && echo "✓ theory.html generated" || { echo "✗ theory.html missing"; exit 1; }
+          test -f book/book/index.html && echo "✓ index.html generated" || { echo "✗ index.html missing"; exit 1; }

--- a/.github/workflows/l3dg3rr-docs.yml
+++ b/.github/workflows/l3dg3rr-docs.yml
@@ -24,7 +24,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          submodules: recursive
+          submodules: false
+
+      - name: Initialize l3dg3rr submodule
+        run: git submodule update --init --recursive vendor/l3dg3rr
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable

--- a/.gitmodules
+++ b/.gitmodules
@@ -37,3 +37,6 @@
 [submodule "vendor/tomllm"]
 	path = vendor/tomllm
 	url = https://github.com/PromptExecution/tomllm.git
+[submodule "vendor/l3dg3rr"]
+	path = vendor/l3dg3rr
+	url = https://github.com/PromptExecution/l3dg3rr.git


### PR DESCRIPTION
## Changes

- Rebased `l3dg3rr-upstream-follow` onto `upstream/main` (strategy: ours — dropped 18 commits already upstream, retained 128 unique commits)
- Re-added `vendor/l3dg3rr` submodule (lost during `--strategy=ours` rebase)
- Updated l3dg3rr to `e9da669` — PR #69 `feat/wrkflw-docgen-pipeline`
- Added `l3dg3rr-docs.yml` CI workflow for mdBook build with rhai-mermaid injection

## Commits (2 ahead of upstream/main)

$(git log --oneline upstream/main..HEAD)

## Verification

$(cd vendor/l3dg3rr && git log --oneline -3)
