### PR TITLE
gov, hierarchy, cli: close gaps #1-#8, #10

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -823,6 +823,7 @@ dependencies = [
 name = "b00t-c0re-hierarchy"
 version = "0.1.0"
 dependencies = [
+ "b00t-c0re-gov",
  "chrono",
  "serde",
  "serde_json",

--- a/b00t-c0re-gov/src/errors.rs
+++ b/b00t-c0re-gov/src/errors.rs
@@ -17,6 +17,9 @@ pub enum GovernanceError {
     
     #[error("Insufficient calories: {available:.1} available, {required:.1} required")]
     InsufficientCalories { available: f64, required: f64 },
+
+    #[error("Agent invocation failed: {0}")]
+    InvocationFailed(String),
     
     #[error("IO error: {0}")]
     Io(#[from] std::io::Error),

--- a/b00t-c0re-gov/src/gates/at_timestamp.rs
+++ b/b00t-c0re-gov/src/gates/at_timestamp.rs
@@ -39,7 +39,8 @@ impl GovernanceGate for AtTimestampGate {
         // TTL = (target - now) ms + 60 s grace so the hook stays valid until it can fire.
         // If timestamp is in the past or zero, use None (hook fires immediately or is ignored).
         let ttl_ms = if timestamp > now_secs {
-            Some(((timestamp - now_secs) as u64) * 1_000 + 60_000)
+            let diff_secs = (timestamp - now_secs) as u64; // safe: we verified timestamp > now_secs
+            Some(diff_secs.saturating_mul(1_000).saturating_add(60_000))
         } else {
             None
         };

--- a/b00t-c0re-gov/src/gates/at_timestamp.rs
+++ b/b00t-c0re-gov/src/gates/at_timestamp.rs
@@ -35,11 +35,20 @@ impl GovernanceGate for AtTimestampGate {
             .and_then(|v| v.as_i64())
             .unwrap_or(0);
 
+        let now_secs = chrono::Utc::now().timestamp();
+        // TTL = (target - now) ms + 60 s grace so the hook stays valid until it can fire.
+        // If timestamp is in the past or zero, use None (hook fires immediately or is ignored).
+        let ttl_ms = if timestamp > now_secs {
+            Some(((timestamp - now_secs) as u64) * 1_000 + 60_000)
+        } else {
+            None
+        };
+
         GateResult::Hook(HookToken {
             id: Uuid::new_v4(),
             hook_type: HookType::AtTimestamp(timestamp),
             created_at: chrono::Utc::now(),
-            ttl_ms: Some(86_400_000), // 24h default TTL for timestamp hooks
+            ttl_ms,
             description: format!(
                 "AtTimestamp gate '{}': paused '{}' until Unix timestamp {}",
                 self.name, action, timestamp
@@ -59,7 +68,8 @@ mod unit_tests {
     #[tokio::test]
     async fn test_at_timestamp_gate_returns_hook_with_timestamp_from_metadata() {
         let gate = AtTimestampGate::new("release-window", "Only allow after release date");
-        let timestamp: i64 = 1_756_300_000; // Some future date
+        // Use a timestamp 7 days in the future so this test stays valid regardless of wall time.
+        let timestamp: i64 = chrono::Utc::now().timestamp() + 7 * 86_400;
         let context = GateCheckContext {
             agent_id: "test-agent".to_string(),
             task: "test task".to_string(),
@@ -72,7 +82,12 @@ mod unit_tests {
         match result {
             GateResult::Hook(token) => {
                 assert_eq!(token.hook_type, HookType::AtTimestamp(timestamp));
-                assert!(token.ttl_ms.is_some());
+                // timestamp is in the future → TTL must be set and exceed 24h
+                assert!(token.ttl_ms.is_some(), "future timestamp must have a TTL");
+                assert!(
+                    token.ttl_ms.unwrap() > 86_400_000,
+                    "TTL should exceed 24h for a far-future timestamp"
+                );
                 assert!(token.description.contains("release-window"));
                 assert!(token.description.contains(&timestamp.to_string()));
             }
@@ -95,6 +110,8 @@ mod unit_tests {
         match result {
             GateResult::Hook(token) => {
                 assert_eq!(token.hook_type, HookType::AtTimestamp(0));
+                // timestamp 0 is in the past → no TTL
+                assert!(token.ttl_ms.is_none(), "past/zero timestamp must have no TTL");
             }
             _ => panic!("Expected Hook result, got {:?}", result),
         }

--- a/b00t-c0re-gov/src/gates/at_timestamp.rs
+++ b/b00t-c0re-gov/src/gates/at_timestamp.rs
@@ -1,0 +1,109 @@
+use async_trait::async_trait;
+use uuid::Uuid;
+
+use crate::traits::*;
+use crate::types::*;
+
+/// A gate that returns a Hook with a specific Unix timestamp.
+/// The agent must wait until the timestamp is reached before the action is allowed.
+/// Reads the timestamp from the `timestamp` field in metadata as i64 Unix seconds.
+pub struct AtTimestampGate {
+    name: String,
+    description: String,
+}
+
+impl AtTimestampGate {
+    /// Create a gate that returns a Hook with a Unix timestamp from metadata.
+    pub fn new(name: &str, description: &str) -> Self {
+        AtTimestampGate {
+            name: name.to_string(),
+            description: description.to_string(),
+        }
+    }
+}
+
+#[async_trait]
+impl GovernanceGate for AtTimestampGate {
+    fn name(&self) -> &str {
+        &self.name
+    }
+
+    async fn check(&self, action: &str, context: &GateCheckContext) -> GateResult {
+        let timestamp = context
+            .metadata
+            .get("timestamp")
+            .and_then(|v| v.as_i64())
+            .unwrap_or(0);
+
+        GateResult::Hook(HookToken {
+            id: Uuid::new_v4(),
+            hook_type: HookType::AtTimestamp(timestamp),
+            created_at: chrono::Utc::now(),
+            ttl_ms: Some(86_400_000), // 24h default TTL for timestamp hooks
+            description: format!(
+                "AtTimestamp gate '{}': paused '{}' until Unix timestamp {}",
+                self.name, action, timestamp
+            ),
+        })
+    }
+
+    fn description(&self) -> &str {
+        &self.description
+    }
+}
+
+#[cfg(test)]
+mod unit_tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn test_at_timestamp_gate_returns_hook_with_timestamp_from_metadata() {
+        let gate = AtTimestampGate::new("release-window", "Only allow after release date");
+        let timestamp: i64 = 1_756_300_000; // Some future date
+        let context = GateCheckContext {
+            agent_id: "test-agent".to_string(),
+            task: "test task".to_string(),
+            action: "deploy-release".to_string(),
+            metadata: serde_json::json!({"timestamp": timestamp}),
+        };
+
+        let result = gate.check("deploy-release", &context).await;
+
+        match result {
+            GateResult::Hook(token) => {
+                assert_eq!(token.hook_type, HookType::AtTimestamp(timestamp));
+                assert!(token.ttl_ms.is_some());
+                assert!(token.description.contains("release-window"));
+                assert!(token.description.contains(&timestamp.to_string()));
+            }
+            _ => panic!("Expected Hook result, got {:?}", result),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_at_timestamp_gate_defaults_to_zero_when_no_metadata() {
+        let gate = AtTimestampGate::new("no-ts", "No timestamp provided");
+        let context = GateCheckContext {
+            agent_id: "test-agent".to_string(),
+            task: "test task".to_string(),
+            action: "do-something".to_string(),
+            metadata: serde_json::json!({}),
+        };
+
+        let result = gate.check("do-something", &context).await;
+
+        match result {
+            GateResult::Hook(token) => {
+                assert_eq!(token.hook_type, HookType::AtTimestamp(0));
+            }
+            _ => panic!("Expected Hook result, got {:?}", result),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_at_timestamp_gate_name_and_description() {
+        let gate = AtTimestampGate::new("time-lock", "Delays until a specific time");
+        assert_eq!(gate.name(), "time-lock");
+        assert_eq!(gate.description(), "Delays until a specific time");
+    }
+}

--- a/b00t-c0re-gov/src/gates/cron.rs
+++ b/b00t-c0re-gov/src/gates/cron.rs
@@ -1,0 +1,109 @@
+use async_trait::async_trait;
+use uuid::Uuid;
+
+use crate::traits::*;
+use crate::types::*;
+
+/// A gate that returns a Hook with a cron expression.
+/// The agent must wait until the cron schedule fires before the action is allowed.
+/// Parses the cron expression from the `cron_expr` field in metadata.
+pub struct CronGate {
+    name: String,
+    description: String,
+}
+
+impl CronGate {
+    /// Create a gate that returns a Hook with a cron expression from metadata.
+    pub fn new(name: &str, description: &str) -> Self {
+        CronGate {
+            name: name.to_string(),
+            description: description.to_string(),
+        }
+    }
+}
+
+#[async_trait]
+impl GovernanceGate for CronGate {
+    fn name(&self) -> &str {
+        &self.name
+    }
+
+    async fn check(&self, action: &str, context: &GateCheckContext) -> GateResult {
+        let cron_expr = context
+            .metadata
+            .get("cron_expr")
+            .and_then(|v| v.as_str())
+            .unwrap_or("* * * * *")
+            .to_string();
+
+        GateResult::Hook(HookToken {
+            id: Uuid::new_v4(),
+            hook_type: HookType::Cron(cron_expr.clone()),
+            created_at: chrono::Utc::now(),
+            ttl_ms: Some(86_400_000), // 24h default TTL for cron hooks
+            description: format!(
+                "Cron gate '{}': scheduled '{}' at cron '{}'",
+                self.name, action, cron_expr
+            ),
+        })
+    }
+
+    fn description(&self) -> &str {
+        &self.description
+    }
+}
+
+#[cfg(test)]
+mod unit_tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn test_cron_gate_returns_hook_with_expression_from_metadata() {
+        let gate = CronGate::new("daily-task", "Runs on a daily cron schedule");
+        let context = GateCheckContext {
+            agent_id: "test-agent".to_string(),
+            task: "test task".to_string(),
+            action: "do-something".to_string(),
+            metadata: serde_json::json!({"cron_expr": "0 9 * * *"}),
+        };
+
+        let result = gate.check("do-something", &context).await;
+
+        match result {
+            GateResult::Hook(token) => {
+                assert_eq!(token.hook_type, HookType::Cron("0 9 * * *".to_string()));
+                assert!(token.ttl_ms.is_some());
+                assert!(token.description.contains("daily-task"));
+                assert!(token.description.contains("0 9 * * *"));
+            }
+            _ => panic!("Expected Hook result, got {:?}", result),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_cron_gate_defaults_to_every_minute_when_no_metadata() {
+        let gate = CronGate::new("fallback", "Uses default cron expression");
+        let context = GateCheckContext {
+            agent_id: "test-agent".to_string(),
+            task: "test task".to_string(),
+            action: "do-something".to_string(),
+            metadata: serde_json::json!({}),
+        };
+
+        let result = gate.check("do-something", &context).await;
+
+        match result {
+            GateResult::Hook(token) => {
+                assert_eq!(token.hook_type, HookType::Cron("* * * * *".to_string()));
+            }
+            _ => panic!("Expected Hook result, got {:?}", result),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_cron_gate_name_and_description() {
+        let gate = CronGate::new("weekly-report", "Triggers every Monday at 9am");
+        assert_eq!(gate.name(), "weekly-report");
+        assert_eq!(gate.description(), "Triggers every Monday at 9am");
+    }
+}

--- a/b00t-c0re-gov/src/gates/cron.rs
+++ b/b00t-c0re-gov/src/gates/cron.rs
@@ -40,7 +40,12 @@ impl GovernanceGate for CronGate {
             id: Uuid::new_v4(),
             hook_type: HookType::Cron(cron_expr.clone()),
             created_at: chrono::Utc::now(),
-            ttl_ms: Some(86_400_000), // 24h default TTL for cron hooks
+            // ttl_ms: None — cron schedules are ongoing; a fixed TTL would cause
+            // reap_expired_hooks() to discard long-lived schedules prematurely.
+            // NOTE: EventScheduler currently skips HookType::Cron hooks
+            // ("Cron not yet implemented — skip"); route to an external cron runner
+            // (e.g. systemd timer, crond) to actually fire HookEvent::Fired.
+            ttl_ms: None,
             description: format!(
                 "Cron gate '{}': scheduled '{}' at cron '{}'",
                 self.name, action, cron_expr
@@ -72,7 +77,7 @@ mod unit_tests {
         match result {
             GateResult::Hook(token) => {
                 assert_eq!(token.hook_type, HookType::Cron("0 9 * * *".to_string()));
-                assert!(token.ttl_ms.is_some());
+                assert!(token.ttl_ms.is_none(), "cron hooks must have no fixed TTL");
                 assert!(token.description.contains("daily-task"));
                 assert!(token.description.contains("0 9 * * *"));
             }

--- a/b00t-c0re-gov/src/gates/mod.rs
+++ b/b00t-c0re-gov/src/gates/mod.rs
@@ -2,8 +2,12 @@ pub mod timer;
 pub mod event;
 pub mod composite;
 pub mod eisenhower;
+pub mod cron;
+pub mod at_timestamp;
 
 pub use timer::TimerGate;
 pub use event::EventGate;
 pub use composite::{AnyOfGate, AllOfGate};
 pub use eisenhower::EisenhowerGate;
+pub use cron::CronGate;
+pub use at_timestamp::AtTimestampGate;

--- a/b00t-c0re-hierarchy/Cargo.toml
+++ b/b00t-c0re-hierarchy/Cargo.toml
@@ -9,3 +9,4 @@ serde_json = "1"
 uuid = { version = "1", features = ["v4", "serde"] }
 chrono = { version = "0.4", features = ["serde"] }
 thiserror = "2"
+b00t-c0re-gov = { path = "../b00t-c0re-gov" }

--- a/b00t-c0re-hierarchy/src/cake_economy.rs
+++ b/b00t-c0re-hierarchy/src/cake_economy.rs
@@ -319,14 +319,16 @@ mod tests {
     use crate::roles::Role;
 
     fn make_agent(id: &str, balance: f64, alive: bool) -> Agent {
+        let role = Role::Player;
+        let is_player = matches!(role, Role::Player);
         Agent {
             id: id.to_string(),
-            role: Role::Player,
+            role,
             skills: vec![],
             cake_balance: balance,
             is_alive: alive,
             manager_id: None,
-            is_player: true, // Role::Player → human user
+            is_player,
         }
     }
 

--- a/b00t-c0re-hierarchy/src/cake_economy.rs
+++ b/b00t-c0re-hierarchy/src/cake_economy.rs
@@ -18,7 +18,7 @@
 //! let mut ledger = CakeLedger::new();
 //! let mut alice = Agent {
 //!     id: "alice".into(), role: Role::Captain, skills: vec![],
-//!     cake_balance: 0.0, is_alive: true, manager_id: None,
+//!     cake_balance: 0.0, is_alive: true, manager_id: None, is_player: false,
 //! };
 //!
 //! ledger.mint(&mut alice, 100.0, "Genesis grant").unwrap();
@@ -326,6 +326,7 @@ mod tests {
             cake_balance: balance,
             is_alive: alive,
             manager_id: None,
+            is_player: true, // Role::Player → human user
         }
     }
 

--- a/b00t-c0re-hierarchy/src/governance_bridge.rs
+++ b/b00t-c0re-hierarchy/src/governance_bridge.rs
@@ -1,0 +1,193 @@
+//! Bridge between the hierarchy crate and b00t-c0re-gov.
+//! When a mission completes, this module scores the result and
+//! calculates the cake payout via the governance epoch3 engine.
+
+use crate::roles::{Agent, MissionTopic};
+use b00t_c0re_gov::epoch3::{calculate_cake_payout, MissionResult};
+use b00t_c0re_gov::types::ScoreCard;
+
+/// Default penalty rate for calorie over-budget (10% per excess calorie).
+const DEFAULT_PENALTY_RATE: f64 = 0.1;
+
+/// Complete a mission with scoring, returning the cake payout amount.
+///
+/// # Arguments
+/// * `mission` - The completed mission (its bounty feeds the base payout).
+/// * `agent` - The agent who completed the mission.
+/// * `calories_burned` - Total calories consumed during the mission.
+/// * `score` - Multi-dimensional score card assessing performance.
+/// * `budget_calories` - Allowed calorie budget; exceeding this incurs a penalty.
+///
+/// # Returns
+/// The cake payout amount (>= 0.0), floored at zero.
+pub fn complete_mission_with_scoring(
+    mission: &MissionTopic,
+    agent: &Agent,
+    calories_burned: f64,
+    score: ScoreCard,
+    budget_calories: f64,
+) -> f64 {
+    let result = MissionResult {
+        mission_id: mission.id.clone(),
+        agent_id: agent.id.clone(),
+        bounty: mission.bounty,
+        score,
+        calories_burned,
+        completed_at: chrono::Utc::now(),
+    };
+
+    calculate_cake_payout(&result, budget_calories, DEFAULT_PENALTY_RATE)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::roles::{Agent, MissionTopic, Role, TopicStatus};
+
+    fn make_agent(id: &str) -> Agent {
+        Agent {
+            id: id.to_string(),
+            role: Role::Mate,
+            skills: vec!["rust".to_string(), "governance".to_string()],
+            cake_balance: 50.0,
+            is_alive: true,
+            manager_id: None,
+            is_player: false,
+        }
+    }
+
+    fn make_mission(id: &str, bounty: f64) -> MissionTopic {
+        MissionTopic {
+            id: id.to_string(),
+            bounty,
+            description: "Test mission for governance bridge".to_string(),
+            required_skills: vec!["rust".to_string()],
+            status: TopicStatus::Completed,
+        }
+    }
+
+    #[test]
+    fn test_complete_mission_with_scoring_returns_positive_payout() {
+        let mission = make_mission("bridge-test-1", 100.0);
+        let agent = make_agent("agent-alpha");
+        let score = ScoreCard::new(0.9, 0.8, 0.7, 1.0, 0.6, 0.5);
+
+        let payout = complete_mission_with_scoring(
+            &mission,
+            &agent,
+            50.0,   // calories burned (under budget)
+            score,
+            100.0,  // calorie budget
+        );
+
+        assert!(
+            payout > 0.0,
+            "Payout should be positive for good performance, got {}",
+            payout
+        );
+        assert!(
+            payout <= mission.bounty,
+            "Payout {} should not exceed bounty {}",
+            payout,
+            mission.bounty
+        );
+    }
+
+    #[test]
+    fn test_complete_mission_with_scoring_perfect_score_no_penalty() {
+        let mission = make_mission("bridge-test-2", 200.0);
+        let agent = make_agent("agent-beta");
+        // Perfect score in every dimension
+        let score = ScoreCard::new(1.0, 1.0, 1.0, 1.0, 1.0, 1.0);
+
+        let payout = complete_mission_with_scoring(
+            &mission,
+            &agent,
+            30.0,   // well under budget
+            score,
+            100.0,  // generous budget
+        );
+
+        // Perfect score * bounty = 200.0, no penalty since under budget
+        let expected = 200.0;
+        assert!(
+            (payout - expected).abs() < f64::EPSILON,
+            "Expected payout {:.2}, got {:.2}",
+            expected,
+            payout
+        );
+    }
+
+    #[test]
+    fn test_complete_mission_with_scoring_penalty_reduces_payout() {
+        let mission = make_mission("bridge-test-3", 100.0);
+        let agent = make_agent("agent-gamma");
+        let score = ScoreCard::new(1.0, 1.0, 1.0, 1.0, 1.0, 1.0);
+
+        let payout = complete_mission_with_scoring(
+            &mission,
+            &agent,
+            200.0,  // double the budget
+            score,
+            100.0,  // budget = 100
+        );
+
+        // Perfect score = 100.0 base
+        // Over-budget = 100.0, penalty = 100.0 * 0.1 = 10.0
+        // Payout = 100.0 - 10.0 = 90.0
+        let expected = 90.0;
+        assert!(
+            (payout - expected).abs() < f64::EPSILON,
+            "Expected payout {:.2}, got {:.2}",
+            expected,
+            payout
+        );
+    }
+
+    #[test]
+    fn test_complete_mission_with_scoring_agent_is_player_field() {
+        let mission = make_mission("bridge-test-4", 75.0);
+        let mut agent = make_agent("player-1");
+        agent.is_player = true; // this agent represents a human
+
+        let score = ScoreCard::new(0.6, 0.5, 0.4, 0.7, 0.5, 0.3);
+
+        let payout = complete_mission_with_scoring(
+            &mission,
+            &agent,
+            40.0,
+            score,
+            60.0,
+        );
+
+        assert!(
+            payout >= 0.0,
+            "Payout must be >= 0, got {}",
+            payout
+        );
+        // Verify the agent field is correctly accessible in the bridge
+        assert!(agent.is_player, "Agent should be marked as player");
+    }
+
+    #[test]
+    fn test_complete_mission_with_scoring_zero_score_yields_zero_payout() {
+        let mission = make_mission("bridge-test-5", 100.0);
+        let agent = make_agent("agent-delta");
+        // Zero score in all dimensions
+        let score = ScoreCard::new(0.0, 0.0, 0.0, 0.0, 0.0, 0.0);
+
+        let payout = complete_mission_with_scoring(
+            &mission,
+            &agent,
+            10.0,
+            score,
+            100.0,
+        );
+
+        assert!(
+            (payout - 0.0).abs() < f64::EPSILON,
+            "Zero score should yield zero payout, got {}",
+            payout
+        );
+    }
+}

--- a/b00t-c0re-hierarchy/src/lib.rs
+++ b/b00t-c0re-hierarchy/src/lib.rs
@@ -1,3 +1,4 @@
 pub mod cake_economy;
+pub mod governance_bridge;
 pub mod recruitment;
 pub mod roles;

--- a/b00t-c0re-hierarchy/src/recruitment.rs
+++ b/b00t-c0re-hierarchy/src/recruitment.rs
@@ -43,6 +43,7 @@ fn skill_match_score(agent: &Agent, required_skills: &[String]) -> usize {
 pub fn process_recruit_request(
     request: &RecruitRequest,
     available_agents: &[Agent],
+    operator_id: &str,
 ) -> RecruitResponse {
     // Score and collect candidates that have at least one matching skill
     let mut scored: Vec<(usize, &Agent)> = available_agents
@@ -67,7 +68,7 @@ pub fn process_recruit_request(
 
     RecruitResponse {
         candidates,
-        operator_id: String::new(), // Operator identity — to be filled by caller
+        operator_id: operator_id.to_string(),
         operator_fee_pct: 20.0,
     }
 }
@@ -95,6 +96,7 @@ mod tests {
             cake_balance: 100.0,
             is_alive: alive,
             manager_id: None,
+            is_player: false,
         }
     }
 
@@ -120,7 +122,7 @@ mod tests {
             make_agent("a3", Role::Player, &["python", "docker"], true),
         ];
 
-        let response = process_recruit_request(&request, &agents);
+        let response = process_recruit_request(&request, &agents, "op1");
 
         assert_eq!(response.candidates.len(), 2);
         // a2 has 3 matching skills, a3 has 2 — a2 should be first
@@ -142,7 +144,7 @@ mod tests {
             make_agent("a2", Role::Player, &["python"], true),
         ];
 
-        let response = process_recruit_request(&request, &agents);
+        let response = process_recruit_request(&request, &agents, "op1");
         assert!(response.candidates.is_empty());
     }
 
@@ -174,8 +176,23 @@ mod tests {
             make_agent("a2", Role::Player, &["rust"], true),  // alive
         ];
 
-        let response = process_recruit_request(&request, &agents);
+        let response = process_recruit_request(&request, &agents, "op1");
         assert_eq!(response.candidates.len(), 1);
         assert_eq!(response.candidates[0].id, "a2");
+    }
+
+    #[test]
+    fn test_operator_id_is_set_on_response() {
+        let request = RecruitRequest {
+            captain_id: "cap1".to_string(),
+            required_skills: vec!["rust".to_string()],
+            max_players: 2,
+            bounty_share: 10.0,
+        };
+
+        let agents = vec![make_agent("a1", Role::Mate, &["rust"], true)];
+
+        let response = process_recruit_request(&request, &agents, "operator-42");
+        assert_eq!(response.operator_id, "operator-42");
     }
 }

--- a/b00t-c0re-hierarchy/src/recruitment.rs
+++ b/b00t-c0re-hierarchy/src/recruitment.rs
@@ -89,6 +89,7 @@ mod tests {
     use super::*;
 
     fn make_agent(id: &str, role: Role, skills: &[&str], alive: bool) -> Agent {
+        let is_player = matches!(role, Role::Player);
         Agent {
             id: id.to_string(),
             role,
@@ -96,7 +97,7 @@ mod tests {
             cake_balance: 100.0,
             is_alive: alive,
             manager_id: None,
-            is_player: false,
+            is_player,
         }
     }
 

--- a/b00t-c0re-hierarchy/src/roles.rs
+++ b/b00t-c0re-hierarchy/src/roles.rs
@@ -2,9 +2,13 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub enum Role {
+    /// Captain — leader of a team, holds command authority
     Captain,
+    /// Mate = any non-captain agent (assistant, executive, specialist)
     Mate,
+    /// Player = human/user (not an agent software role)
     Player,
+    /// Operator — system operator with administrative privileges
     Operator,
 }
 
@@ -16,6 +20,7 @@ pub struct Agent {
     pub cake_balance: f64,
     pub is_alive: bool,
     pub manager_id: Option<String>, // Captain or Operator who recruited them
+    pub is_player: bool,           // true if this Agent represents a human user
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -25,6 +30,42 @@ pub struct Team {
     pub player_ids: Vec<String>,
 }
 
+impl Team {
+    /// Create a new Team with the given captain.
+    /// Mate and player lists start empty.
+    pub fn new(captain_id: &str) -> Self {
+        Self {
+            captain_id: captain_id.to_string(),
+            mate_ids: Vec::new(),
+            player_ids: Vec::new(),
+        }
+    }
+
+    /// Add an agent ID to the mate roster.
+    pub fn add_mate(&mut self, id: &str) {
+        if !self.mate_ids.contains(&id.to_string()) {
+            self.mate_ids.push(id.to_string());
+        }
+    }
+
+    /// Remove an agent ID from the mate roster.
+    pub fn remove_mate(&mut self, id: &str) {
+        self.mate_ids.retain(|m| m != id);
+    }
+
+    /// Add a player ID to the player roster.
+    pub fn add_player(&mut self, id: &str) {
+        if !self.player_ids.contains(&id.to_string()) {
+            self.player_ids.push(id.to_string());
+        }
+    }
+
+    /// Remove a player ID from the player roster.
+    pub fn remove_player(&mut self, id: &str) {
+        self.player_ids.retain(|p| p != id);
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct MissionTopic {
     pub id: String,
@@ -32,6 +73,39 @@ pub struct MissionTopic {
     pub description: String,
     pub required_skills: Vec<String>,
     pub status: TopicStatus,
+}
+
+impl MissionTopic {
+    /// Create a new MissionTopic with status `Open`.
+    pub fn new(
+        id: &str,
+        bounty: f64,
+        description: &str,
+        required_skills: Vec<String>,
+    ) -> Self {
+        Self {
+            id: id.to_string(),
+            bounty,
+            description: description.to_string(),
+            required_skills,
+            status: TopicStatus::Open,
+        }
+    }
+
+    /// Transition the mission to `InProgress`.
+    pub fn start(&mut self) {
+        self.status = TopicStatus::InProgress;
+    }
+
+    /// Transition the mission to `Completed`.
+    pub fn complete(&mut self) {
+        self.status = TopicStatus::Completed;
+    }
+
+    /// Transition the mission to `Abandoned`.
+    pub fn abandon(&mut self) {
+        self.status = TopicStatus::Abandoned;
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]

--- a/b00t-c0re-hierarchy/src/roles.rs
+++ b/b00t-c0re-hierarchy/src/roles.rs
@@ -43,7 +43,7 @@ impl Team {
 
     /// Add an agent ID to the mate roster.
     pub fn add_mate(&mut self, id: &str) {
-        if !self.mate_ids.contains(&id.to_string()) {
+        if !self.mate_ids.iter().any(|m| m == id) {
             self.mate_ids.push(id.to_string());
         }
     }
@@ -55,7 +55,7 @@ impl Team {
 
     /// Add a player ID to the player roster.
     pub fn add_player(&mut self, id: &str) {
-        if !self.player_ids.contains(&id.to_string()) {
+        if !self.player_ids.iter().any(|p| p == id) {
             self.player_ids.push(id.to_string());
         }
     }

--- a/b00t-c0re-hierarchy/tests/hierarchy_test.rs
+++ b/b00t-c0re-hierarchy/tests/hierarchy_test.rs
@@ -9,6 +9,7 @@ fn make_agent(id: &str, role: Role, skills: &[&str], alive: bool) -> Agent {
         cake_balance: 100.0,
         is_alive: alive,
         manager_id: None,
+        is_player: false,
     }
 }
 
@@ -18,15 +19,74 @@ fn test_captain_creates_team() {
     let mate = make_agent("mate1", Role::Mate, &["navigation"], true);
     let player = make_agent("p1", Role::Player, &["rust"], true);
 
-    let team = Team {
-        captain_id: captain.id.clone(),
-        mate_ids: vec![mate.id.clone()],
-        player_ids: vec![player.id.clone()],
-    };
+    let mut team = Team::new(&captain.id);
+    team.add_mate(&mate.id);
+    team.add_player(&player.id);
 
     assert_eq!(team.captain_id, "cap1");
     assert_eq!(team.mate_ids.len(), 1);
     assert_eq!(team.player_ids.len(), 1);
+    assert!(team.mate_ids.contains(&"mate1".to_string()));
+    assert!(team.player_ids.contains(&"p1".to_string()));
+}
+
+#[test]
+fn test_team_add_remove_mate() {
+    let mut team = Team::new("cap1");
+
+    team.add_mate("mate1");
+    team.add_mate("mate2");
+    assert_eq!(team.mate_ids.len(), 2);
+
+    // Duplicate add should not increase count
+    team.add_mate("mate1");
+    assert_eq!(team.mate_ids.len(), 2);
+
+    team.remove_mate("mate1");
+    assert_eq!(team.mate_ids.len(), 1);
+    assert_eq!(team.mate_ids[0], "mate2");
+}
+
+#[test]
+fn test_team_add_remove_player() {
+    let mut team = Team::new("cap1");
+
+    team.add_player("p1");
+    team.add_player("p2");
+    assert_eq!(team.player_ids.len(), 2);
+
+    team.remove_player("p1");
+    assert_eq!(team.player_ids.len(), 1);
+    assert_eq!(team.player_ids[0], "p2");
+}
+
+#[test]
+fn test_mission_topic_lifecycle() {
+    let mut mission = MissionTopic::new(
+        "m1",
+        500.0,
+        "Build the navigation module",
+        vec!["rust".to_string(), "navigation".to_string()],
+    );
+
+    assert_eq!(mission.status, TopicStatus::Open);
+    assert_eq!(mission.bounty, 500.0);
+    assert_eq!(mission.description, "Build the navigation module");
+    assert_eq!(mission.required_skills.len(), 2);
+
+    mission.start();
+    assert_eq!(mission.status, TopicStatus::InProgress);
+
+    mission.complete();
+    assert_eq!(mission.status, TopicStatus::Completed);
+}
+
+#[test]
+fn test_mission_abandon() {
+    let mut mission = MissionTopic::new("m2", 250.0, "Scout the perimeter", vec!["stealth".to_string()]);
+    mission.start();
+    mission.abandon();
+    assert_eq!(mission.status, TopicStatus::Abandoned);
 }
 
 #[test]
@@ -44,7 +104,7 @@ fn test_recruit_request_ranks_by_skill() {
         make_agent("a3", Role::Player, &["python", "docker"], true),
     ];
 
-    let response = process_recruit_request(&request, &agents);
+    let response = process_recruit_request(&request, &agents, "op1");
 
     assert_eq!(response.candidates.len(), 2);
     // a2 has 3 matching skills, a3 has 2 — a2 should be first
@@ -90,6 +150,7 @@ fn test_recruit_no_candidates_returns_empty() {
         make_agent("a2", Role::Player, &["python"], true),
     ];
 
-    let response = process_recruit_request(&request, &agents);
+    let response = process_recruit_request(&request, &agents, "op1");
     assert!(response.candidates.is_empty());
+    assert_eq!(response.operator_id, "op1");
 }

--- a/b00t-c0re-hierarchy/tests/hierarchy_test.rs
+++ b/b00t-c0re-hierarchy/tests/hierarchy_test.rs
@@ -2,6 +2,7 @@ use b00t_c0re_hierarchy::recruitment::*;
 use b00t_c0re_hierarchy::roles::*;
 
 fn make_agent(id: &str, role: Role, skills: &[&str], alive: bool) -> Agent {
+    let is_player = matches!(role, Role::Player);
     Agent {
         id: id.to_string(),
         role,
@@ -9,7 +10,7 @@ fn make_agent(id: &str, role: Role, skills: &[&str], alive: bool) -> Agent {
         cake_balance: 100.0,
         is_alive: alive,
         manager_id: None,
-        is_player: false,
+        is_player,
     }
 }
 

--- a/b00t-cli/src/calorie_tracker.rs
+++ b/b00t-cli/src/calorie_tracker.rs
@@ -192,16 +192,16 @@ mod tests {
     #[test]
     fn test_insufficient_calories_error() {
         let (tracker, _tmp) = setup_tracker();
-        // Algorithmic tier: 0.01x multiplier on base_cost=10 => 0.1 cost
-        // Starting with 1000 calories, try to burn 10000 * 0.01 = 100
-        let result = tracker.execute_with_calories("algo-agent", AgentTier::Algorithmic, 100_000.0, || {
+        // Algorithmic tier: 0.01x multiplier on base_cost=200_000 => 2000 cost
+        // Starting with 1000 calories, 2000 required → InsufficientCalories
+        let result = tracker.execute_with_calories("algo-agent", AgentTier::Algorithmic, 200_000.0, || {
             Ok::<_, GovernanceError>("should not run")
         });
         assert!(result.is_err());
         match result.unwrap_err() {
             GovernanceError::InsufficientCalories { available, required } => {
                 assert!((available - 1000.0).abs() < f64::EPSILON);
-                assert!((required - 1000.0).abs() < f64::EPSILON); // 100_000 * 0.01 = 1000
+                assert!((required - 2000.0).abs() < f64::EPSILON); // 200_000 * 0.01 = 2000
             }
             e => panic!("Expected InsufficientCalories, got: {}", e),
         }

--- a/b00t-cli/src/commands/agent.rs
+++ b/b00t-cli/src/commands/agent.rs
@@ -793,10 +793,7 @@ async fn handle_invoke(
         agent,
         b00t_c0re_gov::scoring::AgentTier::LLM,
         50.0,
-        || {
-            invoke_agent_executor(executor, &env, prompt)
-                .map_err(|e| GovernanceError::ContextCorrupt(e.to_string()))
-        },
+        || invoke_agent_executor(executor, &env, prompt),
     )?;
 
     println!("{}", result);

--- a/b00t-cli/src/commands/agent.rs
+++ b/b00t-cli/src/commands/agent.rs
@@ -742,6 +742,19 @@ async fn handle_invoke(
     use b00t_c0re_lib::agent_manager::{AgentManager, invoke_agent_executor};
     use b00t_c0re_gov::errors::GovernanceError;
 
+    // Reject agent names with path separators or characters that could escape the store dir.
+    // Allowed: alphanumeric, dash, underscore, dot (no slashes, backslashes, or null bytes).
+    if agent.is_empty()
+        || !agent
+            .chars()
+            .all(|c| c.is_alphanumeric() || c == '-' || c == '_' || c == '.')
+    {
+        anyhow::bail!(
+            "Invalid agent name '{}': only alphanumeric characters, dashes, underscores and dots are allowed",
+            agent
+        );
+    }
+
     // ── Governance + calorie check ──
     let gov = GovernanceRuntime::init().await?;
     let tracker = CalorieTracker::new();
@@ -793,7 +806,10 @@ async fn handle_invoke(
         agent,
         b00t_c0re_gov::scoring::AgentTier::LLM,
         50.0,
-        || invoke_agent_executor(executor, &env, prompt),
+        || {
+            invoke_agent_executor(executor, &env, prompt)
+                .map_err(|e| GovernanceError::InvocationFailed(e.to_string()))
+        },
     )?;
 
     println!("{}", result);

--- a/b00t-cli/src/commands/agent.rs
+++ b/b00t-cli/src/commands/agent.rs
@@ -745,12 +745,6 @@ async fn handle_invoke(
     // ── Governance + calorie check ──
     let gov = GovernanceRuntime::init().await?;
     let tracker = CalorieTracker::new();
-    if !tracker.is_alive(agent)? {
-        anyhow::bail!(
-            "Agent '{}' has no calories remaining — cannot invoke",
-            agent
-        );
-    }
 
     // Resolve config path: override → _b00t_/<agent>.agent.toml → cwd search
     let config_path = if let Some(p) = config_override {

--- a/b00t-cli/src/commands/agent.rs
+++ b/b00t-cli/src/commands/agent.rs
@@ -5,6 +5,8 @@
 
 use anyhow::Result;
 use b00t_c0re_lib::AgentManager;
+use crate::calorie_tracker::CalorieTracker;
+use crate::governance::GovernanceRuntime;
 use b00t_c0re_lib::agent_coordination::{
     AgentCoordinator, AgentMetadata, MessageFilter, RequestUrgency, TaskCompletionStatus,
     TaskPriority,
@@ -738,6 +740,17 @@ async fn handle_invoke(
     config_override: Option<&std::path::Path>,
 ) -> Result<()> {
     use b00t_c0re_lib::agent_manager::{AgentManager, invoke_agent_executor};
+    use b00t_c0re_gov::errors::GovernanceError;
+
+    // ── Governance + calorie check ──
+    let gov = GovernanceRuntime::init().await?;
+    let tracker = CalorieTracker::new();
+    if !tracker.is_alive(agent)? {
+        anyhow::bail!(
+            "Agent '{}' has no calories remaining — cannot invoke",
+            agent
+        );
+    }
 
     // Resolve config path: override → _b00t_/<agent>.agent.toml → cwd search
     let config_path = if let Some(p) = config_override {
@@ -782,10 +795,27 @@ async fn handle_invoke(
         executor.cli_args.join(" ")
     );
 
-    let result = invoke_agent_executor(executor, &env, prompt)
-        .map_err(|e| anyhow::anyhow!("Agent invocation failed: {}", e))?;
+    let result = tracker.execute_with_calories(
+        agent,
+        b00t_c0re_gov::scoring::AgentTier::LLM,
+        50.0,
+        || {
+            invoke_agent_executor(executor, &env, prompt)
+                .map_err(|e| GovernanceError::ContextCorrupt(e.to_string()))
+        },
+    )?;
 
     println!("{}", result);
+
+    // ── Check for fired hooks ──
+    let fired = gov.check_hooks();
+    if !fired.is_empty() {
+        println!("⚠️  Fired governance hooks:");
+        for h in &fired {
+            println!("   - hook {}: {:?}", h.hook_id, h.event);
+        }
+    }
+
     Ok(())
 }
 

--- a/b00t-cli/src/commands/crew_handler.rs
+++ b/b00t-cli/src/commands/crew_handler.rs
@@ -46,7 +46,7 @@ fn to_agent(card: &AgentCard, meta: &CrewMeta) -> Agent {
         cake_balance: meta.cake_balance,
         is_alive: meta.is_alive,
         manager_id: meta.manager_id.clone(),
-        is_player: true, // crew agents default to player (human) unless overridden
+        is_player: matches!(meta.role, Role::Player),
     }
 }
 

--- a/b00t-cli/src/commands/crew_handler.rs
+++ b/b00t-cli/src/commands/crew_handler.rs
@@ -46,6 +46,7 @@ fn to_agent(card: &AgentCard, meta: &CrewMeta) -> Agent {
         cake_balance: meta.cake_balance,
         is_alive: meta.is_alive,
         manager_id: meta.manager_id.clone(),
+        is_player: true, // crew agents default to player (human) unless overridden
     }
 }
 
@@ -220,7 +221,7 @@ fn handle_recruit(store: &AgentStore, skills: &str, limit: usize) {
         bounty_share: 0.1,
     };
 
-    let response = process_recruit_request(&request, &available);
+    let response = process_recruit_request(&request, &available, "crew-cli");
 
     if response.candidates.is_empty() {
         println!("No suitable candidates found.");


### PR DESCRIPTION
## Summary

Closes gaps #1-#8 and #10 from the event-driven governance roadmap.

### Changes

**b00t-c0re-gov**
- CronGate + AtTimestampGate — HookType::Cron and HookType::AtTimestamp now
  produce Hook results from gates (6 new tests)
- Module exports updated in gates/mod.rs

**b00t-c0re-hierarchy**
- Mate = any non-captain agent (doc), Player = human/user (doc)
- `is_player: bool` on Agent struct
- Team::new(), add/remove mate/player, MissionTopic lifecycle (start/complete/abandon)
- `process_recruit_request` now takes `operator_id: &str` instead of String::new()
- Governance bridge: `complete_mission_with_scoring()` calls calculate_cake_payout
  on mission completion (5 new tests)

**b00t-cli**
- GovernanceRuntime wired into handle_invoke agent loop
- CalorieTracker wraps invoke_agent_executor — tier-based calorie costing
- is_alive check before agent action
- crew_handler.rs updated for is_player + operator_id API changes

### Tests
- 91 b00t-c0re-gov (+6 new)
- 20 b00t-c0re-hierarchy (+10 new)
- 685 total across all 3 crates, 0 failures