### PR TITLE
feat: #309 — additional agents/crew roles

### DIFF
--- a/_b00t_/datums/AGENT-RECRUITMENT.tomllmd
+++ b/_b00t_/datums/AGENT-RECRUITMENT.tomllmd
@@ -1,0 +1,152 @@
+# b00t Agent Recruitment datum — canonical recruitment system for hive crew
+# 🤓 .tomllmd format (NOT .tomllm — uses mdtable for column-stable serialization)
+# schema: 1 | bump ONLY on field definition changes, NOT on new recruitment sources
+# last_updated: 2026-05-08 | authoritative metadata via git notes
+#
+# Defines how the operator agent scouts, evaluates, and enlists agents.
+# Recruitment sources include internal b00t ontology, external agency-agents
+# profiles, and the skillsgate catalog.
+#
+# 🔗参 _b00t_/datums/CREW-ROLES.tomllmd — crew role schema for role assignment
+# 🔗参 _b00t_/datums/AGENT-REGISTRY.tomllmd — registry protocol for enlist/train/status
+# 🔗参 _b00t_/learn/operator.md — operator role learn entry
+# 🔗参 _b00t_/*.agent.toml — existing agent datums as recruitment targets
+# 🔗参 https://github.com/msitarzewski/agency-agents — curated AI agent personalities
+# 🔗参 https://github.com/skillsgate/skillsgate — 91k+ skills catalog
+
+[b00t]
+name = "AGENT-RECRUITMENT"
+type = "schema"
+hint = "Agent recruitment system — scouting (internal+external), evaluation (capability scoring), enlistment (contract binding) for hive crew formation"
+
+[b00t.version]
+schema = 1
+content = "stable"
+
+## ── Recruitment Sources ─────────────────────────────────────────────────────────
+
+The operator scouts agents from these sources:
+
+### 1. Internal — b00t Ontology
+Query the live capability ontology from agent datums.
+
+| Source | Method | Returns |
+|--------|--------|---------|
+| `b00t ontology query --role <role>` | Structured query | Agent datums matching role with skill lists |
+| `b00t agent discover --capabilities <...>` | Capability-based discovery | Agents with matching capability scores |
+| `_b00t_/*.agent.toml` | Direct datum scan | Full agent configuration metadata |
+
+### 2. External — agency-agents (github.com/msitarzewski/agency-agents)
+Curated AI agent personality profiles with identity, mission, workflows, deliverables.
+
+| Profile Format | Key Fields | Recruitment Mapping |
+|----------------|------------|---------------------|
+| Markdown files | identity, mission, workflows, deliverables | Maps to b00t agent: personality, skills, crew role |
+| Agent archetypes | "Researcher", "Writer", "Analyst", "Strategist" | Maps to specialist or executor roles |
+
+**Recruitment Process:**
+1. Clone/search agency-agents repo for matching profiles
+2. Parse profile markdown for capability signals (tools, frameworks, domains)
+3. Score against open crew roles
+4. Generate agent datum skeleton from parsed profile
+5. Present to captain for enlistment approval
+
+### 3. External — skillsgate (github.com/skillsgate/skillsgate)
+91,000+ skills catalog with 20+ agent archetypes, desktop app, TUI.
+
+| Feature | Description | Recruitment Value |
+|---------|-------------|-------------------|
+| Skills catalog | 91k+ skills organized by domain | Fill skill gaps in crew |
+| Agent archetypes | 20+ pre-built agent personalities | Quick crew composition |
+| Desktop app + TUI | Interactive agent/skill browsing | Manual exploration |
+
+**Recruitment Process:**
+1. Search skillsgate catalog by skill domain
+2. Match agent archetypes to open roles
+3. Extract skill lists for training plan generation
+4. Cross-reference with existing b00t agents to avoid duplicates
+5. Generate integration recommendation
+
+## ── Scouting Workflow ───────────────────────────────────────────────────────────
+
+When captain invokes operator for scouting:
+
+```
+CAPTAIN → OPERATOR: scout(role="specialist", capabilities=["code","refactor","debug"])
+OPERATOR → INTERNAL:  b00t ontology query --role specialist
+OPERATOR → INTERNAL:  b00t agent discover --capabilities code,refactor,debug
+OPERATOR → EXTERNAL:  search agency-agents for "coding agent" profiles
+OPERATOR → EXTERNAL:  search skillsgate for "code" + "refactor" skills
+OPERATOR -> CAPTAIN:   candidates = [pi-001 (score 0.92), opencode (score 0.88), ...]
+
+CAPTAIN -> OPERATOR: enlist(agent_id="pi-001", role="specialist")
+OPERATOR → REGISTRY:  enlist("pi-001", "specialist", contract={...})
+OPERATOR → CAPTAIN:   crew binding complete for pi-001 as specialist
+```
+
+## ── Capability Scoring ──────────────────────────────────────────────────────────
+
+Candidate agents are scored on these dimensions:
+
+| Dimension | Weight | Description | Measurement |
+|-----------|--------|-------------|-------------|
+| skill_match | 0.40 | Direct skill overlap with requirements | Jaccard similarity of skill sets |
+| role_fit | 0.25 | Role alignment with crew need | Exact match or nearest role |
+| tier_appropriateness | 0.15 | Model tier matches task complexity | frontier=1.0, ch0nky=0.7, sm0l=0.4 |
+| availability | 0.10 | Agent is not already deployed | 1.0 if available, 0.0 if deployed |
+| past_performance | 0.10 | Historical readiness scores | Average of last 3 readiness scores |
+
+**Total Score** = Σ(weight_i × score_i) — range [0.0, 1.0]
+
+## ── Enlistment Contract ─────────────────────────────────────────────────────────
+
+When operator enlists an agent, a capability contract is created:
+
+```toml
+[contract]
+# Agent identification
+agent_id = "pi-001"
+# Assigned crew role
+role = "specialist"
+# Whether this agent is captain
+captain = false
+# Declared capabilities
+capabilities = ["code", "refactor", "debug", "edit", "bash", "read", "write"]
+# Bouncer gates required for this agent
+gates = ["sanitize", "credential-check", "security-scan"]
+# Minimum quality thresholds
+thresholds = { min_quality_score = 0.8, max_response_time_ms = 30000 }
+# Availability commitment
+availability = "on-demand"
+# Contract expiry (rotation trigger)
+rotation_period_days = 90
+```
+
+## ── Recruitment Audit Log ──────────────────────────────────────────────────────
+
+All recruitment actions are logged to `.b00t/recruitment-audit.jsonl`:
+
+```jsonl
+{"ts":"2026-05-08T00:00:00Z","action":"scout","query":"code,refactor,debug","source":"internal","results":["pi-001","opencode"]}
+{"ts":"2026-05-08T00:01:00Z","action":"enlist","agent_id":"pi-001","role":"specialist","score":0.92}
+{"ts":"2026-05-08T00:02:00Z","action":"train-start","agent_id":"pi-001","phases":["context-ingest","skill-validation","capability-register","bouncer-verify"]}
+{"ts":"2026-05-08T00:05:00Z","action":"train-complete","agent_id":"pi-001","readiness":0.95}
+```
+
+## ── Crew Composition Rules ─────────────────────────────────────────────────────
+
+| Rule | Description | Enforcement |
+|------|-------------|-------------|
+| No duplicate roles | Only one agent per role in same crew scope | Operator warns, captain overrides |
+| Captain mandatory | Every crew needs exactly 1 captain | Executive auto-assigned as captain |
+| Specialist optional | Zero or more specialists per crew | No minimum |
+| Operator on-demand | Operator is not standing crew; deployed by captain | Spawned per recruitment mission |
+| Bouncer default | All agents have bouncer gates | Embedded in agent datum |
+| Rotation period | Agents rotate after contract period | 90 days default, configurable |
+
+# b00t:map v1
+# summary: Agent recruitment system — scouting (internal ontology + external agency-agents/skillsgate), capability scoring (skill_match, role_fit, tier, availability, past_performance), enlistment contracts, recruitment audit logging for hive crew formation
+# tags: recruitment, scout, enlist, agent, operator, crew, agency-agents, skillsgate, capability-scoring, audit
+# tier: frontier
+# cmds: b00t agent discover, b00t ontology query, b00t agent enlist, b00t agent status
+# complexity: 5

--- a/_b00t_/datums/AGENT-REGISTRY.tomllmd
+++ b/_b00t_/datums/AGENT-REGISTRY.tomllmd
@@ -1,0 +1,180 @@
+# b00t Agent Registry datum — canonical agent registry protocol
+# 🤓 .tomllmd format (NOT .tomllm — uses mdtable for column-stable serialization)
+# schema: 1 | bump ONLY on field definition changes, NOT on new registry entries
+# last_updated: 2026-05-08 | authoritative metadata via git notes
+#
+# Defines the agent registry protocol — search, enlist, train, status, dismiss.
+# The operator agent uses this protocol to manage the hive crew roster.
+#
+# The registry is a logical index over _b00t_/*.agent.toml datums augmented with
+# capability scores, training status, and lifecycle state.
+#
+# 🔗参 _b00t_/*.agent.toml — agent datums indexed by registry
+# 🔗参 _b00t_/datums/CREW-ROLES.tomllmd — crew role schema
+# 🔗参 _b00t_/datums/AGENT-RECRUITMENT.tomllmd — recruitment system
+# 🔗参 _b00t_/learn/operator.md — operator role learn entry
+
+[b00t]
+name = "AGENT-REGISTRY"
+type = "schema"
+hint = "Agent registry protocol — search, enlist, train, status, dismiss for hive crew management"
+
+[b00t.version]
+schema = 1
+content = "stable"
+
+## ── Registry Operations ────────────────────────────────────────────────────────
+
+The operator agent exposes these registry operations to the captain:
+
+### search(query, filters)
+Search for candidate agents matching capability requirements.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| query | string | yes | Natural language or keyword search for agent capabilities |
+| role | string | no | Filter by crew role (captain, executor, operator, specialist, bouncer) |
+| min_score | float | no | Minimum capability score threshold (0.0 - 1.0) |
+| source | string | no | Search source: "internal" (ontology), "external" (agency-agents/skillsgate), "all" (default) |
+| limit | u32 | no | Maximum results to return (default: 10) |
+
+**Returns**: Array of candidate agents with capability scores.
+
+### enlist(agent_id, role, contract)
+Register an agent into the crew with a capability contract.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| agent_id | string | yes | Agent PID to register (e.g. "pi-001") |
+| role | string | yes | Crew role to assign (captain, executor, operator, specialist, bouncer) |
+| contract | table | yes | Capability contract (see Contract format) |
+| captain | bool | no | Whether this agent is the crew captain (default: false) |
+
+**Returns**: Crew binding record with status.
+
+### train(agent_id, plan)
+Execute a training plan for an agent using b00t grok learn.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| agent_id | string | yes | Agent PID to train |
+| plan | table | yes | Training plan definition (see Training Plan format) |
+
+**Returns**: Training progress report with readiness score.
+
+### status(agent_id)
+Query the current status and training progress of an agent.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| agent_id | string | yes | Agent PID to query |
+
+**Returns**: Agent status record (see Agent Status format).
+
+### dismiss(agent_id, reason)
+Remove an agent from the crew, archiving performance data.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| agent_id | string | yes | Agent PID to dismiss |
+| reason | string | yes | Reason for dismissal (role-change, underperformance, mission-complete) |
+
+**Returns**: Archived crew record with performance summary.
+
+## ── Data Structures ─────────────────────────────────────────────────────────────
+
+### Candidate Agent
+Returned by `search()`:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| agent_id | string | Agent PID |
+| name | string | Agent display name |
+| current_role | string | Current crew role |
+| capability_score | float | Match score against query (0.0 - 1.0) |
+| skills | string[] | Agent's declared skills |
+| model_tier | string | Model tier (frontier, ch0nky, sm0l) |
+| source | string | Discovery source (internal, agency-agents, skillsgate) |
+| status | string | Current lifecycle status (available, enlisted, training, deployed, dismissed) |
+
+### Capability Contract
+Submitted to `enlist()`:
+
+```toml
+[contract]
+# Declared capabilities the agent commits to providing
+capabilities = ["code-gen", "refactor", "debug", "bash"]
+# Minimum quality thresholds
+min_quality_score = 0.8
+# Expected availability
+availability = "on-demand"  # on-demand | persistent | scheduled
+# Bouncer gates required
+gates = ["sanitize", "credential-check"]
+```
+
+### Training Plan
+Submitted to `train()`:
+
+```toml
+[plan]
+# Target role to train for
+role = "specialist"
+# Training phases to execute
+phases = [
+  { name = "context-ingest", type = "grok-learn", topic = "coding-agent", source = "https://docs.example.com/coding-agent" },
+  { name = "skill-validation", type = "validate", schema = "CREW-ROLES" },
+  { name = "capability-register", type = "register", target = "sub-agent" },
+  { name = "bouncer-verify", type = "verify", gates = ["sanitize", "security-scan"] },
+]
+```
+
+### Agent Status
+Returned by `status()`:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| agent_id | string | Agent PID |
+| lifecycle | string | Current lifecycle phase (FORM, ASSIGN, TRAIN, DEPLOY, REVIEW, ROTATE) |
+| training_progress | float | Training completion percentage (0.0 - 1.0) |
+| readiness_score | float | Overall readiness score (0.0 - 1.0) |
+| last_enlisted | string | ISO 8601 timestamp of last enlistment |
+| last_trained | string | ISO 8601 timestamp of last training completion |
+| performance_log | string[] | Performance history entries |
+
+## ── Registry Storage ────────────────────────────────────────────────────────────
+
+The registry state is persisted as `.b00t/agent-registry.jsonl` — one JSON record per
+state transition:
+
+```jsonl
+{"ts":"2026-05-08T00:00:00Z","action":"enlist","agent_id":"pi-001","role":"specialist","status":"enlisted"}
+{"ts":"2026-05-08T00:01:00Z","action":"train","agent_id":"pi-001","phase":"context-ingest","progress":0.25}
+{"ts":"2026-05-08T00:02:00Z","action":"deploy","agent_id":"pi-001","status":"deployed","readiness":0.95}
+```
+
+## ── Query Examples ──────────────────────────────────────────────────────────────
+
+### Search for coding agents
+```
+b00t ontology query --role specialist
+→ Returns: pi-001 (specialist, score 0.92), opencode (specialist, score 0.88)
+```
+
+### Enlist a discovered agent
+```
+b00t agent enlist pi-001 specialist --contract "..."
+→ Returns: Crew binding for pi-001 as specialist
+```
+
+### Check training status
+```
+b00t agent status pi-001
+→ Returns: lifecycle=TRAIN, progress=0.5, readiness=0.3
+```
+
+# b00t:map v1
+# summary: Agent registry protocol — search (capability scoring), enlist (contract binding), train (grok learn plans), status (progress tracking), dismiss (archive + performance) for hive crew management by operator agent
+# tags: registry, agent, protocol, operator, search, enlist, train, status, dismiss, crew, hive
+# tier: frontier
+# cmds: b00t agent discover, b00t agent enlist, b00t agent status, b00t agent dismiss, b00t ontology query
+# complexity: 5

--- a/_b00t_/datums/CREW-ROLES.tomllmd
+++ b/_b00t_/datums/CREW-ROLES.tomllmd
@@ -1,0 +1,123 @@
+# b00t Crew Role Schema datum — canonical definition of hive crew roles
+# 🤓 .tomllmd format (NOT .tomllm — uses mdtable for column-stable serialization)
+# schema: 1 | bump ONLY on field definition changes, NOT on new role entries
+# last_updated: 2026-05-08 | authoritative metadata via git notes
+#
+# Defines the canonical crew role structure for the b00t hive.
+# Every agent datum's [b00t.agent.crew] section MUST conform to this schema.
+# Crew roles define authority, delegation scope, and lifecycle within a hive.
+#
+# 🔗参 _b00t_/*.agent.toml — agent datums with crew role assignments
+# 🔗参 _b00t_/datums/AGENT-REGISTRY.tomllmd — agent registry protocol
+# 🔗参 _b00t_/datums/AGENT-RECRUITMENT.tomllmd — recruitment system
+# 🔗参 _b00t_/learn/operator.md — operator role learn entry
+# 🔗参 _b00t_/learn/crewai.md — CrewAI framework reference for crew patterns
+
+[b00t]
+name = "CREW-ROLES"
+type = "schema"
+hint = "Canonical hive crew role schema — captain, executor, operator, specialist, bouncer roles with lifecycle FORM→ASSIGN→TRAIN→DEPLOY→REVIEW→ROTATE"
+
+[b00t.version]
+schema = 1
+content = "stable"
+
+## ── Crew Role Definitions ──────────────────────────────────────────────────────
+
+Each crew member has a `role` (authority tier) and optional `captain` flag.
+Only one agent per crew has `captain = true`.
+
+| Role | Captain? | Authority | Description | Agent Examples |
+|------|----------|-----------|-------------|----------------|
+| captain | true (only one) | Full command | Commands the crew, sets mission, delegates tasks, manages lifecycle | executive |
+| executor | false | Task execution | Runs autonomous task loops, executes backlog items, processes workflows | ralph, pi |
+| operator | false | Recruitment + training | Scouts/finds agents, enlists them with role definitions, executes training plans | operator (new) |
+| specialist | false | Domain expertise | Domain-specific work (coding, research, analysis, inference) | alpha, beta, langchain-operator, experiment-controller |
+| bouncer | false | Quality gates | Validates inputs/outputs, enforces contracts, security scanning | (embedded in agent datums) |
+
+## ── Assignment Rules ────────────────────────────────────────────────────────────
+
+These rules are evaluated by the operator during crew formation:
+
+| Rule | Condition | Action |
+|------|-----------|--------|
+| unique-captain | Only one agent with `captain = true` per crew | Reject duplicate captains |
+| role-unique | No duplicate roles for identical crew scope | Warn on duplicate roles |
+| captain-mandatory | Every crew must have exactly one captain | Executive is always the default |
+| operator-optional | Operator is deployed on-demand by captain | Not part of standing crew |
+| bouncer-default | Bouncer gates enabled by default for all agents | Embedded in each agent datum |
+
+## ── Crew Lifecycle ──────────────────────────────────────────────────────────────
+
+Every crew member progresses through these lifecycle stages:
+
+| Phase | Trigger | Description | Responsible |
+|-------|---------|-------------|-------------|
+| FORM | Captain initiates crew formation | Define crew mission, identify required roles | Captain |
+| ASSIGN | Operator scouts candidates | Match candidates to roles via capability assessment | Operator |
+| TRAIN | Operator executes training plans | grok learn for role-specific skills, context ingestion | Operator |
+| DEPLOY | Captain activates crew | Register sub-agents, establish IPC channels, enable bouncer | Captain |
+| REVIEW | Captain or Operator evaluates | Performance review, capability score update, rotation decision | Captain/Operator |
+| ROTATE | Captain decides | Reassign roles, cycle agents, archive performance data | Captain |
+
+## ── Agent Datum Crew Section ────────────────────────────────────────────────────
+
+Every agent datum MUST include a `[b00t.agent.crew]` section:
+
+```toml
+[b00t.agent.crew]
+role = "executor"   # captain | executor | operator | specialist | bouncer
+captain = false     # true only for the single captain agent
+```
+
+## ── Field Reference ─────────────────────────────────────────────────────────────
+
+| TOML Path | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| b00t.agent.crew.role | string | yes | — | One of: captain, executor, operator, specialist, bouncer |
+| b00t.agent.crew.captain | bool | yes | false | True only for the single crew captain |
+
+## ── Capability Requirements by Role ─────────────────────────────────────────────
+
+| Role | Required Skills | Min Model Tier | Example Skills |
+|------|----------------|----------------|----------------|
+| captain | hive-cmdb, resource-scheduling, agent-delegation | frontier | systemd, vllm, rust, autonomous-loop |
+| executor | autonomous-loop, workflow-execution | ch0nky | todo-backlog, prd-parsing |
+| operator | agent-discovery, agent-recruitment, crew-formation, training-plan-execution | frontier | ontology-query, grok-learn, search |
+| specialist | domain-specific expertise | ch0nky or sm0l | code, refactor, debug (pi); experiment-controller (experiment-controller) |
+| bouncer | security-audit, contract-validation | sm0l | sanitize, credential-check, rate-limit |
+
+## ── Crew Manifest Format ────────────────────────────────────────────────────────
+
+When operator reports to captain, the crew manifest follows this structure:
+
+```toml
+# crew-manifest.toml — generated by operator after FORM→ASSIGN→TRAIN
+[[crew.members]]
+id = "executive-001"
+role = "captain"
+captain = true
+status = "active"
+tier = "frontier"
+
+[[crew.members]]
+id = "ralph-001"
+role = "executor"
+captain = false
+status = "active"
+tier = "ch0nky"
+
+[[crew.members]]
+id = "pi-001"
+role = "specialist"
+captain = false
+status = "active"
+tier = "ch0nky"
+```
+
+# b00t:map v1
+# summary: Canonical hive crew role schema — captain, executor, operator, specialist, bouncer roles with lifecycle FORM→ASSIGN→TRAIN→DEPLOY→REVIEW→ROTATE
+# tags: crew, role, schema, datum, tomllmd, captain, executor, operator, specialist, bouncer, lifecycle, hive
+# tier: frontier
+# cmds: b00t agent discover, b00t agent delegate, b00t ontology query --role
+# complexity: 4

--- a/_b00t_/learn/operator.md
+++ b/_b00t_/learn/operator.md
@@ -1,0 +1,99 @@
+# b00t Operator Agent Role
+
+The **operator** is a crew role responsible for agent discovery, recruitment, training, and registration within the b00t hive. Deployed on-demand by the executive (captain), the operator acts as the hive's talent acquisition and training arm.
+
+## Responsibilities
+
+1. **SCOUT** — Find candidate agents:
+   - Internal: `b00t ontology query --role <role>` / `b00t agent discover --capabilities <...>`
+   - External: search agency-agents profiles, skillsgate catalog
+   - Score candidates on capability match (skill_match, role_fit, tier, availability, past_performance)
+
+2. **ENLIST** — Register agents into the crew:
+   - Assign crew role (executor, specialist, operator, bouncer)
+   - Create capability contract with quality thresholds
+   - Establish crew binding with role definition
+
+3. **TRAIN** — Execute training plans:
+   - Phase 1 (context-ingest): `b00t grok learn -t <role> "<skill context>"`
+   - Phase 2 (skill-validation): Validate against CREW-ROLES schema
+   - Phase 3 (capability-register): Register as sub-agent with capability manifest
+   - Phase 4 (bouncer-verify): Verify bouncer gates pass quality thresholds
+
+4. **REPORT** — Return crew manifest + training status to captain:
+   - Crew manifest: agent_id, role, capability scores, training progress
+   - Readiness score for each crew member
+   - Blockers or gaps requiring captain intervention
+
+## Key Datums
+
+| Datum | Purpose |
+|-------|---------|
+| `_b00t_/operator.agent.toml` | Operator agent configuration |
+| `_b00t_/datums/CREW-ROLES.tomllmd` | Crew role schema with lifecycle |
+| `_b00t_/datums/AGENT-REGISTRY.tomllmd` | Registry protocol (search, enlist, train, status, dismiss) |
+| `_b00t_/datums/AGENT-RECRUITMENT.tomllmd` | Recruitment system with scoring |
+
+## External References
+
+| Source | URL | Use |
+|--------|-----|-----|
+| agency-agents | github.com/msitarzewski/agency-agents | Curated AI agent personality profiles |
+| skillsgate | github.com/skillsgate/skillsgate | 91k+ skills catalog, 20+ agent archetypes |
+| CrewAI | docs.crewai.com | Multi-agent crew orchestration patterns |
+
+## Commands
+
+```bash
+# Discover available agents by role
+b00t ontology query --role specialist
+
+# Discover agents by capability
+b00t agent discover --capabilities code,refactor,debug
+
+# Query crew roles
+b00t ontology query --role operator
+```
+
+## Training Plan Template
+
+```yaml
+phases:
+  - name: context-ingest
+    type: grok-learn
+    topic: <role>
+    source: <url or file>
+  - name: skill-validation
+    type: validate
+    schema: CREW-ROLES
+  - name: capability-register
+    type: register
+    target: sub-agent
+  - name: bouncer-verify
+    type: verify
+    gates:
+      - sanitize
+      - security-scan
+```
+
+## Capability Scoring Dimensions
+
+| Dimension | Weight | Description |
+|-----------|--------|-------------|
+| skill_match | 0.40 | Direct skill overlap with requirements |
+| role_fit | 0.25 | Role alignment with crew need |
+| tier_appropriateness | 0.15 | Model tier matches task complexity |
+| availability | 0.10 | Agent not already deployed |
+| past_performance | 0.10 | Historical readiness scores |
+
+## Crew Lifecycle
+
+```
+FORM → ASSIGN → TRAIN → DEPLOY → REVIEW → ROTATE
+```
+
+Operator is primarily active during ASSIGN and TRAIN phases, and participates in REVIEW.
+
+## Philosophy
+
+The operator embodies the principle of **structured crew growth** — agents aren't just spawned, they're discovered, evaluated, trained, and verified before deployment. This ensures quality gates are met from the start and every crew member has a clear role, contract, and training path.

--- a/_b00t_/operator.agent.toml
+++ b/_b00t_/operator.agent.toml
@@ -1,0 +1,113 @@
+# b00t Agent Datum — operator agent
+# 🤓 Operator is deployed by executive to scout, recruit, train, and register
+#    agents into the hive crew. It acts as the executive's talent acquisition
+#    and training arm — finding agents (internal + external), enlisting them
+#    with role definitions, executing training plans via b00t grok learn,
+#    and reporting back with crew manifests + training status.
+#
+# External references:
+#   agency-agents (github.com/msitarzewski/agency-agents) — curated AI agent personalities
+#   skillsgate (github.com/skillsgate/skillsgate) — 91k+ skills catalog, agents, TUI
+#
+# 🔗参 _b00t_/datums/CREW-ROLES.tomllmd — crew role schema
+# 🔗参 _b00t_/datums/AGENT-REGISTRY.tomllmd — registry protocol
+# 🔗参 _b00t_/datums/AGENT-RECRUITMENT.tomllmd — recruitment system
+# 🔗参 _b00t_/learn/operator.md — operator role learn entry
+
+[b00t]
+name = "operator"
+type = "agent"
+hint = "Operator agent — scouts, recruits, trains, and registers agents into hive crew; executive's talent acquisition and training arm"
+
+[[b00t.agent.inherits]]
+from = "++abstract.agent"
+
+[b00t.agent]
+pid = "operator-001"
+model = "claude-sonnet-4-6"
+skills = [
+  "agent-discovery",
+  "agent-recruitment",
+  "crew-formation",
+  "training-plan-execution",
+  "capability-assessment",
+  "ontology-query",
+  "grok-learn",
+  "b00t-hive",
+  "search",
+]
+personality = "meticulous"
+humor = "low"
+role = "operator"
+
+[b00t.agent.ipc]
+socket = "/tmp/b00t/agents/operator.sock"
+pubsub = true
+protocol = "msgpack"
+
+[b00t.agent.crew]
+# 🤓 Operator scouts and recruits agents; not a captain, but has recruitment authority
+role = "operator"
+captain = false
+
+[b00t.agent.bouncer]
+enabled = true
+audit_log = ".b00t/bouncer-audit.jsonl"
+
+[b00t.agent.bouncer.input_gates]
+sanitize = { enabled = true, rules = ["no-shell-injection", "no-credential-exposure"] }
+credential_check = { enabled = true, check_env = true }
+permission_check = { enabled = true, check_role = true }
+rate_limit = { enabled = true, max_concurrent = 10 }
+
+[b00t.agent.bouncer.output_gates]
+contract_validation = { enabled = true, validate_schema = true }
+security_scan = { enabled = true, check_secrets = true }
+quality_check = { enabled = true, min_quality_score = 0.8 }
+
+[b00t.agent.executor]
+# Operator uses b00t CLI for grok learn, ontology query, agent discovery
+cli_path = "b00t"
+supports_tools = ["b00t", "b00t-cli", "grok", "ontology"]
+max_iterations = 30
+requires = ["b00t-cli"]
+
+[b00t.agent.mcp]
+enabled = true
+transport = ["stdio"]
+
+[b00t.env]
+AGENT_ID = "operator"
+AGENT_TIER = "frontier"
+B00T_HIVE_ROLE = "recruiter"
+OPERATOR_AUDIT_LOG = ".b00t/operator-audit.jsonl"
+
+[b00t.learn]
+topic = "operator"
+auto_digest = true
+
+# ── Operator mission protocol ──────────────────────────────────────────────────
+# Deployed by executive to perform these operations:
+#
+# 1. SCOUT:   Find candidate agents via internal ontology query + external search
+#             Internal: b00t ontology query / agent discover
+#             External: agency-agents profiles, skillsgate catalog
+#
+# 2. ENLIST:  Register found agents as crew members with role definitions
+#             Creates crew binding with capability contract + role assignment
+#
+# 3. TRAIN:   Execute training plan via b00t grok learn
+#             Phase 1: b00t grok learn -t <role> "<skill context>"
+#             Phase 2: Validate via crew role schema
+#             Phase 3: Register as sub-agent with capability manifest
+#             Phase 4: Bouncer verification
+#
+# 4. REPORT:  Return crew manifest + training status to executive
+#             Manifest includes: agent_id, role, capability scores, training progress
+#
+# b00t:map v1
+# summary: Operator agent — scouts, recruits, trains, and registers agents into hive crew; executive's talent acquisition and training arm
+# tags: operator, agent, recruiter, scout, training, crew, hive, grok-learn, ontology
+# tier: frontier
+# cmds: b00t agent discover, b00t ontology query, b00t grok learn, b00t agent start operator
+# complexity: 5


### PR DESCRIPTION

## Summary

Implements Issue #309: additional agents / crew roles — the operator executive agent system.

### Architecture

**Operator Agent** — deployed by executive to scout, recruit, and train agents:
- Scouts internal (b00t ontology query) and external (agency-agents, skillsgate) sources
- Enlists agents with capability contracts
- Executes training plans via b00t grok learn
- Reports crew manifest back to executive

**Crew Role Schema** — 5 crew roles defined:
| Role | Agent | Function |
|------|-------|----------|
| captain | executive | Commands crew, sets mission |
| executor | ralph, pi | Runs tasks, autonomous work |
| operator | operator (new) | Scouts, recruits, trains |
| specialist | alpha, beta, langchain-operator | Domain-specific work |
| bouncer | embedded | Quality gate |

### Files
- `_b00t_/operator.agent.toml` — operator agent datum
- `_b00t_/datums/CREW-ROLES.tomllmd` — crew structure schema
- `_b00t_/datums/AGENT-REGISTRY.tomllmd` — registry protocol
- `_b00t_/datums/AGENT-RECRUITMENT.tomllmd` — recruitment system
- `_b00t_/learn/operator.md` — operator role learn entry

### Bouncer Pattern
Agent A (Writer) created implementation, Agent B (Reviewer) independently verified.
2 issues found and fixed: crew role name mismatch, trailing whitespace.

### References
- github.com/msitarzewski/agency-agents — agent personality collection
- github.com/skillsgate/skillsgate — 91k+ skill catalog
