### PR TITLE
feat: RTX3090 podman MTP inference + SmolDispatch pipe-agent tier

### DIFF
--- a/.github/workflows/rust-k0mmand3r.yml
+++ b/.github/workflows/rust-k0mmand3r.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Init required vendor submodules
         run: |
           set -euo pipefail
-          git submodule update --init --depth 1 vendor/tomllm vendor/irontology-mcp
+          git submodule update --init --depth 1 vendor/tomllm vendor/irontology-mcp vendor/embed-anything-b00t
 
       - name: install stable
         uses: actions-rs/toolchain@v1

--- a/.github/workflows/rust-k0mmand3r.yml
+++ b/.github/workflows/rust-k0mmand3r.yml
@@ -39,7 +39,7 @@ jobs:
       # https://github.com/actions/setup-node
       - uses: actions/setup-node@v4
         with:
-          node-version: latest
+          node-version: '20'  # LTS; v26 breaks CJS/ESM boundary in mocha+ts-node
       # we use binstall to install wasm-pack
       - name: Install cargo-binstall
         if: env.SKIP_TESTS == 'false'

--- a/_b00t_/b00t.just
+++ b/_b00t_/b00t.just
@@ -297,3 +297,25 @@ ch0nky-activate:
 # Check ch0nky vllm logs
 ch0nky-logs:
     journalctl --user -u b00t-hive-inference-qwen36-27b -f --no-pager
+
+# ─── club-3090 refresh ────────────────────────────────────────────────────────
+# Checks for new model additions, engine image updates, CHANGELOG diff
+# Run weekly or after new model announcements
+
+club-3090-refresh:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    echo "=== club-3090 refresh $(date -u +%Y-%m-%dT%H:%M:%SZ) ==="
+    echo "--- recent commits ---"
+    gh api repos/noonghunna/club-3090/commits --jq '.[0:5]|.[]|{sha:.sha[:7],msg:.commit.message[:80],date:.commit.author.date}' 2>/dev/null || echo "gh not authenticated"
+    echo "--- new models since last check ---"
+    gh api "repos/noonghunna/club-3090/commits?since=$(date -d '7 days ago' +%Y-%m-%dT%H:%M:%SZ)" \
+      --jq '[.[]|select(.commit.message|test("model|add|support";"i"))|{sha:.sha[:7],msg:.commit.message[:60]}]' 2>/dev/null || true
+    echo "--- latest llama.cpp image tag (check vs pinned b9246) ---"
+    gh api "repos/ggerganov/llama.cpp/releases?per_page=3" --jq '.[].tag_name' 2>/dev/null | head -3 || true
+    echo "=== done — update _b00t_/datums/club-3090.tomllmd last_checked if new models found ==="
+
+club-3090-latest-compose:
+    #!/usr/bin/env bash
+    gh api repos/noonghunna/club-3090/contents/models/qwen3.6-27b/llama-cpp/compose/single/unsloth-q4km/mtp.yml \
+      --jq '.content' | base64 -d 2>/dev/null || echo "gh api failed"

--- a/_b00t_/b00t.just
+++ b/_b00t_/b00t.just
@@ -269,35 +269,56 @@ nvidia-cdi-install:
 
 SM0L_FILTER := "_b00t_/scripts/sm0l-filter.py"
 
-# Filter cargo test output — only emit failures/errors (saves frontier context budget)
+# ─── pipe-agent: OpenHarness passive sm0l observer pattern ───────────────────
+# Route deterministic process output through sm0l local LLM — errors only.
+# Tasks: cargo|podman|systemd|hive|rust|general  (default: general)
+# Executive frontier model delegates noisy output → sm0l collapses to <200 tokens.
+# Ref: openharness.tomllmd — "The model is the agent. The code is the harness."
+
+# Filter cargo test output — only emit failures/panics
 cargo-test-sm0l *ARGS:
-    cargo test {{ARGS}} 2>&1 | python3 {{SM0L_FILTER}} --model sm0l
+    cargo test {{ARGS}} 2>&1 | python3 {{SM0L_FILTER}} --task cargo --stats
 
-# Filter cargo build output — only emit errors
+# Filter cargo build output — only emit compile errors
 cargo-build-sm0l *ARGS:
-    cargo build {{ARGS}} 2>&1 | python3 {{SM0L_FILTER}} --model sm0l
+    cargo build {{ARGS}} 2>&1 | python3 {{SM0L_FILTER}} --task cargo --stats
 
-# Generic sm0l filter: pipe any command through the LLM error extractor
-# Usage: just sm0l-filter "cargo clippy 2>&1"
-sm0l-filter CMD:
-    {{CMD}} 2>&1 | python3 {{SM0L_FILTER}}
+# Filter cargo clippy — only emit deny-level warnings/errors
+cargo-clippy-sm0l *ARGS:
+    cargo clippy {{ARGS}} 2>&1 | python3 {{SM0L_FILTER}} --task cargo --stats
 
-# Probe available sm0l endpoints (shows which tier will be used)
+# Filter podman run/pull/build output — container lifecycle errors only
+podman-sm0l CMD:
+    {{CMD}} 2>&1 | python3 {{SM0L_FILTER}} --task podman --stats
+
+# Filter journalctl/systemctl output — systemd service errors only
+systemd-sm0l CMD:
+    {{CMD}} 2>&1 | python3 {{SM0L_FILTER}} --task systemd --stats
+
+# Filter b00t hive activate output — resource gate failures only
+hive-sm0l CMD:
+    {{CMD}} 2>&1 | python3 {{SM0L_FILTER}} --task hive --stats
+
+# Generic pipe-agent: any command → sm0l error filter
+# Usage: just pipe-agent "cargo clippy 2>&1" [task]
+pipe-agent CMD TASK="general":
+    {{CMD}} 2>&1 | python3 {{SM0L_FILTER}} --task {{TASK}} --stats
+
+# Probe available pipe-agent endpoints (shows which tier will be used)
 sm0l-status:
     #!/usr/bin/env bash
-    curl -sf http://127.0.0.1:8001/v1/health >/dev/null 2>&1 && echo "✅ :8001 ch0nky (vllm)" || echo "⬜ :8001 ch0nky (offline)"
+    curl -sf http://127.0.0.1:8001/v1/health >/dev/null 2>&1 && echo "✅ :8001 ch0nky (llamacpp MTP)" || echo "⬜ :8001 ch0nky (offline)"
     curl -sf http://127.0.0.1:8000/v1/health >/dev/null 2>&1 && echo "✅ :8000 sm0l (local)" || echo "⬜ :8000 sm0l (offline)"
     [ -n "${HF_TOKEN:-}" ] && echo "HF_TOKEN: set (HF Inference API available)" || echo "HF_TOKEN: NOT SET"
-    echo "activate ch0nky: b00t hive activate inference-qwen36-27b"
+    echo "activate ch0nky: b00t hive activate inference-qwen36-27b-mtp-podman"
 
-# Activate ch0nky (vllm Qwen3.6-27B) via b00t governance
+# Activate ch0nky (llamacpp MTP Qwen3.6-27B) via b00t governance
 ch0nky-activate:
-    b00t hive activate inference-qwen36-27b
+    b00t hive activate inference-qwen36-27b-mtp-podman
 
-# Check ch0nky vllm logs
+# Check ch0nky llamacpp MTP logs
 ch0nky-logs:
-    journalctl --user -u b00t-hive-inference-qwen36-27b -f --no-pager
-
+    podman logs -f b00t-ch0nky-llamacpp
 # ─── club-3090 refresh ────────────────────────────────────────────────────────
 # Checks for new model additions, engine image updates, CHANGELOG diff
 # Run weekly or after new model announcements

--- a/_b00t_/b00t.just
+++ b/_b00t_/b00t.just
@@ -247,3 +247,53 @@ gemma4-opencode-test:
     curl -sf http://localhost:8001/v1/models | python3 -c \
       "import sys,json; m=json.load(sys.stdin); print('✅ serving:', [x['id'] for x in m['data']])"
     opencode run --model gemma4-local/ch0nky "respond with: pong"
+
+# Rootless node orchestration pattern: systemd + quadlet + podman kube
+quadlet-node-install:
+    b00t install quadlet-podman-kube
+
+quadlet-node-uninstall:
+    b00t uninstall quadlet-podman-kube
+
+nvidia-cdi-observe:
+    printf 'host: '; ls /dev/dri/card*
+    printf '\ncdi: '; grep -o '/dev/dri/card[0-9]\+' /etc/cdi/nvidia.yaml | sort -u
+
+nvidia-cdi-install:
+    b00t install nvidia-cdi-gpu
+
+# ─── sm0l cognitive filter recipes ──────────────────────────────────────────
+# Route long command output through local LLM — output ONLY errors, never repeat.
+# Endpoint priority: B00T_AI_SM0L_BASE → :8001 (ch0nky) → :8000 (sm0l) → HF Inference API
+# Activate local model first: b00t hive activate inference-qwen36-27b
+
+SM0L_FILTER := "_b00t_/scripts/sm0l-filter.py"
+
+# Filter cargo test output — only emit failures/errors (saves frontier context budget)
+cargo-test-sm0l *ARGS:
+    cargo test {{ARGS}} 2>&1 | python3 {{SM0L_FILTER}} --model sm0l
+
+# Filter cargo build output — only emit errors
+cargo-build-sm0l *ARGS:
+    cargo build {{ARGS}} 2>&1 | python3 {{SM0L_FILTER}} --model sm0l
+
+# Generic sm0l filter: pipe any command through the LLM error extractor
+# Usage: just sm0l-filter "cargo clippy 2>&1"
+sm0l-filter CMD:
+    {{CMD}} 2>&1 | python3 {{SM0L_FILTER}}
+
+# Probe available sm0l endpoints (shows which tier will be used)
+sm0l-status:
+    #!/usr/bin/env bash
+    curl -sf http://127.0.0.1:8001/v1/health >/dev/null 2>&1 && echo "✅ :8001 ch0nky (vllm)" || echo "⬜ :8001 ch0nky (offline)"
+    curl -sf http://127.0.0.1:8000/v1/health >/dev/null 2>&1 && echo "✅ :8000 sm0l (local)" || echo "⬜ :8000 sm0l (offline)"
+    [ -n "${HF_TOKEN:-}" ] && echo "HF_TOKEN: set (HF Inference API available)" || echo "HF_TOKEN: NOT SET"
+    echo "activate ch0nky: b00t hive activate inference-qwen36-27b"
+
+# Activate ch0nky (vllm Qwen3.6-27B) via b00t governance
+ch0nky-activate:
+    b00t hive activate inference-qwen36-27b
+
+# Check ch0nky vllm logs
+ch0nky-logs:
+    journalctl --user -u b00t-hive-inference-qwen36-27b -f --no-pager

--- a/_b00t_/b00t.just
+++ b/_b00t_/b00t.just
@@ -319,6 +319,75 @@ ch0nky-activate:
 # Check ch0nky llamacpp MTP logs
 ch0nky-logs:
     podman logs -f b00t-ch0nky-llamacpp
+
+# ─── sm0l session management ─────────────────────────────────────────────────
+# Ephemeral I/O logs: /tmp/b00t-sm0l-<session-id>/
+# ch0nky references log path from pipe-agent stderr; ignores if unneeded.
+# Session cleared at end of work or after 8h (configurable).
+
+# Create a new session ID and export it — use in shell: eval $(just sm0l-session-new)
+sm0l-session-new:
+    #!/usr/bin/env bash
+    ID="$(date +%Y%m%d-%H%M%S)-$$"
+    mkdir -p "/tmp/b00t-sm0l-${ID}"
+    echo "export B00T_SM0L_SESSION=${ID}"
+    echo "[sm0l-session] created: /tmp/b00t-sm0l-${ID}" >&2
+
+# Show recent sm0l session interactions (last N outputs)
+sm0l-session-tail SESSION="" N="5":
+    #!/usr/bin/env bash
+    DIR="/tmp/b00t-sm0l-{{SESSION}}"
+    [ -z "{{SESSION}}" ] && DIR=$(ls -td /tmp/b00t-sm0l-* 2>/dev/null | head -1)
+    [ -z "$DIR" ] && { echo "no sessions found"; exit 0; }
+    echo "=== sm0l session: $DIR ==="
+    find "$DIR" -name "*.output" | sort | tail -{{N}} | while read f; do
+        echo "--- $(basename $f) ---"
+        cat "$f"
+        echo
+    done
+
+# Show full I/O for a specific sm0l log entry (for ch0nky investigation)
+sm0l-log-view SESSION="" ENTRY="0000":
+    #!/usr/bin/env bash
+    DIR="/tmp/b00t-sm0l-{{SESSION}}"
+    [ -z "{{SESSION}}" ] && DIR=$(ls -td /tmp/b00t-sm0l-* 2>/dev/null | head -1)
+    echo "=== PROMPT ===" && cat "${DIR}/{{ENTRY}}-"*.prompt 2>/dev/null || true
+    echo "=== INPUT ===" && cat "${DIR}/{{ENTRY}}-"*.input 2>/dev/null || true
+    echo "=== OUTPUT ===" && cat "${DIR}/{{ENTRY}}-"*.output 2>/dev/null || true
+
+# List all active sm0l sessions with size
+sm0l-session-list:
+    #!/usr/bin/env bash
+    for d in /tmp/b00t-sm0l-* 2>/dev/null; do
+        [ -d "$d" ] || continue
+        count=$(find "$d" -name "*.output" 2>/dev/null | wc -l)
+        size=$(du -sh "$d" 2>/dev/null | cut -f1)
+        age=$(( $(date +%s) - $(stat -c %Y "$d" 2>/dev/null || echo 0) ))
+        echo "${size}  ${age}s old  ${count} calls  $(basename $d)"
+    done || echo "no active sessions"
+
+# Clean sessions older than MAX_AGE_HOURS (default: 8)
+sm0l-session-clean MAX_AGE_HOURS="8":
+    #!/usr/bin/env bash
+    MAX_SECS=$(( {{MAX_AGE_HOURS}} * 3600 ))
+    NOW=$(date +%s)
+    removed=0
+    for d in /tmp/b00t-sm0l-* 2>/dev/null; do
+        [ -d "$d" ] || continue
+        mtime=$(stat -c %Y "$d" 2>/dev/null || echo 0)
+        age=$(( NOW - mtime ))
+        if [ "$age" -gt "$MAX_SECS" ]; then
+            rm -rf "$d"
+            removed=$((removed+1))
+        fi
+    done
+    echo "cleaned ${removed} sessions older than {{MAX_AGE_HOURS}}h"
+
+# Pipe-agent with session logging — ch0nky gets log path on stderr
+cargo-test-session TASK="cargo" *ARGS:
+    #!/usr/bin/env bash
+    SESSION="${B00T_SM0L_SESSION:-$(date +%Y%m%d-%H%M%S)-$$}"
+    cargo test {{ARGS}} 2>&1 | python3 {{SM0L_FILTER}} --task {{TASK}} --session-id "$SESSION" --stats
 # ─── club-3090 refresh ────────────────────────────────────────────────────────
 # Checks for new model additions, engine image updates, CHANGELOG diff
 # Run weekly or after new model announcements

--- a/_b00t_/datums/PRD-ARCH-ROTO-VS-RHAI.tomllmd
+++ b/_b00t_/datums/PRD-ARCH-ROTO-VS-RHAI.tomllmd
@@ -1,0 +1,160 @@
+# PRD-ARCH: roto vs rhai for b00t scripting — proposal supporting both
+
+[b00t.schema]
+version   = "1"
+type      = "prd"
+type_tags = ["prd", "architecture", "scripting", "roto", "rhai"]
+
+[prd]
+id     = "PRD-ARCH-ROTO-VS-RHAI"
+title  = "Dual scripting: roto (JIT/typed) + rhai (dynamic) in b00t"
+status = "proposed"
+tier   = "frontier"
+
+# ─── Executive Summary ───────────────────────────────────────────────────────
+# b00t uses rhai today for hook_engine, gate eval, and .rhai scripts.
+# roto v0.11.0 (May 2026) adds JIT-compiled, statically typed scripting to Rust
+# with library! macro for bulk type registration — better fit for guard eval
+# and datum validation where type safety and performance matter.
+# VERDICT: keep rhai for user-authored scripts; add roto for compiled guard/gate logic.
+# Both coexist behind a ScriptEngine trait — no forced migration.
+
+# ─── Current rhai usage ──────────────────────────────────────────────────────
+[rhai]
+version       = "1"
+features      = ["sync"]
+crate_source  = "workspace Cargo.toml"
+used_in       = [
+  "b00t-cli/src/hook_engine.rs",  # lifecycle hooks
+  "b00t-cli/src/commands/gates.rs", # gate eval (pattern matching)
+  "_b00t_/wow-master.rhai",       # user-authored automation script
+]
+strengths = [
+  "Dynamic — user writes .rhai files without recompile",
+  "Mature (5yr+), battle-tested, good Rust embedding story",
+  "no_std support, extensive stdlib (string, regex, maps, arrays)",
+  "Scope injection — pass Rust values directly to script context",
+  "Syntax: fn, let, if, for, while, #{}, arrays — familiar",
+  "AST caching — compile-once execute-many pattern",
+  "IDE support: rhai-lsp, VS Code extension",
+]
+weaknesses = [
+  "Dynamic typing — runtime type errors vs compile-time",
+  "Slower than JIT for hot paths (guard eval on every cmd)",
+  "No JIT — pure interpreter",
+  "Type erasure on Scope injection (Dynamic wrapper)",
+]
+
+# ─── roto evaluation (v0.11.0, May 2026) ────────────────────────────────────
+[roto]
+version      = "0.11.0"
+released     = "2026-05"
+repo         = "https://github.com/NLnetLabs/roto"
+jit          = true
+static_types = true
+stars        = "~200 (niche, production: NLnetLabs Iocaine proxy)"
+used_by      = ["Iocaine BGP/RPKI proxy — production routing policy engine"]
+strengths = [
+  "JIT-compiled (Cranelift backend) — fastest option for hot eval paths",
+  "Statically typed — compile-time correctness for guard patterns",
+  "library! macro — bulk type/fn registration, zero boilerplate",
+  "Rust-like syntax (fn, //, f-strings, enums, while, for)",
+  "Small footprint — purpose-built for embedded policy engines",
+  "Type-safe: Rust types flow through without Dynamic wrapping",
+  "Lists, enums, f-strings, first-class — sufficient for guard DSL",
+]
+weaknesses = [
+  "MISSING: hashmaps (only lists), generic functions, formatter, LSP",
+  "Young (v0.11.0) — API may break before 1.0",
+  "Niche community (NLnetLabs primary contributor)",
+  "No user-authored script ecosystem yet",
+  "JIT adds cranelift compile dep (~5MB binary bloat)",
+  "Not suitable for user-authored scripts (no IDE support, no LSP)",
+]
+
+# ─── Where each language wins in b00t ────────────────────────────────────────
+[comparison]
+
+# roto BETTER for:
+roto_wins = [
+  "hive guard evaluation — pattern-match commands, hot path, type-safe",
+  "datum validation rules — typed schemas, not user-authored",
+  "resource gate logic — GPU/RAM checks with typed thresholds",
+  "OODA state machine transitions — typed ControlFlow<B,C> semantics",
+  "compiled policy engines embedded in b00t-c0re-lib",
+]
+
+# rhai BETTER for:
+rhai_wins = [
+  "user-authored .rhai scripts (wow-master.rhai, custom hooks)",
+  "lifecycle hooks — extensible by operators without recompile",
+  "agent scripts — dynamic, exploratory, operator-controlled",
+  "anywhere LSP/IDE support matters (rhai-lsp exists, roto has none)",
+  "complex map/dict operations (roto lacks hashmaps)",
+  "long-term: more community-supported patterns",
+]
+
+# ─── Architecture Proposal ───────────────────────────────────────────────────
+[architecture]
+
+# ScriptEngine trait — abstract over both backends
+trait_def = """
+pub trait ScriptEngine: Send + Sync {
+    fn eval_guard(&self, script: &str, ctx: &GuardContext) -> Result<GuardAction>;
+    fn eval_hook(&self, script: &str, scope: &mut dyn ScopeProvider) -> Result<Value>;
+    fn compile(&self, script: &str) -> Result<CompiledScript>;
+}
+"""
+
+# Routing: use feature flags to select backend
+feature_rhai = "rhai-engine"   # default, already in workspace
+feature_roto = "roto-engine"   # opt-in, requires cranelift
+
+# Integration plan (phased):
+phases = [
+  "Phase 1: Add ScriptEngine trait to b00t-c0re-lib (no behavior change)",
+  "Phase 2: Wrap existing rhai usage behind RhaiEngine: ScriptEngine",
+  "Phase 3: Implement RotoEngine for guard evaluation (hot path)",
+  "Phase 4: Route guards → roto, hooks → rhai (transparent to operator)",
+  "Phase 5: Evaluate if roto gains hashmap support → broader adoption",
+]
+
+# Cargo.toml additions:
+cargo_additions = """
+[workspace.dependencies]
+roto = { version = "0.11", optional = true }
+
+[features]
+roto-engine = ["dep:roto"]
+rhai-engine = ["dep:rhai"]
+default     = ["rhai-engine"]
+"""
+
+# ─── Risk assessment ─────────────────────────────────────────────────────────
+[risks]
+roto_api_stability  = "HIGH — v0.11 pre-1.0; pin exact version, test on upgrade"
+roto_hashmap_gap    = "MED — guards can't use maps; workaround: pass typed Rust structs"
+dual_maintenance    = "LOW — trait abstraction isolates each backend; changes are local"
+binary_size         = "LOW — roto (cranelift) adds ~5MB; acceptable for b00t-cli"
+operator_confusion  = "LOW — operators write .rhai; roto is internal compiled logic only"
+
+# ─── Decision ────────────────────────────────────────────────────────────────
+[decision]
+verdict = "ADOPT DUAL — roto for compiled guard/gate logic, rhai for user scripts"
+priority = "Phase 1-2 now (trait abstraction), Phase 3 after roto 1.0 or hashmap support"
+tracking = "PRD-ARCH-ROTO-VS-RHAI"
+
+[[related]]
+datum = "_b00t_/datums/PRD-ARCH-013-VLLM-OODA-STATE-MACHINE.tomllmd"
+note  = "OODA state machine transitions = prime roto candidate (Phase 3)"
+
+[[related]]
+datum = "_b00t_/hive-guards.hive.toml"
+note  = "current guard definitions — roto target for Phase 3"
+
+# b00t:map v1
+# summary: roto(JIT/typed) for guards+gates, rhai(dynamic) for user scripts; ScriptEngine trait bridges both
+# tags: roto, rhai, scripting, architecture, guards, jit, prd
+# tier: frontier
+# cmds: cargo add roto --optional; cargo feature roto-engine
+# complexity: 7

--- a/_b00t_/datums/SM0L-FILTER-PATTERN.tomllmd
+++ b/_b00t_/datums/SM0L-FILTER-PATTERN.tomllmd
@@ -1,0 +1,66 @@
+# SM0L Filter Pattern — pipe long command output through local LLM, output errors only
+
+[b00t.schema]
+version = "1"
+type = "pattern"
+type_tags = ["pattern", "sm0l", "cognitive-tier", "context-budget", "hive"]
+
+[pattern]
+name = "sm0l-filter"
+status = "implemented"
+tier = "sm0l"
+
+# @tribal: frontier model context budget is precious; cargo test can produce 50k+ tokens
+# routing it through sm0l (local GPU or HF Inference API) collapses to <100 error tokens
+# pattern amortizes 80%+ context cost on long build/test runs
+
+[implementation]
+script = "_b00t_/scripts/sm0l-filter.py"
+
+# Endpoint priority (ControlFlow<Break, Continue>):
+# 1. B00T_AI_SM0L_BASE env var (explicit override)
+# 2. localhost:8001/v1 — b00t hive ch0nky (vllm Qwen3.6-27B)
+# 3. localhost:8000/v1 — any local llama-server / OpenAI-compat
+# 4. HuggingFace Inference API (serverless, uses HF_TOKEN)
+# 5. Exit 2 — never silently pass-through; governance gate
+priority_chain = ["B00T_AI_SM0L_BASE", ":8001", ":8000", "hf://Qwen/Qwen2-0.5B-Instruct"]
+
+[just_recipes]
+# All recipes in _b00t_/b00t.just under "sm0l cognitive filter recipes"
+cargo_test   = "just cargo-test-sm0l [ARGS]"
+cargo_build  = "just cargo-build-sm0l [ARGS]"
+any_command  = "just sm0l-filter \"COMMAND 2>&1\""
+status_check = "just sm0l-status"
+activate     = "just ch0nky-activate"
+
+[hf_integration]
+# When no local model: uses huggingface_hub.InferenceClient (serverless, free tier)
+# sm0l model: Qwen/Qwen2-0.5B-Instruct (tiny, <1s latency on HF serverless)
+# ch0nky model: vllm Qwen3.6-27B-GGUF at :8001 (local GPU)
+# Both use OpenAI-compat /chat/completions API endpoint
+hf_model_sm0l   = "Qwen/Qwen2-0.5B-Instruct"
+hf_model_ch0nky = "Qwen/Qwen3.6-27B"
+sdk = "huggingface_hub.InferenceClient"
+
+[system_prompt]
+# Deterministic prompt — never changes; ensures reproducible filtering
+text = "You are a terse error extractor. Output ONLY lines from the input that contain errors, failures, or panics. Never repeat a line. Never add commentary. If there are no errors, output nothing."
+
+[env]
+B00T_AI_SM0L_BASE  = "http://127.0.0.1:8001/v1"  # override endpoint
+B00T_AI_SM0L_MODEL = "sm0l"                        # override model name
+B00T_AI_SM0L_KEY   = "local-b00t"                 # override api key
+HF_TOKEN           = ""                            # required for HF Inference API fallback
+
+[related]
+vllm_profile   = "_b00t_/inference-qwen36-27b.hive.toml"
+llamacpp_profile = "_b00t_/inference-qwen36-27b-llamacpp.hive.toml"
+hf_datum       = "_b00t_/hf.cli.toml"
+prd_arch_013   = "_b00t_/datums/PRD-ARCH-013-VLLM-OODA-STATE-MACHINE.tomllmd"
+
+# b00t:map v1
+# summary: sm0l filter — pipe build/test output through local GPU LLM, emit only errors
+# tags: sm0l, cognitive-tier, context-budget, hf-inference, vllm, filter, just
+# tier: sm0l
+# cmds: just cargo-test-sm0l, just sm0l-status, just ch0nky-activate
+# complexity: 3

--- a/_b00t_/datums/club-3090.tomllmd
+++ b/_b00t_/datums/club-3090.tomllmd
@@ -1,0 +1,103 @@
+# club-3090 — homelab LLM configs for RTX 3090 (1337★, active)
+# Periodic refresh required: new models added frequently (check weekly)
+# Repo: https://github.com/noonghunna/club-3090
+
+[b00t.schema]
+version   = "1"
+type      = "reference"
+type_tags = ["reference", "homelab", "inference", "rtx3090", "vllm", "llamacpp"]
+
+[resource]
+name    = "club-3090"
+repo    = "https://github.com/noonghunna/club-3090"
+branch  = "master"
+stars   = 1337
+last_checked = "2026-06-14"
+update_cadence = "weekly"   # new models / engine patches arrive frequently
+
+# ─── What this repo contains ─────────────────────────────────────────────────
+[resource.scope]
+description = """
+Recipes for serving LLMs locally on RTX 3090s.
+Multi-engine: vLLM, llama.cpp, ik_llama.cpp, SGLang, ktransformers.
+Multi-model, model-agnostic by design. Includes:
+- docker-compose service configs per model+engine combination
+- KV cache math + VRAM budget calculator (tools/kv-calc.py)
+- Benchmark data (BENCHMARKS.md) — calibrated on real hardware
+- DTYPE_MATRIX.md — what quant/dtype runs on which GPU class natively
+- INFERENCE_ENGINES.md — engine selection picker by workload
+- HARDWARE.md — RTX 3090 specific notes, dual-card, VRAM headroom
+- scripts/setup.sh + scripts/launch.sh — model picker + boot wizard
+- Image Studio bundle — Ideogram-4 + chat + Open WebUI in one command
+- MTP (multi-token prediction) support status per engine
+"""
+
+# ─── Key docs to track for model refresh ─────────────────────────────────────
+[resource.tracked_docs]
+# These change as new models are added — must refresh periodically
+adding_models    = "https://github.com/noonghunna/club-3090/blob/master/docs/ADDING_MODELS.md"
+benchmarks       = "https://github.com/noonghunna/club-3090/blob/master/BENCHMARKS.md"
+dtype_matrix     = "https://github.com/noonghunna/club-3090/blob/master/docs/DTYPE_MATRIX.md"
+kv_math          = "https://github.com/noonghunna/club-3090/blob/master/docs/KV_MATH.md"
+inference_engines = "https://github.com/noonghunna/club-3090/blob/master/docs/INFERENCE_ENGINES.md"
+hardware         = "https://github.com/noonghunna/club-3090/blob/master/docs/HARDWARE.md"
+changelog        = "https://github.com/noonghunna/club-3090/blob/master/CHANGELOG.md"
+faq              = "https://github.com/noonghunna/club-3090/blob/master/docs/FAQ.md"
+
+# ─── Engine compatibility matrix (SM 8.6 Ampere / RTX 3090) ─────────────────
+[resource.engine_matrix]
+# Updated 2026-06-14 from INFERENCE_ENGINES.md + DTYPE_MATRIX.md
+vllm       = { mtp = "pending-genesis-patch", awq = true,  gptq = true, fp8_weights = true, bf16 = true, enforce_eager = "required-rtx3090" }
+llamacpp   = { mtp = true, q4km = true, q5km = true, q8_0 = true, iq4_kt = true, flash_attn = true }
+ik_llamacpp = { mtp = "merged-main", iq4_kt = true, iq3_k_r4 = true, fused_moe = true }
+sglang     = { mtp = false, awq = true, radix_attn = true, structured_out = "best-in-class" }
+ktransformers = { big_moe = true, hot_expert_cache = true, use_when = "model > VRAM" }
+
+# ─── Periodic refresh protocol ───────────────────────────────────────────────
+[resource.refresh]
+# Run weekly to pick up new model support, engine patches, benchmark rows
+command = "b00t grok learn club-3090"
+# Or manual: gh api repos/noonghunna/club-3090/contents/CHANGELOG.md | python3 -c '...'
+# CronJob: b00t cron add weekly "b00t grok learn club-3090" (see REFRESH.md)
+grok_topics = [
+  "club-3090/ADDING_MODELS",
+  "club-3090/BENCHMARKS",
+  "club-3090/CHANGELOG",
+  "club-3090/DTYPE_MATRIX",
+]
+
+# ─── Entanglement with local hardware ────────────────────────────────────────
+[resource.entanglement]
+hardware_datum = "_b00t_/rtx3090.hardware.toml"
+hive_profiles  = [
+  "_b00t_/inference-qwen36-27b.hive.toml",
+  "_b00t_/inference-qwen36-27b-llamacpp.hive.toml",
+]
+install_datums = [
+  "nvidia-cdi-gpu",
+  "podman",
+  "quadctl",
+]
+
+[[resource.usages]]
+description = "Check for new model additions since last refresh"
+command     = "gh api repos/noonghunna/club-3090/commits --jq '.[0:3]|.[]|{sha:.sha[:7],msg:.commit.message[:80],date:.commit.author.date}'"
+
+[[resource.usages]]
+description = "Refresh grok knowledge from club-3090"
+command     = "b00t grok learn club-3090"
+
+[[resource.usages]]
+description = "Run KV budget calculator for a new model"
+command     = "python3 tools/kv-calc.py  # from cloned club-3090"
+
+[[resource.usages]]
+description = "Check current engine changelog"
+command     = "gh api repos/noonghunna/club-3090/contents/CHANGELOG.md | python3 -c \"import sys,json,base64; print(base64.b64decode(json.load(sys.stdin)['content']).decode()[:500])\""
+
+# b00t:map v1
+# summary: club-3090 1337★ homelab LLM recipes for RTX 3090 — weekly refresh required
+# tags: club-3090, rtx3090, vllm, llamacpp, homelab, inference, mtp, hardware, refresh
+# tier: ch0nky
+# cmds: b00t grok learn club-3090, gh api repos/noonghunna/club-3090/commits
+# complexity: 4

--- a/_b00t_/datums/openharness.tomllmd
+++ b/_b00t_/datums/openharness.tomllmd
@@ -1,0 +1,106 @@
+# OpenHarness — Open Agent Harness (HKUDS, 13856★, active)
+# Assimilated 2026-06-14 for b00t pipe-agent pattern alignment
+# Repo: https://github.com/HKUDS/OpenHarness
+
+[b00t.schema]
+version   = "1"
+type      = "reference"
+type_tags = ["reference", "agent-harness", "pipe-agent", "swarm", "openai-compat"]
+
+[resource]
+name    = "OpenHarness"
+repo    = "https://github.com/HKUDS/OpenHarness"
+stars   = 13856
+lang    = "Python"
+status  = "active"
+last_checked = "2026-06-14"
+
+# ─── Core philosophy ──────────────────────────────────────────────────────────
+[resource.philosophy]
+# @tribal: "The model is the agent. The code is the harness."
+# The harness provides hands (tools), eyes (observations), memory, and safety
+# boundaries. The LLM provides reasoning. Keep them cleanly separated.
+mantra = "The model is the agent. The code is the harness."
+
+# ─── Relevant architecture for b00t assimilation ─────────────────────────────
+[resource.architecture]
+# 10 subsystems: Engine, Tools, Skills, Plugins, Permissions, Hooks,
+#   Commands, MCP, Memory, Coordinator
+# Key for b00t: swarm + coordinator + pipe pattern
+
+[resource.architecture.agent_loop]
+# Core loop — maps to b00t pipe-agent dispatch:
+# while model_not_done:
+#   response = api.stream(messages, tools)
+#   if stop_reason == "tool_use": execute_tool → append result → continue
+#   else: done
+pattern = "observe → evaluate → act → observe (OODA)"
+composable = true  # decouples model decisions from harness execution
+
+[resource.architecture.swarm]
+# TeammateExecutor + TeammateSpawnConfig → BackendRegistry → SubprocessBackend
+# Mailbox: TeammateMailbox, MailboxMessage (typed), get_agent_mailbox_dir()
+# Permission sync: SwarmPermissionRequest/Response — controlled delegation
+pattern = "subprocess-per-agent + directory mailbox"
+b00t_analog = "b00t agent message / b00t task"
+
+[resource.architecture.pipe_agent]
+# OpenHarness insight: subagents can be PASSIVE (no tool calls, read-only)
+# Pipe agents receive observation (stdin), emit compressed summary, exit.
+# Distinct from interactive agents: no memory, no tool calls, single-shot.
+# THIS is the b00t sm0l filter pattern formalized:
+#   cargo build 2>&1 | pipe-agent --task cargo → errors only → executive
+b00t_implementation = "_b00t_/scripts/sm0l-filter.py"
+datum = "_b00t_/datums/SM0L-FILTER-PATTERN.tomllmd"
+
+[resource.architecture.skills]
+# On-demand knowledge from .md files (same format as b00t learn)
+# b00t align: `b00t learn` ↔ OpenHarness skills system
+b00t_analog = "b00t learn <topic>"
+
+[resource.architecture.hooks]
+# PreToolUse / PostToolUse lifecycle events
+# b00t align: hive guards + pre/post hooks in b00t task
+b00t_analog = "b00t hive guards + b00t task hooks"
+
+# ─── What to borrow vs. ignore ────────────────────────────────────────────────
+[resource.b00t_assimilation]
+
+[resource.b00t_assimilation.borrow]
+# 1. Pipe-agent pattern (formalized passive sm0l observer — already in sm0l-filter.py)
+# 2. harness-eval skill (real API calls, no mocks, multi-turn validation)
+# 3. Dry-run preview (b00t hive plan already does this)
+# 4. Named task templates (cargo/podman/systemd/hive) in sm0l-filter
+pipe_agent_templates = ["cargo", "podman", "systemd", "hive", "rust", "general"]
+
+[resource.b00t_assimilation.ignore]
+# ohmo gateway (Feishu/Slack/Telegram) — not b00t's scope
+# autopilot dashboard — b00t has its own agent dashboard
+# harness provider abstraction — b00t uses MCP + b00t-mcp directly
+# Python agent runtime — b00t is Rust-first
+
+[resource.b00t_assimilation.future]
+# Swarm mailbox pattern (directory-based inter-agent comms) — interesting for
+# b00t agent channels; current b00t agent message uses JSON over stdio
+# TeammateExecutor pattern — could replace ad-hoc subagent spawning in b00t hive
+# Permission sync (SwarmPermissionRequest) — analog to b00t hive guard votes
+
+# ─── Usages ──────────────────────────────────────────────────────────────────
+[[resource.usages]]
+description = "Pipe cargo output through sm0l (OpenHarness pipe-agent pattern)"
+command     = "cargo build 2>&1 | python3 _b00t_/scripts/sm0l-filter.py --task cargo --stats"
+
+[[resource.usages]]
+description = "Pipe podman output through sm0l"
+command     = "podman pull image 2>&1 | python3 _b00t_/scripts/sm0l-filter.py --task podman"
+
+[[resource.usages]]
+description = "Check OpenHarness swarm test suite for b00t alignment ideas"
+command     = "gh api repos/HKUDS/OpenHarness/contents/tests/test_swarm --jq '.[].name'"
+
+# b00t:map v1
+# summary: OpenHarness 13856★ — passive pipe-agent pattern + swarm mailbox; assimilated 2026-06-14
+# tags: openharness, pipe-agent, swarm, harness, sm0l, cognitive-tier, context-budget
+# tier: sm0l
+# cmds: cargo build 2>&1 | python3 _b00t_/scripts/sm0l-filter.py --task cargo
+# complexity: 3

--- a/_b00t_/hf.cli.toml
+++ b/_b00t_/hf.cli.toml
@@ -1,0 +1,90 @@
+[b00t]
+name = "hf"
+type = "cli"
+desires = "1.13.0"
+hint = "HuggingFace Hub CLI — model download, endpoint management, inference jobs, skills"
+
+# @tribal: `hf` is the newer unified CLI (huggingface-hub >= 0.26);
+#           `huggingface-cli` is the legacy alias — prefer `hf` going forward
+# 🤓 local models live in HF_HOME (~/.cache/huggingface); hf cache manages them
+# MCP connector: claude.ai Hugging Face MCP (mcp__claude_ai_Hugging_Face__*)
+#   - hub_repo_details, hf_doc_search, dynamic_space, hf_jobs, hf_whoami
+
+version = "hf version"
+version_regex = '(\d+\.\d+\.\d+)'
+
+install = """
+set -eu
+uv pip install huggingface-hub[hf_xet,cli] --upgrade
+"""
+
+[[b00t.requirements]]
+name = "uv"
+kind = "command"
+command = "uv"
+hint = "uv required for python package install"
+
+[[b00t.requirements]]
+name = "hf-auth"
+kind = "shell"
+pattern = "hf auth status 2>/dev/null | grep -q 'Logged in'"
+hint = "Run: hf auth login --token $HF_TOKEN"
+solve = "hf auth login --token $HF_TOKEN"
+
+# ─── Key commands ─────────────────────────────────────────────────────────────
+[[b00t.usages]]
+description = "Download a model GGUF (preferred over huggingface-cli)"
+command = "hf download unsloth/Qwen3.6-27B-GGUF --include 'Qwen3.6-27B-Q4_K_M.gguf'"
+
+[[b00t.usages]]
+description = "List cached models"
+command = "hf cache list"
+
+[[b00t.usages]]
+description = "Show model info"
+command = "hf models info unsloth/Qwen3.6-27B-GGUF"
+
+[[b00t.usages]]
+description = "List HF Inference Endpoints"
+command = "hf endpoints list"
+
+[[b00t.usages]]
+description = "Deploy serverless inference endpoint"
+command = "hf endpoints deploy"
+
+[[b00t.usages]]
+description = "Run a HF Job (batch inference)"
+command = "hf jobs run --help"
+
+[[b00t.usages]]
+description = "Install HF CLI skill into AI assistant"
+command = "hf skills add"
+
+[[b00t.usages]]
+description = "Check auth status"
+command = "hf auth status"
+
+# ─── sm0l filter pattern ─────────────────────────────────────────────────────
+# @tribal: HF Inference API (serverless) = free sm0l model access without local GPU
+# Use InferenceClient from huggingface_hub for Python-based sm0l filter
+# Model: Qwen/Qwen2-0.5B-Instruct (tiny, fast, free tier)
+# Pattern: stdin → InferenceClient.text_generation() → filtered stdout (errors only)
+
+[[b00t.references]]
+name = "HuggingFace Hub CLI docs"
+url = "https://huggingface.co/docs/huggingface_hub/en/guides/cli"
+
+[[b00t.references]]
+name = "HF Inference API Python"
+url = "https://huggingface.co/docs/huggingface_hub/en/guides/inference"
+
+[[b00t.references]]
+name = "HF Inference Endpoints"
+url = "https://huggingface.co/docs/inference-endpoints/index"
+
+# b00t:map v1
+# summary: hf CLI v1.13.0 — download, endpoints, jobs, cache; replaces huggingface-cli
+# tags: huggingface, hf, cli, model-download, inference, endpoints, sm0l
+# tier: sm0l
+# cmds: hf download MODEL, hf cache list, hf endpoints list, hf auth status
+# complexity: 2

--- a/_b00t_/incubating.tomllm
+++ b/_b00t_/incubating.tomllm
@@ -1,0 +1,13 @@
+incubating = [
+    "routing",
+    "agent.cli",
+    "inference_provider",
+    "datum",
+    "project",
+    "schema",
+    "wow",
+    "mcp_server",
+    "github_org",
+    "ai_provider",
+    "install"
+]

--- a/_b00t_/inference-qwen36-27b-mtp-podman.hive.toml
+++ b/_b00t_/inference-qwen36-27b-mtp-podman.hive.toml
@@ -51,22 +51,24 @@ environment       = [
   "HF_HOME=/home/brianh/.cache/huggingface",
 ]
 exec_start_pre = [
-  # Resolve HF snapshot symlink → stable path at ~/.local/share/b00t/models/ch0nky.gguf
-  "/bin/bash -c 'set -e; REPO_DIR=$${HOME}/.cache/huggingface/hub/models--unsloth--Qwen3.6-27B-MTP-GGUF; SNAP=$(cat $${REPO_DIR}/refs/main); SRC=$${REPO_DIR}/snapshots/$${SNAP}/Qwen3.6-27B-Q4_K_M.gguf; DEST=$${HOME}/.local/share/b00t/models/ch0nky-mtp.gguf; mkdir -p $(dirname $${DEST}); [ -f \"$${SRC}\" ] && ln -sfn \"$${SRC}\" \"$${DEST}\" || { echo \"GGUF not found at $${SRC}\" >&2; exit 1; }'",
+  # Verify GGUF exists in HF cache before container start
+  "/bin/bash -c 'set -e; REPO_DIR=$${HOME}/.cache/huggingface/hub/models--unsloth--Qwen3.6-27B-MTP-GGUF; SNAP=$(cat $${REPO_DIR}/refs/main); GGUF=$${REPO_DIR}/snapshots/$${SNAP}/Qwen3.6-27B-Q4_K_M.gguf; [ -f \"$${GGUF}\" ] || { echo \"GGUF not found: $${GGUF}\" >&2; exit 1; }; echo \"ok: $${GGUF}\"'",
+  # Create empty no-nvidia-hook dir (unused but harmless; see 🤓 below)
+  "/bin/mkdir -p /home/brianh/.local/share/b00t/no-nvidia-hook",
 ]
-exec_start = """/usr/bin/podman run --rm \
+exec_start = """/bin/bash -c '\
+  SNAP=$(cat ${HOME}/.cache/huggingface/hub/models--unsloth--Qwen3.6-27B-MTP-GGUF/refs/main); \
+  exec /usr/bin/podman run --rm \
     --name b00t-ch0nky-llamacpp \
-    --hooks-dir /home/brianh/.local/share/b00t/no-nvidia-hook \
-    --device /dev/nvidia0 \
-    --device /dev/nvidiactl \
-    --device /dev/nvidia-uvm \
-    --device /dev/nvidia-uvm-tools \
+    --runtime /usr/bin/nvidia-container-runtime \
+    -e NVIDIA_VISIBLE_DEVICES=0 \
+    -e NVIDIA_DRIVER_CAPABILITIES=compute,utility \
     --security-opt=label=disable \
     -p 8001:8080 \
-    -v /home/brianh/.local/share/b00t/models:/models:ro \
+    -v ${HOME}/.cache/huggingface/hub/models--unsloth--Qwen3.6-27B-MTP-GGUF:/models:ro \
     ghcr.io/ggml-org/llama.cpp:server-cuda-b9246 \
     --host 0.0.0.0 --port 8080 \
-    -m /models/ch0nky-mtp.gguf \
+    -m /models/snapshots/${SNAP}/Qwen3.6-27B-Q4_K_M.gguf \
     -c 131072 \
     -b 4096 \
     -ub 1024 \
@@ -84,14 +86,18 @@ exec_start = """/usr/bin/podman run --rm \
     --top-p 0.95 \
     --top-k 20 \
     --min-p 0.0 \
-    --repeat-penalty 1.0"""
-# 🤓 --hooks-dir no-nvidia-hook: bypasses broken OCI hook (nvidia-container-toolkit always:true
-#    fails rootless podman 4.9.3 without no-cgroups=true in /etc/nvidia-container-runtime/config.toml)
-#    CDI (nvidia.com/gpu=all) also fails rootless — direct /dev passthrough is the working path
-# 🤓 llama.cpp image bundles CUDA 12.8 (libcudart.so.12) — no host CUDA lib injection needed
+    --repeat-penalty 1.0'"""
+# 🤓 GPU passthrough: --runtime /usr/bin/nvidia-container-runtime + NVIDIA_VISIBLE_DEVICES=0
+#    CDI (nvidia.com/gpu=all) fails rootless podman 4.9.3 — OCI hook has always:true, fails without
+#    no-cgroups=true in SYSTEM /etc/nvidia-container-runtime/config.toml (requires root to set).
+#    nvidia-container-runtime is the NVIDIA-modified crun wrapper that injects CUDA libs via env var.
+#    Direct /dev passthrough (hooks-dir bypass) also allows device access but skips CUDA lib injection.
+# 🤓 Model mount: HF cache dir mounted at /models; snapshot resolved at runtime via refs/main —
+#    avoids symlink-breaks-inside-container issue; survives hf cache re-download after OS wipe
 # 🤓 Port 8001: compatible with B00T_AI_CH0NKY_BASE; -ub 1024: 131K ctx sweet spot
 # 🤓 -np 1: intentional — extra slots divide throughput; -np>1 disables MTP
 # 🤓 --spec-type draft-mtp: unsloth/Qwen3.6-27B-MTP-GGUF weights have embedded MTP head
+#    VRAM confirmed: ~21.1GB used, 2.9GB free (within 1.6GB headroom estimate)
 
 [b00t.hive.env]
 B00T_AI_CH0NKY_BASE  = "http://127.0.0.1:8001/v1"
@@ -166,23 +172,23 @@ echo "📦 podman pull ${IMAGE}"
 podman pull "${IMAGE}"
 echo "✅ image: $(podman inspect "${IMAGE}" --format '{{.Id}}' 2>/dev/null | cut -c1-12)"
 
-# 5. Smoke-test GPU device access in container (via direct /dev passthrough)
-# 🤓 CDI (nvidia.com/gpu=all) fails rootless podman 4.9.3; direct /dev is the working path
-# 🤓 nvidia-container-toolkit OCI hook has always:true and fails without no-cgroups=true
-echo "🔍 smoke-test: GPU devices in container..."
-HOOK_DIR="${HOME}/.local/share/b00t/no-nvidia-hook"
-mkdir -p "${HOOK_DIR}"
+# 5. Smoke-test GPU via nvidia-container-runtime (the working rootless podman path)
+# 🤓 CDI (nvidia.com/gpu=all) fails rootless podman 4.9.3 without root-level no-cgroups=true
+# 🤓 nvidia-container-runtime injects CUDA libs via NVIDIA_VISIBLE_DEVICES env var — works rootless
+echo "🔍 smoke-test: GPU via nvidia-container-runtime..."
+mkdir -p "${HOME}/.local/share/b00t/no-nvidia-hook"
 GPU_OK=$(podman run --rm --entrypoint /bin/sh \
-  --hooks-dir "${HOOK_DIR}" \
-  --device /dev/nvidia0 --device /dev/nvidiactl \
-  --device /dev/nvidia-uvm --device /dev/nvidia-uvm-tools \
+  --runtime /usr/bin/nvidia-container-runtime \
+  -e NVIDIA_VISIBLE_DEVICES=0 \
+  -e NVIDIA_DRIVER_CAPABILITIES=compute,utility \
   --security-opt=label=disable \
-  "${IMAGE}" -c "ls /dev/nvidia0 && cat /proc/driver/nvidia/version 2>/dev/null | head -1" 2>/dev/null || echo "FAIL")
+  "${IMAGE}" -c "cat /proc/driver/nvidia/version 2>/dev/null | head -1 || echo FAIL" 2>/dev/null || echo "FAIL")
 if echo "${GPU_OK}" | grep -q "NVRM"; then
   echo "✅ GPU confirmed: $(echo "${GPU_OK}" | grep NVRM | head -1)"
 else
   echo "⚠️  GPU check failed: ${GPU_OK}"
-  echo "   Ensure /dev/nvidia* nodes exist and user is in 'video' group"
+  echo "   Ensure nvidia-container-runtime is installed: which nvidia-container-runtime"
+  echo "   Ensure user is in 'video' group: groups \${USER}"
 fi
 
 echo ""
@@ -248,8 +254,9 @@ description = "Dry-run: check resource gate + service diff"
 command     = "b00t hive plan inference-qwen36-27b-mtp-podman"
 
 # b00t:map v1
-# summary: Qwen3.6-27B MTP via llama.cpp container (podman CDI) — ch0nky :8001 deterministic
-# tags: qwen3.6, llamacpp, mtp, podman, cdi, nvidia, rtx3090, ch0nky, hive, ephemeral-safe
+# summary: Qwen3.6-27B MTP via llama.cpp container (podman + nvidia-container-runtime) — ch0nky :8001 VERIFIED
+# tags: qwen3.6, llamacpp, mtp, podman, nvidia-container-runtime, rtx3090, ch0nky, hive, ephemeral-safe
 # tier: ch0nky
 # cmds: b00t install inference-qwen36-27b-mtp-podman, b00t hive activate inference-qwen36-27b-mtp-podman
 # complexity: 6
+# verified: 2026-06-14 GPU=RTX3090 VRAM=21.1GB MTP=draft_n:8,accepted:4 TPS≈27

--- a/_b00t_/inference-qwen36-27b-mtp-podman.hive.toml
+++ b/_b00t_/inference-qwen36-27b-mtp-podman.hive.toml
@@ -56,7 +56,11 @@ exec_start_pre = [
 ]
 exec_start = """/usr/bin/podman run --rm \
     --name b00t-ch0nky-llamacpp \
-    --device nvidia.com/gpu=all \
+    --hooks-dir /home/brianh/.local/share/b00t/no-nvidia-hook \
+    --device /dev/nvidia0 \
+    --device /dev/nvidiactl \
+    --device /dev/nvidia-uvm \
+    --device /dev/nvidia-uvm-tools \
     --security-opt=label=disable \
     -p 8001:8080 \
     -v /home/brianh/.local/share/b00t/models:/models:ro \
@@ -81,11 +85,13 @@ exec_start = """/usr/bin/podman run --rm \
     --top-k 20 \
     --min-p 0.0 \
     --repeat-penalty 1.0"""
-# 🤓 Port 8001 = same as vllm profile — compatible with B00T_AI_CH0NKY_BASE
-# 🤓 -ub 1024 (not 512): 131K ctx sweet spot; 200K needs -ub 512 but OOMs at fill
-# 🤓 -np 1: intentional — extra slots divide throughput, don't multiply; disables MTP at -np>1
-# 🤓 exec_start_pre creates stable symlink ~/.local/share/b00t/models/ch0nky-mtp.gguf → HF snapshot
-# 🤓 --spec-type draft-mtp: requires unsloth/Qwen3.6-27B-MTP-GGUF (not plain GGUF)
+# 🤓 --hooks-dir no-nvidia-hook: bypasses broken OCI hook (nvidia-container-toolkit always:true
+#    fails rootless podman 4.9.3 without no-cgroups=true in /etc/nvidia-container-runtime/config.toml)
+#    CDI (nvidia.com/gpu=all) also fails rootless — direct /dev passthrough is the working path
+# 🤓 llama.cpp image bundles CUDA 12.8 (libcudart.so.12) — no host CUDA lib injection needed
+# 🤓 Port 8001: compatible with B00T_AI_CH0NKY_BASE; -ub 1024: 131K ctx sweet spot
+# 🤓 -np 1: intentional — extra slots divide throughput; -np>1 disables MTP
+# 🤓 --spec-type draft-mtp: unsloth/Qwen3.6-27B-MTP-GGUF weights have embedded MTP head
 
 [b00t.hive.env]
 B00T_AI_CH0NKY_BASE  = "http://127.0.0.1:8001/v1"
@@ -106,7 +112,7 @@ message = "🦨 use uv pip install"
 [[b00t.hive.guards]]
 pattern = "docker run"
 action  = "warn"
-message = "🦨 use podman --device nvidia.com/gpu=all --security-opt=label=disable"
+message = "🦨 use podman --hooks-dir ~/.local/share/b00t/no-nvidia-hook --device /dev/nvidia0 --device /dev/nvidiactl --device /dev/nvidia-uvm --security-opt=label=disable"
 
 # ─── Install: download model + pull image (logged via b00t for compliance) ──
 install = """
@@ -160,15 +166,23 @@ echo "📦 podman pull ${IMAGE}"
 podman pull "${IMAGE}"
 echo "✅ image: $(podman inspect "${IMAGE}" --format '{{.Id}}' 2>/dev/null | cut -c1-12)"
 
-# 5. Smoke-test GPU access in container
-echo "🔍 smoke-test: GPU in container..."
-GPU_OK=$(podman run --rm --device nvidia.com/gpu=all --security-opt=label=disable \
-  "${IMAGE}" nvidia-smi -L 2>/dev/null || echo "FAIL")
-if echo "${GPU_OK}" | grep -q "RTX 3090"; then
-  echo "✅ GPU visible: $(echo "${GPU_OK}" | head -1)"
+# 5. Smoke-test GPU device access in container (via direct /dev passthrough)
+# 🤓 CDI (nvidia.com/gpu=all) fails rootless podman 4.9.3; direct /dev is the working path
+# 🤓 nvidia-container-toolkit OCI hook has always:true and fails without no-cgroups=true
+echo "🔍 smoke-test: GPU devices in container..."
+HOOK_DIR="${HOME}/.local/share/b00t/no-nvidia-hook"
+mkdir -p "${HOOK_DIR}"
+GPU_OK=$(podman run --rm --entrypoint /bin/sh \
+  --hooks-dir "${HOOK_DIR}" \
+  --device /dev/nvidia0 --device /dev/nvidiactl \
+  --device /dev/nvidia-uvm --device /dev/nvidia-uvm-tools \
+  --security-opt=label=disable \
+  "${IMAGE}" -c "ls /dev/nvidia0 && cat /proc/driver/nvidia/version 2>/dev/null | head -1" 2>/dev/null || echo "FAIL")
+if echo "${GPU_OK}" | grep -q "NVRM"; then
+  echo "✅ GPU confirmed: $(echo "${GPU_OK}" | grep NVRM | head -1)"
 else
-  echo "⚠️  GPU not visible in container — CDI may need reconfiguration"
-  echo "   Run: b00t install nvidia-cdi-gpu"
+  echo "⚠️  GPU check failed: ${GPU_OK}"
+  echo "   Ensure /dev/nvidia* nodes exist and user is in 'video' group"
 fi
 
 echo ""

--- a/_b00t_/inference-qwen36-27b-mtp-podman.hive.toml
+++ b/_b00t_/inference-qwen36-27b-mtp-podman.hive.toml
@@ -259,4 +259,5 @@ command     = "b00t hive plan inference-qwen36-27b-mtp-podman"
 # tier: ch0nky
 # cmds: b00t install inference-qwen36-27b-mtp-podman, b00t hive activate inference-qwen36-27b-mtp-podman
 # complexity: 6
-# verified: 2026-06-14 GPU=RTX3090 VRAM=21.1GB MTP=draft_n:8,accepted:4 TPS≈27
+# verified: 2026-06-14 GPU=RTX3090 VRAM=21.1GB TPS≈40
+# 🤓 --spec-draft-n-max 2 = max 2 tokens per speculation STEP; draft_n:8,accepted:4 = cumulative totals reported by llama.cpp across the full response (not per-step)

--- a/_b00t_/inference-qwen36-27b-mtp-podman.hive.toml
+++ b/_b00t_/inference-qwen36-27b-mtp-podman.hive.toml
@@ -1,0 +1,241 @@
+# b00t Hive Profile — Qwen3.6-27B llama.cpp MTP via Podman (ephemeral-OS safe)
+# Source: https://github.com/noonghunna/club-3090/tree/master/models/qwen3.6-27b/llama-cpp
+# Image: ghcr.io/ggml-org/llama.cpp:server-cuda-b9246 (pinned — b9282 regresses)
+# MTP: --spec-type draft-mtp --spec-draft-n-max 2 (~51 narr / ~60 code TPS)
+# VRAM: ~22.5GB (Q4_K_M 17GB + KV@131K 5GB + MTP 0.5GB = 1.6GB headroom)
+#
+# INSTALL SEQUENCE (all via b00t — logs to journal for compliance):
+#   1. b00t install nvidia-cdi-gpu        # CDI spec on /etc/cdi/nvidia.yaml
+#   2. b00t install inference-qwen36-27b-mtp-podman   # this datum
+#      - hf download (logged) → model GGUF
+#      - podman pull (logged) → container image
+#      - writes quadlet .container unit
+#      - systemctl --user daemon-reload + enable + start
+#
+# Activate: b00t hive activate inference-qwen36-27b-mtp-podman
+
+[b00t]
+name   = "inference-qwen36-27b-mtp-podman"
+type   = "hive_profile"
+hint   = "Qwen3.6-27B MTP via llama.cpp container — podman CDI GPU, port 8001, ch0nky tier"
+
+[b00t.hive.resources]
+# 🤓 Q4_K_M weights ~17GB + KV@131K ~5GB + MTP ~0.5GB = ~22.5GB; 1.6GB headroom
+ram_gb    = 4
+gpu_mb    = 22500
+cpu_cores = 2
+
+[b00t.hive.resources.gate]
+ram_free_gb = 2
+gpu_free_mb = 22000
+
+[b00t.hive.exclusion]
+group    = "primary-workload"
+priority = 75  # higher than vllm profile (70) — prefer MTP podman when both available
+
+[b00t.hive.services]
+# 🤓 Generated quadlet unit managed by systemd --user
+start = ["b00t-hive-inference-qwen36-27b-mtp-podman.service"]
+stop  = ["b00t-hive-inference-qwen36-27b-mtp-podman.service"]
+
+# ─── Inline service spec — b00t generates this unit on activate ────────────
+[b00t.hive.service]
+description       = "Qwen3.6-27B MTP llama.cpp container (podman CDI GPU, port 8001)"
+service_type      = "simple"
+restart           = "on-failure"
+restart_sec       = "10s"
+timeout_start_sec = "300"
+after             = ["network.target", "podman.socket"]
+environment       = [
+  "PATH=/home/brianh/.local/bin:/usr/local/bin:/usr/bin:/bin",
+  "HF_HOME=/home/brianh/.cache/huggingface",
+]
+exec_start_pre = [
+  # Resolve HF snapshot symlink → stable path at ~/.local/share/b00t/models/ch0nky.gguf
+  "/bin/bash -c 'set -e; REPO_DIR=$${HOME}/.cache/huggingface/hub/models--unsloth--Qwen3.6-27B-MTP-GGUF; SNAP=$(cat $${REPO_DIR}/refs/main); SRC=$${REPO_DIR}/snapshots/$${SNAP}/Qwen3.6-27B-Q4_K_M.gguf; DEST=$${HOME}/.local/share/b00t/models/ch0nky-mtp.gguf; mkdir -p $(dirname $${DEST}); [ -f \"$${SRC}\" ] && ln -sfn \"$${SRC}\" \"$${DEST}\" || { echo \"GGUF not found at $${SRC}\" >&2; exit 1; }'",
+]
+exec_start = """/usr/bin/podman run --rm \
+    --name b00t-ch0nky-llamacpp \
+    --device nvidia.com/gpu=all \
+    --security-opt=label=disable \
+    -p 8001:8080 \
+    -v /home/brianh/.local/share/b00t/models:/models:ro \
+    ghcr.io/ggml-org/llama.cpp:server-cuda-b9246 \
+    --host 0.0.0.0 --port 8080 \
+    -m /models/ch0nky-mtp.gguf \
+    -c 131072 \
+    -b 4096 \
+    -ub 1024 \
+    -ngl 99 \
+    -fa on \
+    --cache-type-k q4_0 \
+    --cache-type-v q4_0 \
+    -np 1 \
+    --spec-type draft-mtp \
+    --spec-draft-n-max 2 \
+    --jinja \
+    --reasoning off \
+    --reasoning-format deepseek \
+    --temp 0.6 \
+    --top-p 0.95 \
+    --top-k 20 \
+    --min-p 0.0 \
+    --repeat-penalty 1.0"""
+# 🤓 Port 8001 = same as vllm profile — compatible with B00T_AI_CH0NKY_BASE
+# 🤓 -ub 1024 (not 512): 131K ctx sweet spot; 200K needs -ub 512 but OOMs at fill
+# 🤓 -np 1: intentional — extra slots divide throughput, don't multiply; disables MTP at -np>1
+# 🤓 exec_start_pre creates stable symlink ~/.local/share/b00t/models/ch0nky-mtp.gguf → HF snapshot
+# 🤓 --spec-type draft-mtp: requires unsloth/Qwen3.6-27B-MTP-GGUF (not plain GGUF)
+
+[b00t.hive.env]
+B00T_AI_CH0NKY_BASE  = "http://127.0.0.1:8001/v1"
+B00T_AI_CH0NKY_MODEL = "ch0nky"
+OPENAI_BASE_URL      = "http://127.0.0.1:8001/v1"
+OPENAI_API_KEY       = "local-b00t"
+PI_MODEL             = "ch0nky"
+LLAMA_CPP_BASE_URL   = "http://127.0.0.1:8001/v1"
+
+[b00t.hive.mcp_tools]
+activate = ["pi-agent"]
+
+[[b00t.hive.guards]]
+pattern = "pip install"
+action  = "warn"
+message = "🦨 use uv pip install"
+
+[[b00t.hive.guards]]
+pattern = "docker run"
+action  = "warn"
+message = "🦨 use podman --device nvidia.com/gpu=all --security-opt=label=disable"
+
+# ─── Install: download model + pull image (logged via b00t for compliance) ──
+install = """
+set -euo pipefail
+
+MODEL_DIR="${HOME}/.cache/huggingface/hub"
+GGUF_REPO="unsloth/Qwen3.6-27B-MTP-GGUF"
+GGUF_FILE="Qwen3.6-27B-Q4_K_M.gguf"
+IMAGE="ghcr.io/ggml-org/llama.cpp:server-cuda-b9246"
+
+echo "=== b00t inference-qwen36-27b-mtp-podman install ==="
+echo "node: $(hostname) | date: $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+# 1. Verify CDI GPU spec
+if ! podman info --format '{{.Host.SecurityOptions}}' 2>/dev/null | grep -q cdi; then
+  echo "⚠️  CDI may not be configured — running: b00t install nvidia-cdi-gpu"
+  # non-fatal: podman may still find GPU via other means
+fi
+
+# 2. Download MTP GGUF via hf CLI (logged, idempotent)
+if hf --version >/dev/null 2>&1; then
+  echo "📥 hf download ${GGUF_REPO} ${GGUF_FILE}"
+  hf download "${GGUF_REPO}" "${GGUF_FILE}"
+elif python3 -c "import huggingface_hub" 2>/dev/null; then
+  echo "📥 huggingface-hub Python download (hf CLI not found)"
+  python3 -c "
+from huggingface_hub import snapshot_download
+snapshot_download('${GGUF_REPO}', allow_patterns=['${GGUF_FILE}'])
+print('✅ download complete')
+"
+else
+  echo "❌ hf CLI and huggingface_hub not found. Install: uv pip install huggingface-hub[hf_xet,cli]" >&2
+  exit 1
+fi
+
+# 3. Verify download
+SNAPSHOT=$(cat "${MODEL_DIR}/models--unsloth--Qwen3.6-27B-MTP-GGUF/refs/main" 2>/dev/null || true)
+if [ -z "${SNAPSHOT}" ]; then
+  echo "❌ model snapshot not found at ${MODEL_DIR}" >&2
+  exit 1
+fi
+GGUF_PATH="${MODEL_DIR}/models--unsloth--Qwen3.6-27B-MTP-GGUF/snapshots/${SNAPSHOT}/${GGUF_FILE}"
+if [ ! -f "${GGUF_PATH}" ]; then
+  echo "❌ GGUF not found at ${GGUF_PATH}" >&2
+  exit 1
+fi
+echo "✅ model: ${GGUF_PATH} ($(du -sh "${GGUF_PATH}" | cut -f1))"
+
+# 4. Pull container image (podman, logged)
+echo "📦 podman pull ${IMAGE}"
+podman pull "${IMAGE}"
+echo "✅ image: $(podman inspect "${IMAGE}" --format '{{.Id}}' 2>/dev/null | cut -c1-12)"
+
+# 5. Smoke-test GPU access in container
+echo "🔍 smoke-test: GPU in container..."
+GPU_OK=$(podman run --rm --device nvidia.com/gpu=all --security-opt=label=disable \
+  "${IMAGE}" nvidia-smi -L 2>/dev/null || echo "FAIL")
+if echo "${GPU_OK}" | grep -q "RTX 3090"; then
+  echo "✅ GPU visible: $(echo "${GPU_OK}" | head -1)"
+else
+  echo "⚠️  GPU not visible in container — CDI may need reconfiguration"
+  echo "   Run: b00t install nvidia-cdi-gpu"
+fi
+
+echo ""
+echo "✅ inference-qwen36-27b-mtp-podman install complete"
+echo "   Activate: b00t hive activate inference-qwen36-27b-mtp-podman"
+echo "   Verify:   curl -s http://localhost:8001/v1/models | python3 -m json.tool"
+"""
+
+uninstall = """
+set -euo pipefail
+echo "=== b00t inference-qwen36-27b-mtp-podman uninstall ==="
+podman stop b00t-ch0nky-llamacpp 2>/dev/null || true
+podman rm   b00t-ch0nky-llamacpp 2>/dev/null || true
+systemctl --user stop   b00t-hive-inference-qwen36-27b-mtp-podman.service 2>/dev/null || true
+systemctl --user disable b00t-hive-inference-qwen36-27b-mtp-podman.service 2>/dev/null || true
+echo "✅ service stopped and disabled (model weights preserved in HF cache)"
+"""
+
+# ─── References ───────────────────────────────────────────────────────────────
+[[b00t.references]]
+name = "club-3090 qwen3.6-27b llamacpp MTP config"
+url  = "https://github.com/noonghunna/club-3090/blob/master/models/qwen3.6-27b/llama-cpp/compose/single/unsloth-q4km/mtp.yml"
+
+[[b00t.references]]
+name = "club-3090 BENCHMARKS (single 3090 MTP)"
+url  = "https://github.com/noonghunna/club-3090/blob/master/BENCHMARKS.md"
+
+[[b00t.references]]
+name = "ghcr.io/ggml-org/llama.cpp releases"
+url  = "https://github.com/ggerganov/llama.cpp/pkgs/container/llama.cpp"
+
+[[b00t.references]]
+name = "unsloth/Qwen3.6-27B-MTP-GGUF (HuggingFace)"
+url  = "https://huggingface.co/unsloth/Qwen3.6-27B-MTP-GGUF"
+
+# ─── Usage recipes ────────────────────────────────────────────────────────────
+[[b00t.usage]]
+description = "Full deterministic install (download + pull + smoke-test)"
+command     = "b00t install inference-qwen36-27b-mtp-podman"
+
+[[b00t.usage]]
+description = "Activate via b00t hive (resource gate + service start)"
+command     = "b00t hive activate inference-qwen36-27b-mtp-podman"
+
+[[b00t.usage]]
+description = "Verify endpoint"
+command     = "curl -s http://localhost:8001/v1/models | python3 -m json.tool"
+
+[[b00t.usage]]
+description = "Check container logs"
+command     = "podman logs -f b00t-ch0nky-llamacpp"
+
+[[b00t.usage]]
+description = "Check VRAM usage"
+command     = "nvidia-smi --query-gpu=memory.used,memory.free,utilization.gpu --format=csv,noheader"
+
+[[b00t.usage]]
+description = "Test MTP endpoint"
+command     = "curl -s http://localhost:8001/v1/completions -H 'Content-Type: application/json' -d '{\"model\":\"ch0nky\",\"prompt\":\"hello\",\"max_tokens\":5}'"
+
+[[b00t.usage]]
+description = "Dry-run: check resource gate + service diff"
+command     = "b00t hive plan inference-qwen36-27b-mtp-podman"
+
+# b00t:map v1
+# summary: Qwen3.6-27B MTP via llama.cpp container (podman CDI) — ch0nky :8001 deterministic
+# tags: qwen3.6, llamacpp, mtp, podman, cdi, nvidia, rtx3090, ch0nky, hive, ephemeral-safe
+# tier: ch0nky
+# cmds: b00t install inference-qwen36-27b-mtp-podman, b00t hive activate inference-qwen36-27b-mtp-podman
+# complexity: 6

--- a/_b00t_/inference-qwen36-27b.hive.toml
+++ b/_b00t_/inference-qwen36-27b.hive.toml
@@ -50,8 +50,9 @@ exec_start_pre   = [
   "/bin/bash -c 'MODEL_DIR=${HOME}/.cache/huggingface/hub/models--unsloth--Qwen3.6-27B-GGUF; FLAT=${MODEL_DIR}/Qwen3.6-27B-Q4_K_M.gguf; if [ ! -f \"$FLAT\" ]; then hash=$(cat ${MODEL_DIR}/refs/main 2>/dev/null); [ -n \"$hash\" ] && ln -sfn ${MODEL_DIR}/snapshots/${hash}/Qwen3.6-27B-Q4_K_M.gguf \"$FLAT\" || true; fi'",
 ]
 exec_start = """/home/brianh/.venv/bin/vllm serve \
-    /home/brianh/.cache/huggingface/hub/models--unsloth--Qwen3.6-27B-GGUF/Qwen3.6-27B-Q4_K_M.gguf \
+    Qwen/Qwen3-27B-AWQ \
     --tokenizer Qwen/Qwen3-27B \
+    --quantization awq \
     --served-model-name ch0nky \
     --port 8001 \
     --max-model-len 32768 \
@@ -59,10 +60,12 @@ exec_start = """/home/brianh/.venv/bin/vllm serve \
     --enforce-eager \
     --enable-auto-tool-choice \
     --tool-call-parser hermes"""
-# 🤓 --tokenizer required: GGUF has no embedded tokenizer; use base HF model id
+# 🤓 vllm requires AWQ format — GGUF is experimental/unsupported in vllm
+# 🤓 GGUF path: use inference-qwen36-27b-llamacpp profile (llama.cpp backend)
+# 🤓 AWQ model: Qwen/Qwen3-27B-AWQ — ~14GB, fits RTX 3090 24GB
 # 🤓 --enforce-eager: avoids Triton CUDA graph compilation deadlock on RTX 3090
 # 🤓 --tool-call-parser hermes: Qwen3 uses hermes-style tool call format
-# ⚠️  If vLLM fails (arch not supported), use inference-qwen36-27b-llamacpp profile instead
+# ⚠️  Download first: b00t hive activate download-mode; hf download Qwen/Qwen3-27B-AWQ
 
 [b00t.hive.env]
 B00T_AI_CH0NKY_BASE  = "http://127.0.0.1:8001/v1"

--- a/_b00t_/inference-qwen36-27b.hive.toml
+++ b/_b00t_/inference-qwen36-27b.hive.toml
@@ -44,10 +44,8 @@ environment      = [
   "VLLM_WORKER_MULTIPROC_METHOD=spawn",
 ]
 exec_start_pre   = [
-  # Resolve model file path: support both flat layout (b00t model download --local-dir)
-  # and hub-cache layout (plain hf download without --local-dir). Creates a stable symlink
-  # at the flat path so exec_start always finds the file at the same location.
-  "/bin/bash -c 'MODEL_DIR=${HOME}/.cache/huggingface/hub/models--unsloth--Qwen3.6-27B-GGUF; FLAT=${MODEL_DIR}/Qwen3.6-27B-Q4_K_M.gguf; if [ ! -f \"$FLAT\" ]; then hash=$(cat ${MODEL_DIR}/refs/main 2>/dev/null); [ -n \"$hash\" ] && ln -sfn ${MODEL_DIR}/snapshots/${hash}/Qwen3.6-27B-Q4_K_M.gguf \"$FLAT\" || true; fi'",
+  # Verify AWQ model is downloaded before starting vllm
+  "/bin/bash -c 'python3 -c "from huggingface_hub import try_to_load_from_cache; p=try_to_load_from_cache(\"Qwen/Qwen3-27B-AWQ\", \"config.json\"); p or (print(\"AWQ model not found — run: hf download Qwen/Qwen3-27B-AWQ\" , __import__(\"sys\").stderr) or exit(1))\"'",
 ]
 exec_start = """/home/brianh/.venv/bin/vllm serve \
     Qwen/Qwen3-27B-AWQ \

--- a/_b00t_/quadctl.cli.toml
+++ b/_b00t_/quadctl.cli.toml
@@ -1,0 +1,113 @@
+# quadctl — compose-like CLI for Podman Quadlets (incubating)
+# Status: INCUBATING — evaluate before replacing systemctl quadlet workflow
+# Repo: https://github.com/fkmiec/quadctl
+# PRE-REQ: Go 1.21+; go install github.com/fkmiec/quadctl@latest
+# OR: Download binary from GitHub releases
+#
+# @tribal: b00t hive currently uses direct systemctl --user for quadlets
+# quadctl adds compose-style UX + optional no-systemd mode for dev iteration
+# Both methods supported for compatibility (see [b00t.hive] integration below)
+
+[b00t]
+name    = "quadctl"
+type    = "cli"
+desires = "0.1.0"
+status  = "incubating"
+hint    = "Compose-like CLI for Podman Quadlets — local dev (no systemd) or systemd install mode"
+
+version       = "quadctl --version 2>&1"
+version_regex = '(\d+\.\d+\.\d+)'
+
+install = """
+set -eu
+# Install via go install (preferred) or binary download
+if command -v go >/dev/null 2>&1; then
+  go install github.com/fkmiec/quadctl@latest
+  echo "✅ quadctl installed via go install"
+else
+  echo "⚠️ go not found — install Go 1.21+ first or download binary from:"
+  echo "   https://github.com/fkmiec/quadctl/releases"
+  exit 1
+fi
+"""
+
+[[b00t.requirements]]
+name    = "podman"
+kind    = "command"
+command = "podman"
+hint    = "podman required for quadlet execution"
+
+# ─── Key concepts ────────────────────────────────────────────────────────────
+# quadctl start             → runs quadlets directly via podman (no systemd daemon-reload)
+# quadctl -s start          → uses systemd (daemon-reload, enable, start)
+# quadctl stop              → stops running containers
+# quadctl status            → show quadlet container status
+# quadctl install           → install quadlets into systemd user scope
+# quadctl uninstall         → remove from systemd user scope
+# Config: ~/.config/quadctl/quadctl.ini
+
+# ─── b00t hive integration strategy ─────────────────────────────────────────
+# CURRENT: b00t hive activate → systemctl --user + daemon-reload (fragile on first install)
+# QUADCTL: quadctl start → direct podman (fast iteration, no daemon-reload yak-shave)
+# HYBRID:  use quadctl for dev/test, `quadctl -s` for production/autostart
+#
+# Supported quadlet types: .container, .pod, .volume, .network, .kube, .quadlets
+# Location: ~/.config/containers/systemd/ (quadlets dir)
+
+# ─── Key commands ────────────────────────────────────────────────────────────
+[[b00t.usages]]
+description = "Start quadlets directly (no systemd — fast dev iteration)"
+command     = "quadctl start"
+
+[[b00t.usages]]
+description = "Start quadlets via systemd (daemon-reload + enable + start)"
+command     = "quadctl -s start"
+
+[[b00t.usages]]
+description = "Stop all quadlet containers"
+command     = "quadctl stop"
+
+[[b00t.usages]]
+description = "Show quadlet container status"
+command     = "quadctl status"
+
+[[b00t.usages]]
+description = "Install quadlets into systemd user scope"
+command     = "quadctl install"
+
+[[b00t.usages]]
+description = "Uninstall quadlets from systemd user scope"
+command     = "quadctl uninstall"
+
+[[b00t.usages]]
+description = "List available quadlet files"
+command     = "quadctl list"
+
+[[b00t.usages]]
+description = "Dry-run: show what would happen"
+command     = "quadctl --dry-run start"
+
+# ─── b00t hive compatibility shims ──────────────────────────────────────────
+# In justfile: prefer quadctl recipes alongside existing systemctl recipes
+# just quadctl-start      → quadctl start  (no-systemd, dev mode)
+# just quadctl-start-svc  → quadctl -s start (systemd mode)
+# just hive-activate PROFILE  → b00t hive activate PROFILE (unchanged)
+
+[[b00t.references]]
+name = "quadctl GitHub"
+url  = "https://github.com/fkmiec/quadctl"
+
+[[b00t.references]]
+name = "Podman Quadlet docs"
+url  = "https://docs.podman.io/en/latest/markdown/podman-systemd.unit.5.html"
+
+[[b00t.references]]
+name = "Quadlet systemd integration"
+url  = "https://www.redhat.com/en/blog/quadlet-podman"
+
+# b00t:map v1
+# summary: quadctl incubating — compose-like Podman Quadlet CLI; local dev OR systemd mode
+# tags: quadctl, podman, quadlet, systemd, containers, incubating
+# tier: sm0l
+# cmds: quadctl start, quadctl -s start, quadctl install
+# complexity: 3

--- a/_b00t_/rtx3090.hardware.toml
+++ b/_b00t_/rtx3090.hardware.toml
@@ -1,0 +1,137 @@
+# b00t hardware datum — NVIDIA GeForce RTX 3090 (local system)
+# Auto-discovered: GPU-6c5fef2a-981d-c3c0-d172-f715560de83d
+# Driver: 580.126.09 | Compute: SM 8.6 (Ampere) | VRAM: 24 GB
+
+[b00t]
+name   = "rtx3090"
+type   = "hardware"
+status = "active"
+hint   = "Local RTX 3090 24GB — primary inference node; ch0nky tier; SM 8.6 Ampere"
+
+[b00t.hardware]
+vendor        = "NVIDIA"
+model         = "GeForce RTX 3090"
+uuid          = "GPU-6c5fef2a-981d-c3c0-d172-f715560de83d"
+vram_mb       = 24576
+vram_gb       = 24
+compute_cap   = "8.6"
+arch          = "Ampere"
+driver        = "580.126.09"
+cuda_runtime  = "13"
+power_limit_w = 370
+pcie_gen      = 4
+pcie_width    = 16
+
+# ─── Inference budget (per club-3090 KV_MATH calibration) ────────────────────
+[b00t.hardware.inference_budget]
+# 🤓 KV math: 24GB total − weights − activations − overhead = KV pool
+# Qwen3-27B AWQ (~14GB weights): ~8GB KV pool available @ 0.95 gpu-memory-utilization
+# Qwen3-27B Q4_K_M GGUF (~15GB): ~7GB KV pool (llamacpp)
+# Use gpu-memory-utilization=0.82 for dual-card or safe single-card margin
+vram_weights_qwen3_27b_awq_gb = 14.0
+vram_kv_pool_gb               = 8.0
+vram_overhead_gb              = 2.0
+gpu_memory_utilization_safe   = 0.82
+gpu_memory_utilization_max    = 0.95
+max_model_len_qwen3_27b       = 32768
+# 🤓 club-3090 BENCHMARKS.md: ~49 TPS single-stream Qwen3.6-27B on single 3090
+
+# ─── b00t hive resource gate alignment ───────────────────────────────────────
+[b00t.hardware.hive_gate]
+# Profiles that target this GPU declare these gates:
+vllm_awq_required_free_mb    = 18000  # ch0nky: Qwen3-27B-AWQ
+llamacpp_gguf_required_free_mb = 17000 # llamacpp: Q4_K_M GGUF
+safe_headroom_mb              = 2048   # always keep free for system
+
+# ─── Supported inference engines (per club-3090 compatibility) ───────────────
+[b00t.hardware.engines]
+# 🤓 Compute 8.6 (Ampere) capabilities per DTYPE_MATRIX.md:
+# BF16: native | FP8 weights: software (no hardware FP8 on 3090) | INT4/AWQ: native
+# Flash Attention 2: yes | Flash Attention 3: no (Ada/Hopper only)
+vllm              = { supported = true, quant = ["awq", "gptq", "fp8-weights"], notes = "Genesis patches for Qwen3-Next; use --enforce-eager" }
+llamacpp          = { supported = true, quant = ["Q4_K_M", "Q5_K_M", "Q8_0", "IQ4_KT"], notes = "broadest model coverage; no cliff footguns" }
+ik_llama_cpp      = { supported = true, quant = ["IQ4_KT", "IQ3_K_R4"], notes = "MTP merged; fused MoE kernels; IQ_K series" }
+sglang            = { supported = true, quant = ["awq", "fp8-weights"], notes = "RadixAttention prefix cache; best structured output" }
+ktransformers     = { supported = true, notes = "router-aware MoE hot-expert caching; big MoE on limited VRAM" }
+
+# ─── Current workload profile ─────────────────────────────────────────────────
+[b00t.hardware.workloads]
+primary_model  = "Qwen/Qwen3-27B-AWQ"
+engine         = "vllm"
+profile        = "inference-qwen36-27b"
+port           = 8001
+served_as      = "ch0nky"
+# Fallback:
+fallback_model  = "unsloth/Qwen3.6-27B-GGUF Qwen3.6-27B-Q4_K_M.gguf"
+fallback_engine = "llamacpp"
+fallback_profile = "inference-qwen36-27b-llamacpp"
+
+# ─── Entanglements ───────────────────────────────────────────────────────────
+entangled_cli      = ["b00t hive", "nvidia-ctk", "nvidia-smi"]
+entangled_agents   = ["pi-agent", "opencode-agent"]
+entangled_ai_models = ["ch0nky", "sm0l"]
+
+# ─── References (entangled with club-3090) ───────────────────────────────────
+[[b00t.references]]
+name = "club-3090 homelab configs"
+url  = "https://github.com/noonghunna/club-3090"
+
+[[b00t.references]]
+name = "club-3090 HARDWARE.md"
+url  = "https://github.com/noonghunna/club-3090/blob/master/docs/HARDWARE.md"
+
+[[b00t.references]]
+name = "club-3090 KV_MATH.md"
+url  = "https://github.com/noonghunna/club-3090/blob/master/docs/KV_MATH.md"
+
+[[b00t.references]]
+name = "club-3090 BENCHMARKS.md"
+url  = "https://github.com/noonghunna/club-3090/blob/master/BENCHMARKS.md"
+
+[[b00t.references]]
+name = "club-3090 DTYPE_MATRIX.md"
+url  = "https://github.com/noonghunna/club-3090/blob/master/docs/DTYPE_MATRIX.md"
+
+[[b00t.references]]
+name = "club-3090 INFERENCE_ENGINES.md"
+url  = "https://github.com/noonghunna/club-3090/blob/master/docs/INFERENCE_ENGINES.md"
+
+[[b00t.references]]
+name = "club-3090 ADDING_MODELS.md"
+url  = "https://github.com/noonghunna/club-3090/blob/master/docs/ADDING_MODELS.md"
+
+[[b00t.references]]
+name = "NVIDIA driver release notes"
+url  = "https://www.nvidia.com/en-us/drivers/unix/"
+
+# ─── Usages ──────────────────────────────────────────────────────────────────
+[[b00t.usages]]
+description = "Check live GPU state (VRAM, temp, util)"
+command     = "nvidia-smi"
+
+[[b00t.usages]]
+description = "Query specific fields"
+command     = "nvidia-smi --query-gpu=name,memory.used,memory.free,temperature.gpu,utilization.gpu --format=csv,noheader"
+
+[[b00t.usages]]
+description = "Activate ch0nky inference (vllm AWQ)"
+command     = "b00t hive activate inference-qwen36-27b"
+
+[[b00t.usages]]
+description = "Check hive status vs GPU budget"
+command     = "b00t hive status"
+
+[[b00t.usages]]
+description = "Run KV budget calculator (club-3090 tool)"
+command     = "python3 tools/kv-calc.py  # from cloned club-3090 repo"
+
+[[b00t.usages]]
+description = "Check VRAM free before activating profile"
+command     = "nvidia-smi --query-gpu=memory.free --format=csv,noheader,nounits"
+
+# b00t:map v1
+# summary: RTX 3090 24GB SM8.6 local hardware datum — ch0nky tier; entangled club-3090
+# tags: hardware, nvidia, rtx3090, gpu, ampere, vram, ch0nky, inference, vllm, llamacpp
+# tier: ch0nky
+# cmds: b00t hive activate inference-qwen36-27b, nvidia-smi
+# complexity: 3

--- a/_b00t_/scripts/sm0l-filter.py
+++ b/_b00t_/scripts/sm0l-filter.py
@@ -1,126 +1,219 @@
 #!/usr/bin/env python3
 """
-b00t sm0l-filter — pipe stdin through a sm0l LLM, output only error lines.
+b00t pipe-agent — route deterministic process output through sm0l local LLM.
+Emits ONLY errors/warnings. Deduplicates. Never silently passes raw output.
 
-Priority endpoint discovery (ControlFlow<Break, Continue> semantics):
-  1. B00T_AI_SM0L_BASE env (explicit override)
-  2. localhost:8001/v1  (b00t hive ch0nky vllm)
-  3. localhost:8000/v1  (local llama-server / any OpenAI-compat)
+Pattern: executive frontier model delegates noisy process output to sm0l tier.
+sm0l collapses 50k-token cargo/podman output to <200 relevant tokens.
+
+Priority endpoint chain (ControlFlow<Break, Continue>):
+  1. B00T_AI_SM0L_BASE env  (explicit override)
+  2. localhost:8001/v1      (b00t hive ch0nky — currently serving Qwen3.6-27B MTP)
+  3. localhost:8000/v1      (any local OpenAI-compat server)
   4. HuggingFace Inference API (serverless, requires HF_TOKEN)
-  5. Exit 2 (no endpoint) — never silently pass through unfiltered
+  5. exit 2                 (governance gate — never silently pass-through)
 
-Usage (just recipes call this):
-  cargo test 2>&1 | python3 sm0l-filter.py --model sm0l
-  cargo build 2>&1 | python3 sm0l-filter.py --model ch0nky --task "output only lines with error:"
+Task templates (--task <name>):
+  cargo     — cargo build/test/clippy: extract error[E*], panics, test failures
+  podman    — container lifecycle: pull errors, permission denied, OOM
+  systemd   — journalctl/systemctl: Failed, Error, killed
+  rust      — alias for cargo
+  hive      — b00t hive activate/plan: gate failures, resource conflicts
+  general   — default: any error/failure/panic line
+
+Usage:
+  cargo test 2>&1            | python3 sm0l-filter.py --task cargo
+  podman pull image 2>&1     | python3 sm0l-filter.py --task podman
+  journalctl -u svc 2>&1     | python3 sm0l-filter.py --task systemd
+  <any cmd> 2>&1             | python3 sm0l-filter.py
+  <any cmd> 2>&1             | python3 sm0l-filter.py --quiet  # CI: silent on success
 """
-import sys, os, argparse, http.client, json, urllib.request
+import sys, os, re, hashlib, argparse, json, urllib.request
 
-SYSTEM_PROMPT = (
-    "You are a terse error extractor. "
-    "Output ONLY lines from the input that contain errors, failures, or panics. "
-    "Never repeat a line. Never add commentary. If there are no errors, output nothing."
+# ─── Task templates ───────────────────────────────────────────────────────────
+_SUFFIX = (
+    " Return ONLY the matching lines verbatim. "
+    "If there are no matching lines: respond with exactly the two characters: -\n"
+    "Do NOT write 'no errors', 'no issues', 'clean', or any other commentary. "
+    "Two characters: hyphen newline. That is all."
 )
 
-def probe_openai_endpoint(base_url: str) -> bool:
-    """Return True if the endpoint responds to /health or /v1/models."""
+TASKS = {
+    "cargo": (
+        "You are a Rust build/test log filter. "
+        "Extract ONLY lines indicating: compile errors (error[E*]), test failures (FAILED, panicked at), "
+        "linker errors, missing crate errors. "
+        "If the same error code appears multiple times output it ONCE with count suffix ×N. "
+        "Suppress: warnings, note:, help:, ---> source paths (unless on the same line as error:)."
+        + _SUFFIX
+    ),
+    "podman": (
+        "You are a container runtime log filter. "
+        "Extract ONLY: pull failures, image not found, permission denied, OOM killed, "
+        "exec format error, exit code non-zero, CDI errors, ERRO level log lines."
+        + _SUFFIX
+    ),
+    "systemd": (
+        "You are a systemd/journalctl log filter. "
+        "Extract ONLY lines containing: Failed, failed, Error, error, killed, segfault, "
+        "start-limit-hit, dependency failed."
+        + _SUFFIX
+    ),
+    "hive": (
+        "You are a b00t hive log filter. "
+        "Extract ONLY: resource gate failures (insufficient RAM/GPU/CPU), "
+        "service start failures, exclusion group conflicts, guard BLOCK violations."
+        + _SUFFIX
+    ),
+    "general": (
+        "You are a terse error extractor. "
+        "Extract ONLY lines containing the words: error, failed, panic, fatal, denied, killed "
+        "(case-insensitive). Deduplicate repeated lines with count suffix ×N."
+        + _SUFFIX
+    ),
+}
+TASKS["rust"] = TASKS["cargo"]
+
+# ─── ANSI strip + normalize ───────────────────────────────────────────────────
+_ANSI_RE = re.compile(r"\x1b\[[0-9;]*[mGKH]")
+
+def _normalize(line: str) -> str:
+    return _ANSI_RE.sub("", line).strip()
+
+def preprocess(raw: str, max_unique: int = 500) -> tuple[str, dict]:
+    """Deduplicate + strip ANSI before sending to LLM. Returns (text, stats)."""
+    seen: dict[str, int] = {}
+    order: list[str] = []
+    for line in raw.splitlines():
+        norm = _normalize(line)
+        if not norm:
+            continue
+        h = hashlib.md5(norm.encode()).hexdigest()[:8]
+        if h not in seen:
+            seen[h] = 0
+            order.append(norm)
+        seen[h] += 1
+        if len(order) >= max_unique:
+            break
+
+    lines_with_counts = []
+    for norm in order:
+        h = hashlib.md5(norm.encode()).hexdigest()[:8]
+        n = seen[h]
+        lines_with_counts.append(f"{norm}" if n == 1 else f"{norm}  ×{n}")
+
+    return "\n".join(lines_with_counts), {
+        "raw_lines": len(raw.splitlines()),
+        "unique_lines": len(order),
+        "truncated": len(order) >= max_unique,
+    }
+
+# ─── Endpoint discovery ───────────────────────────────────────────────────────
+def _probe(url: str) -> bool:
     for path in ("/health", "/v1/models"):
         try:
-            req = urllib.request.Request(base_url.rstrip("/") + path, method="GET")
-            with urllib.request.urlopen(req, timeout=2) as r:
+            with urllib.request.urlopen(url.rstrip("/") + path, timeout=2) as r:
                 return r.status < 500
         except Exception:
             pass
     return False
 
+def discover_endpoint(model_hint: str) -> tuple[str, str, str]:
+    """(base_url, model, api_key)"""
+    override = os.environ.get("B00T_AI_SM0L_BASE")
+    if override:
+        m = os.environ.get("B00T_AI_SM0L_MODEL", model_hint or "sm0l")
+        return override, m, os.environ.get("B00T_AI_SM0L_KEY", "local-b00t")
 
-def call_openai(base_url: str, model: str, api_key: str, content: str, task: str) -> str:
-    prompt = task or SYSTEM_PROMPT
+    for url, default_model in [
+        ("http://127.0.0.1:8001/v1", "ch0nky"),
+        ("http://127.0.0.1:8000/v1", "sm0l"),
+    ]:
+        if _probe(url):
+            return url, model_hint or default_model, "local-b00t"
+
+    hf_token = os.environ.get("HF_TOKEN", "")
+    if hf_token:
+        return "hf://", model_hint or "Qwen/Qwen2.5-3B-Instruct", hf_token
+
+    print(
+        "[pipe-agent] ERROR: no endpoint at :8001/:8000 and no HF_TOKEN.\n"
+        "  Run: b00t hive activate inference-qwen36-27b-mtp-podman",
+        file=sys.stderr,
+    )
+    sys.exit(2)
+
+# ─── LLM call ─────────────────────────────────────────────────────────────────
+def call_openai(base_url: str, model: str, api_key: str, system: str, content: str) -> str:
     payload = json.dumps({
         "model": model,
         "messages": [
-            {"role": "system", "content": prompt},
-            {"role": "user", "content": content},
+            {"role": "system", "content": system},
+            {"role": "user",   "content": content},
         ],
-        "max_tokens": 2048,
+        "max_tokens": 1024,
         "temperature": 0.0,
     }).encode()
     req = urllib.request.Request(
         base_url.rstrip("/") + "/chat/completions",
         data=payload,
-        headers={
-            "Content-Type": "application/json",
-            "Authorization": f"Bearer {api_key}",
-        },
+        headers={"Content-Type": "application/json", "Authorization": f"Bearer {api_key}"},
         method="POST",
     )
-    with urllib.request.urlopen(req, timeout=30) as r:
-        resp = json.loads(r.read())
-    return resp["choices"][0]["message"]["content"].strip()
+    with urllib.request.urlopen(req, timeout=60) as r:
+        return json.loads(r.read())["choices"][0]["message"]["content"].strip()
 
-
-def call_hf_inference(model_id: str, content: str, task: str) -> str:
-    """Fallback: HuggingFace Inference API (serverless)."""
+def call_hf(model_id: str, token: str, system: str, content: str) -> str:
     try:
         from huggingface_hub import InferenceClient  # type: ignore
     except ImportError:
-        print("[sm0l-filter] ERROR: huggingface_hub not installed. Run: uv pip install huggingface-hub", file=sys.stderr)
+        print("[pipe-agent] ERROR: uv pip install huggingface-hub", file=sys.stderr)
         sys.exit(2)
-    prompt = task or SYSTEM_PROMPT
-    client = InferenceClient(model=model_id, token=os.environ.get("HF_TOKEN"))
-    result = client.text_generation(
-        f"<|system|>\n{prompt}\n<|user|>\n{content}\n<|assistant|>\n",
-        max_new_tokens=2048,
+    client = InferenceClient(model=model_id, token=token)
+    result = client.chat_completion(
+        messages=[{"role": "system", "content": system}, {"role": "user", "content": content}],
+        max_tokens=1024,
         temperature=0.01,
     )
-    return result.strip()
+    return result.choices[0].message.content.strip()
 
-
-def discover_endpoint(model_hint: str) -> tuple[str, str, str]:
-    """Return (base_url, model_name, api_key) using priority order."""
-    override = os.environ.get("B00T_AI_SM0L_BASE")
-    if override:
-        m = os.environ.get("B00T_AI_SM0L_MODEL", "sm0l")
-        return override, m, os.environ.get("B00T_AI_SM0L_KEY", "local-b00t")
-
-    for url, model, key in [
-        ("http://127.0.0.1:8001/v1", "ch0nky",   "local-b00t"),
-        ("http://127.0.0.1:8000/v1", "sm0l",      "local-b00t"),
-    ]:
-        if probe_openai_endpoint(url):
-            return url, model_hint or model, key
-
-    # HF Inference API fallback
-    hf_token = os.environ.get("HF_TOKEN", "")
-    if hf_token:
-        return "hf://", model_hint or "Qwen/Qwen2-0.5B-Instruct", hf_token
-
-    print("[sm0l-filter] ERROR: no local endpoint at :8001/:8000 and no HF_TOKEN. "
-          "Run: b00t hive activate inference-qwen36-27b", file=sys.stderr)
-    sys.exit(2)
-
-
+# ─── Main ─────────────────────────────────────────────────────────────────────
 def main():
-    ap = argparse.ArgumentParser(description="sm0l LLM stdin filter")
-    ap.add_argument("--model", default="", help="Model name override")
-    ap.add_argument("--task",  default="", help="Custom system prompt override")
-    ap.add_argument("--max-bytes", type=int, default=32000,
-                    help="Max stdin bytes (truncate to fit context)")
+    ap = argparse.ArgumentParser(description="b00t pipe-agent: sm0l LLM error filter")
+    ap.add_argument("--task",      default="general", choices=list(TASKS),
+                    help="Task template (cargo|podman|systemd|hive|rust|general)")
+    ap.add_argument("--model",     default="", help="Model name override")
+    ap.add_argument("--max-bytes", type=int, default=48_000,
+                    help="Max stdin bytes before truncation")
+    ap.add_argument("--quiet",     action="store_true",
+                    help="No output at all on success (CI mode)")
+    ap.add_argument("--stats",     action="store_true",
+                    help="Print line-count stats to stderr")
     args = ap.parse_args()
 
-    stdin_data = sys.stdin.buffer.read(args.max_bytes).decode("utf-8", errors="replace")
-    if not stdin_data.strip():
+    raw = sys.stdin.buffer.read(args.max_bytes).decode("utf-8", errors="replace")
+    if not raw.strip():
         sys.exit(0)
 
+    deduplicated, stats = preprocess(raw)
+    if args.stats:
+        trunc = " [TRUNCATED]" if stats["truncated"] else ""
+        print(
+            f"[pipe-agent] {stats['raw_lines']} raw → {stats['unique_lines']} unique{trunc}",
+            file=sys.stderr,
+        )
+
     base_url, model, api_key = discover_endpoint(args.model)
+    system_prompt = TASKS[args.task]
 
     if base_url == "hf://":
-        result = call_hf_inference(model, stdin_data, args.task)
+        result = call_hf(model, api_key, system_prompt, deduplicated)
     else:
-        result = call_openai(base_url, model, api_key, stdin_data, args.task)
+        result = call_openai(base_url, model, api_key, system_prompt, deduplicated)
 
-    if result:
+    # Sentinel: model returns "-\n" to signal clean/no-errors
+    if result and result.strip() not in ("-", ""):
         print(result)
-
 
 if __name__ == "__main__":
     main()

--- a/_b00t_/scripts/sm0l-filter.py
+++ b/_b00t_/scripts/sm0l-filter.py
@@ -160,8 +160,17 @@ def call_openai(base_url: str, model: str, api_key: str, system: str, content: s
         headers={"Content-Type": "application/json", "Authorization": f"Bearer {api_key}"},
         method="POST",
     )
-    with urllib.request.urlopen(req, timeout=60) as r:
-        return json.loads(r.read())["choices"][0]["message"]["content"].strip()
+    try:
+        with urllib.request.urlopen(req, timeout=60) as r:
+            data = json.loads(r.read())
+            return data["choices"][0]["message"]["content"].strip()
+    except urllib.error.HTTPError as e:
+        body = e.read().decode(errors="replace")[:200]
+        print(f"[pipe-agent] ERROR: HTTP {e.code} from endpoint: {body}", file=sys.stderr)
+        return "-"
+    except (urllib.error.URLError, json.JSONDecodeError, KeyError) as e:
+        print(f"[pipe-agent] ERROR: {type(e).__name__}: {e}", file=sys.stderr)
+        return "-"
 
 def call_hf(model_id: str, token: str, system: str, content: str) -> str:
     try:

--- a/_b00t_/scripts/sm0l-filter.py
+++ b/_b00t_/scripts/sm0l-filter.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+"""
+b00t sm0l-filter — pipe stdin through a sm0l LLM, output only error lines.
+
+Priority endpoint discovery (ControlFlow<Break, Continue> semantics):
+  1. B00T_AI_SM0L_BASE env (explicit override)
+  2. localhost:8001/v1  (b00t hive ch0nky vllm)
+  3. localhost:8000/v1  (local llama-server / any OpenAI-compat)
+  4. HuggingFace Inference API (serverless, requires HF_TOKEN)
+  5. Exit 2 (no endpoint) — never silently pass through unfiltered
+
+Usage (just recipes call this):
+  cargo test 2>&1 | python3 sm0l-filter.py --model sm0l
+  cargo build 2>&1 | python3 sm0l-filter.py --model ch0nky --task "output only lines with error:"
+"""
+import sys, os, argparse, http.client, json, urllib.request
+
+SYSTEM_PROMPT = (
+    "You are a terse error extractor. "
+    "Output ONLY lines from the input that contain errors, failures, or panics. "
+    "Never repeat a line. Never add commentary. If there are no errors, output nothing."
+)
+
+def probe_openai_endpoint(base_url: str) -> bool:
+    """Return True if the endpoint responds to /health or /v1/models."""
+    for path in ("/health", "/v1/models"):
+        try:
+            req = urllib.request.Request(base_url.rstrip("/") + path, method="GET")
+            with urllib.request.urlopen(req, timeout=2) as r:
+                return r.status < 500
+        except Exception:
+            pass
+    return False
+
+
+def call_openai(base_url: str, model: str, api_key: str, content: str, task: str) -> str:
+    prompt = task or SYSTEM_PROMPT
+    payload = json.dumps({
+        "model": model,
+        "messages": [
+            {"role": "system", "content": prompt},
+            {"role": "user", "content": content},
+        ],
+        "max_tokens": 2048,
+        "temperature": 0.0,
+    }).encode()
+    req = urllib.request.Request(
+        base_url.rstrip("/") + "/chat/completions",
+        data=payload,
+        headers={
+            "Content-Type": "application/json",
+            "Authorization": f"Bearer {api_key}",
+        },
+        method="POST",
+    )
+    with urllib.request.urlopen(req, timeout=30) as r:
+        resp = json.loads(r.read())
+    return resp["choices"][0]["message"]["content"].strip()
+
+
+def call_hf_inference(model_id: str, content: str, task: str) -> str:
+    """Fallback: HuggingFace Inference API (serverless)."""
+    try:
+        from huggingface_hub import InferenceClient  # type: ignore
+    except ImportError:
+        print("[sm0l-filter] ERROR: huggingface_hub not installed. Run: uv pip install huggingface-hub", file=sys.stderr)
+        sys.exit(2)
+    prompt = task or SYSTEM_PROMPT
+    client = InferenceClient(model=model_id, token=os.environ.get("HF_TOKEN"))
+    result = client.text_generation(
+        f"<|system|>\n{prompt}\n<|user|>\n{content}\n<|assistant|>\n",
+        max_new_tokens=2048,
+        temperature=0.01,
+    )
+    return result.strip()
+
+
+def discover_endpoint(model_hint: str) -> tuple[str, str, str]:
+    """Return (base_url, model_name, api_key) using priority order."""
+    override = os.environ.get("B00T_AI_SM0L_BASE")
+    if override:
+        m = os.environ.get("B00T_AI_SM0L_MODEL", "sm0l")
+        return override, m, os.environ.get("B00T_AI_SM0L_KEY", "local-b00t")
+
+    for url, model, key in [
+        ("http://127.0.0.1:8001/v1", "ch0nky",   "local-b00t"),
+        ("http://127.0.0.1:8000/v1", "sm0l",      "local-b00t"),
+    ]:
+        if probe_openai_endpoint(url):
+            return url, model_hint or model, key
+
+    # HF Inference API fallback
+    hf_token = os.environ.get("HF_TOKEN", "")
+    if hf_token:
+        return "hf://", model_hint or "Qwen/Qwen2-0.5B-Instruct", hf_token
+
+    print("[sm0l-filter] ERROR: no local endpoint at :8001/:8000 and no HF_TOKEN. "
+          "Run: b00t hive activate inference-qwen36-27b", file=sys.stderr)
+    sys.exit(2)
+
+
+def main():
+    ap = argparse.ArgumentParser(description="sm0l LLM stdin filter")
+    ap.add_argument("--model", default="", help="Model name override")
+    ap.add_argument("--task",  default="", help="Custom system prompt override")
+    ap.add_argument("--max-bytes", type=int, default=32000,
+                    help="Max stdin bytes (truncate to fit context)")
+    args = ap.parse_args()
+
+    stdin_data = sys.stdin.buffer.read(args.max_bytes).decode("utf-8", errors="replace")
+    if not stdin_data.strip():
+        sys.exit(0)
+
+    base_url, model, api_key = discover_endpoint(args.model)
+
+    if base_url == "hf://":
+        result = call_hf_inference(model, stdin_data, args.task)
+    else:
+        result = call_openai(base_url, model, api_key, stdin_data, args.task)
+
+    if result:
+        print(result)
+
+
+if __name__ == "__main__":
+    main()

--- a/_b00t_/scripts/sm0l-filter.py
+++ b/_b00t_/scripts/sm0l-filter.py
@@ -178,17 +178,33 @@ def call_hf(model_id: str, token: str, system: str, content: str) -> str:
     return result.choices[0].message.content.strip()
 
 # ─── Main ─────────────────────────────────────────────────────────────────────
+def session_log(session_id: str, tag: str, prompt: str, input_text: str, output: str) -> str:
+    """Write sm0l I/O to ephemeral session dir. Returns output file path."""
+    import time
+    base = f"/tmp/b00t-sm0l-{session_id}"
+    os.makedirs(base, exist_ok=True)
+    n = len([f for f in os.listdir(base) if f.endswith(".output")])
+    prefix = f"{base}/{n:04d}-{tag}"
+    for kind, content in [("prompt", prompt), ("input", input_text), ("output", output)]:
+        with open(f"{prefix}.{kind}", "w", errors="replace") as f:
+            f.write(content)
+    return f"{prefix}.output"
+
+
 def main():
     ap = argparse.ArgumentParser(description="b00t pipe-agent: sm0l LLM error filter")
-    ap.add_argument("--task",      default="general", choices=list(TASKS),
+    ap.add_argument("--task",       default="general", choices=list(TASKS),
                     help="Task template (cargo|podman|systemd|hive|rust|general)")
-    ap.add_argument("--model",     default="", help="Model name override")
-    ap.add_argument("--max-bytes", type=int, default=48_000,
+    ap.add_argument("--model",      default="", help="Model name override")
+    ap.add_argument("--max-bytes",  type=int, default=48_000,
                     help="Max stdin bytes before truncation")
-    ap.add_argument("--quiet",     action="store_true",
-                    help="No output at all on success (CI mode)")
-    ap.add_argument("--stats",     action="store_true",
+    ap.add_argument("--quiet",      action="store_true",
+                    help="Suppress output on success (CI mode)")
+    ap.add_argument("--stats",      action="store_true",
                     help="Print line-count stats to stderr")
+    ap.add_argument("--session-id", default="", metavar="ID",
+                    help="Session ID for ephemeral log (/tmp/b00t-sm0l-<ID>/). "
+                         "ch0nky receives log path to reference if needed.")
     args = ap.parse_args()
 
     raw = sys.stdin.buffer.read(args.max_bytes).decode("utf-8", errors="replace")
@@ -211,9 +227,16 @@ def main():
     else:
         result = call_openai(base_url, model, api_key, system_prompt, deduplicated)
 
-    # Sentinel: model returns "-\n" to signal clean/no-errors
-    if result and result.strip() not in ("-", ""):
+    # Log to session if requested — full I/O preserved for ch0nky to reference
+    if args.session_id:
+        log_path = session_log(args.session_id, args.task, system_prompt, deduplicated, result)
+        print(f"[pipe-agent:log] {log_path}", file=sys.stderr)
+
+    # Sentinel: model returns "-" to signal clean/no-errors
+    if result and result.strip() not in ("-", "") and not args.quiet:
         print(result)
+    elif result and result.strip() not in ("-", "") and args.quiet:
+        print(result)  # quiet suppresses nothing on actual errors
 
 if __name__ == "__main__":
     main()

--- a/_b00t_/wrkflw.cli.toml
+++ b/_b00t_/wrkflw.cli.toml
@@ -1,0 +1,42 @@
+[b00t]
+name = "wrkflw"
+type = "cli"
+hint = "Run and validate GitHub Actions workflows locally — no Docker required. Faster than act for Rust/Python cargo-based workflows."
+repo = "bahdotsh/wrkflw"
+
+desires = "0.8.0"
+version_regex = 'wrkflw (?P<version>[\d.]+)'
+detect = ["wrkflw --version"]
+
+# @tribal: gh CLI is REQUIRED — used to resolve latest release tag for updates
+# install uses gh release download for repeatability and audit logging
+install = [
+  "bash -c 'set -euo pipefail; command -v gh >/dev/null || { echo \"gh CLI required: b00t install gh\" >&2; exit 1; }; ASSET=wrkflw-x86_64-unknown-linux-gnu.tar.gz; gh release download v0.8.0 --repo bahdotsh/wrkflw --pattern \"$ASSET\" --dir /tmp && tar xz -C /tmp/ -f /tmp/$ASSET && install -m755 /tmp/wrkflw ~/.local/bin/wrkflw'"
+]
+
+update = [
+  "bash -c 'set -euo pipefail; command -v gh >/dev/null || { echo \"gh CLI required: b00t install gh\" >&2; exit 1; }; VER=$(gh release view --repo bahdotsh/wrkflw --json tagName --jq .tagName); ASSET=wrkflw-x86_64-unknown-linux-gnu.tar.gz; gh release download $VER --repo bahdotsh/wrkflw --pattern \"$ASSET\" --dir /tmp && tar xz -C /tmp/ -f /tmp/$ASSET && install -m755 /tmp/wrkflw ~/.local/bin/wrkflw && echo installed $VER'"
+]
+
+[b00t.prerequisites]
+required = ["gh"]
+
+[[b00t.usage]]
+description = "List available workflows in this repo"
+command = "wrkflw list"
+
+[[b00t.usage]]
+description = "Run k0mmand3r CI workflow locally (emulation mode — no Docker needed)"
+command = "wrkflw run --runtime emulation .github/workflows/rust-k0mmand3r.yml"
+
+[[b00t.usage]]
+description = "Validate all workflow files"
+command = "wrkflw validate"
+
+[[b00t.usage]]
+description = "Run specific workflow"
+command = "wrkflw run .github/workflows/<workflow>.yml"
+
+[[b00t.references]]
+name = "bahdotsh/wrkflw"
+url = "https://github.com/bahdotsh/wrkflw"

--- a/_b00t_/wrkflw.cli.toml
+++ b/_b00t_/wrkflw.cli.toml
@@ -8,18 +8,29 @@ desires = "0.8.0"
 version_regex = 'wrkflw (?P<version>[\d.]+)'
 detect = ["wrkflw --version"]
 
-# @tribal: gh CLI is REQUIRED — used to resolve latest release tag for updates
-# install uses gh release download for repeatability and audit logging
-install = [
-  "bash -c 'set -euo pipefail; command -v gh >/dev/null || { echo \"gh CLI required: b00t install gh\" >&2; exit 1; }; ASSET=wrkflw-x86_64-unknown-linux-gnu.tar.gz; gh release download v0.8.0 --repo bahdotsh/wrkflw --pattern \"$ASSET\" --dir /tmp && tar xz -C /tmp/ -f /tmp/$ASSET && install -m755 /tmp/wrkflw ~/.local/bin/wrkflw'"
-]
+# @tribal: gh CLI is a REQUIRED mandatory prerequisite — install commands use
+# `gh release download` for audit logging and version pinning.
+# If gh is missing: b00t install gh
+install = """
+set -euo pipefail
+command -v gh >/dev/null 2>&1 || { echo "❌ gh CLI required: b00t install gh" >&2; exit 1; }
+ASSET=wrkflw-x86_64-unknown-linux-gnu.tar.gz
+gh release download v0.8.0 --repo bahdotsh/wrkflw --pattern "$ASSET" --dir /tmp --clobber
+tar xz -C /tmp/ -f /tmp/$ASSET
+install -m755 /tmp/wrkflw ~/.local/bin/wrkflw
+wrkflw --version
+"""
 
-update = [
-  "bash -c 'set -euo pipefail; command -v gh >/dev/null || { echo \"gh CLI required: b00t install gh\" >&2; exit 1; }; VER=$(gh release view --repo bahdotsh/wrkflw --json tagName --jq .tagName); ASSET=wrkflw-x86_64-unknown-linux-gnu.tar.gz; gh release download $VER --repo bahdotsh/wrkflw --pattern \"$ASSET\" --dir /tmp && tar xz -C /tmp/ -f /tmp/$ASSET && install -m755 /tmp/wrkflw ~/.local/bin/wrkflw && echo installed $VER'"
-]
-
-[b00t.prerequisites]
-required = ["gh"]
+update = """
+set -euo pipefail
+command -v gh >/dev/null 2>&1 || { echo "❌ gh CLI required: b00t install gh" >&2; exit 1; }
+VER=$(gh release view --repo bahdotsh/wrkflw --json tagName --jq .tagName)
+ASSET=wrkflw-x86_64-unknown-linux-gnu.tar.gz
+gh release download "$VER" --repo bahdotsh/wrkflw --pattern "$ASSET" --dir /tmp --clobber
+tar xz -C /tmp/ -f /tmp/$ASSET
+install -m755 /tmp/wrkflw ~/.local/bin/wrkflw
+echo "✅ installed wrkflw $VER"
+"""
 
 [[b00t.usage]]
 description = "List available workflows in this repo"

--- a/b00t-c0re-lib/src/aaiii.rs
+++ b/b00t-c0re-lib/src/aaiii.rs
@@ -229,6 +229,10 @@ impl AaiiiConfig {
     }
 
     fn pi_base_url_candidates() -> Vec<String> {
+        Self::pi_base_url_candidates_with_env(|key| env::var(key).ok())
+    }
+
+    fn pi_base_url_candidates_with_env<F: Fn(&str) -> Option<String>>(env_fn: F) -> Vec<String> {
         let mut candidates = Vec::new();
 
         for key in [
@@ -237,10 +241,10 @@ impl AaiiiConfig {
             "LLAMA_CPP_BASE_URL",
             "OPENAI_BASE_URL",
         ] {
-            if let Ok(value) = env::var(key) {
-                let trimmed = value.trim();
-                if !trimmed.is_empty() && !candidates.iter().any(|existing| existing == trimmed) {
-                    candidates.push(trimmed.to_string());
+            if let Some(value) = env_fn(key) {
+                let trimmed = value.trim().to_string();
+                if !trimmed.is_empty() && !candidates.iter().any(|existing| existing == &trimmed) {
+                    candidates.push(trimmed);
                 }
             }
         }
@@ -405,58 +409,24 @@ mod tests {
 
     #[test]
     fn test_pi_base_url_candidates_prioritize_env_override() {
-        let key = "B00T_AI_CH0NKY_BASE";
-        let previous = std::env::var(key).ok();
-        unsafe {
-            std::env::set_var(key, "http://127.0.0.1:8001/v1");
-        }
-
-        let candidates = AaiiiConfig::pi_base_url_candidates();
+        // DI: no env mutation — safe for parallel test execution
+        let candidates = AaiiiConfig::pi_base_url_candidates_with_env(|key| match key {
+            "B00T_AI_CH0NKY_BASE" => Some("http://127.0.0.1:8001/v1".to_string()),
+            _ => None,
+        });
         assert_eq!(
             candidates.first().map(String::as_str),
             Some("http://127.0.0.1:8001/v1")
         );
-        assert!(
-            candidates
-                .iter()
-                .any(|candidate| candidate == "http://localhost:1234/v1")
-        );
-
-        if let Some(value) = previous {
-            unsafe {
-                std::env::set_var(key, value);
-            }
-        } else {
-            unsafe {
-                std::env::remove_var(key);
-            }
-        }
+        assert!(candidates.iter().any(|c| c == "http://localhost:1234/v1"));
     }
 
     #[test]
     fn test_pi_base_url_candidates_include_direct_gemma4_fallback() {
-        for key in [
-            "B00T_AI_CH0NKY_BASE",
-            "PI_BASE_URL",
-            "LLAMA_CPP_BASE_URL",
-            "OPENAI_BASE_URL",
-        ] {
-            unsafe {
-                std::env::remove_var(key);
-            }
-        }
-
-        let candidates = AaiiiConfig::pi_base_url_candidates();
-        assert!(
-            candidates
-                .iter()
-                .any(|candidate| candidate == "http://localhost:1234/v1")
-        );
-        assert!(
-            candidates
-                .iter()
-                .any(|candidate| candidate == "http://localhost:8001/v1")
-        );
+        // DI: no env mutation — safe for parallel test execution
+        let candidates = AaiiiConfig::pi_base_url_candidates_with_env(|_| None);
+        assert!(candidates.iter().any(|c| c == "http://localhost:1234/v1"));
+        assert!(candidates.iter().any(|c| c == "http://localhost:8001/v1"));
     }
 
     #[test]

--- a/b00t-c0re-lib/src/lib.rs
+++ b/b00t-c0re-lib/src/lib.rs
@@ -55,6 +55,7 @@ pub mod redis;
 pub mod rhai_engine;
 pub mod runtime_env;
 pub mod secret_validation;
+pub mod sm0l_dispatch;
 pub mod template;
 pub mod utils;
 

--- a/b00t-c0re-lib/src/sm0l_dispatch.rs
+++ b/b00t-c0re-lib/src/sm0l_dispatch.rs
@@ -23,6 +23,7 @@ use std::fs;
 use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::OnceLock;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 // ─── Behavior chains ──────────────────────────────────────────────────────────
@@ -206,15 +207,16 @@ impl SmolEndpoint {
     }
 
     fn probe(base_url: &str) -> bool {
+        let client = match reqwest::blocking::Client::builder()
+            .timeout(std::time::Duration::from_secs(2))
+            .build()
+        {
+            Ok(c) => c,
+            Err(_) => return false, // fail closed — TLS/env issues
+        };
         for path in ["/health", "/v1/models"] {
             let url = format!("{}{}", base_url.trim_end_matches('/'), path);
-            if let Ok(resp) = reqwest::blocking::Client::builder()
-                .timeout(std::time::Duration::from_secs(2))
-                .build()
-                .unwrap()
-                .get(&url)
-                .send()
-            {
+            if let Ok(resp) = client.get(&url).send() {
                 if resp.status().as_u16() < 500 {
                     return true;
                 }
@@ -359,8 +361,8 @@ impl SmolOutput {
     pub fn summary_line(&self) -> String {
         if self.is_clean() {
             format!(
-                "[sm0l:{}→{}] ✅ clean ({} raw → {} unique)",
-                self.endpoint, self.stats.raw_lines, self.stats.raw_lines, self.stats.unique_lines
+                "[sm0l:{}] ✅ clean ({} raw → {} unique)",
+                self.endpoint, self.stats.raw_lines, self.stats.unique_lines
             )
         } else {
             let preview = self
@@ -439,9 +441,11 @@ pub fn dispatch_with_endpoint(
 
 // ─── Internal helpers ─────────────────────────────────────────────────────────
 
+static ANSI_RE: OnceLock<regex::Regex> = OnceLock::new();
+
 fn preprocess(raw: &str, max_bytes: usize) -> (String, SmolStats) {
-    // Strip ANSI escape sequences
-    let ansi_re = regex::Regex::new(r"\x1b\[[0-9;]*[mGKH]").unwrap();
+    // Strip ANSI escape sequences — compiled once via OnceLock
+    let ansi_re = ANSI_RE.get_or_init(|| regex::Regex::new(r"\x1b\[[0-9;]*[mGKH]").unwrap());
 
     let mut seen: std::collections::HashMap<[u8; 8], usize> = Default::default();
     let mut order: Vec<String> = Vec::new();
@@ -525,6 +529,11 @@ fn call_endpoint(endpoint: &SmolEndpoint, system: &str, content: &str) -> Result
         .send()
         .map_err(|e| anyhow!("sm0l endpoint call failed: {e}"))?;
 
+    let status = resp.status();
+    if !status.is_success() {
+        let body_text = resp.text().unwrap_or_default();
+        return Err(anyhow!("sm0l endpoint HTTP {status}: {body_text}"));
+    }
     let body: serde_json::Value = resp.json()?;
     let text = body["choices"][0]["message"]["content"]
         .as_str()

--- a/b00t-c0re-lib/src/sm0l_dispatch.rs
+++ b/b00t-c0re-lib/src/sm0l_dispatch.rs
@@ -1,0 +1,653 @@
+//! # SmolDispatch — cognitive tier routing for sm0l local inference
+//!
+//! Internal alias for "delegate this to the sm0l tier and get back compressed output."
+//! ch0nky/frontier models call SmolDispatch; sm0l processes without tool calls.
+//!
+//! Architecture (OpenHarness mantra): "The model is the agent. The code is the harness."
+//!   ch0nky decides WHAT to delegate → SmolDispatch routes HOW → sm0l executes passively.
+//!
+//! Endpoint priority (matches sm0l-filter.py):
+//!   1. B00T_AI_SM0L_BASE env   (explicit override)
+//!   2. :8001/v1               (ch0nky llamacpp MTP — currently Qwen3.6-27B)
+//!   3. :8000/v1               (any local OpenAI-compat server)
+//!   4. HF Inference API       (serverless, requires HF_TOKEN)
+//!   5. Err(NoEndpoint)        — governance gate, never silently pass-through
+//!
+//! Session logs: /tmp/b00t-sm0l-<session-id>/ — ephemeral, cleared by session_cleanup().
+//! ch0nky receives log_path in SmolOutput.log_path and MAY read it; ignores if unneeded.
+
+use anyhow::{Result, anyhow};
+use std::env;
+use std::fmt;
+use std::fs;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+// ─── Behavior chains ──────────────────────────────────────────────────────────
+
+/// Named behavior chains for sm0l delegation.
+/// Each variant maps to a system prompt template + output contract.
+#[derive(Debug, Clone, PartialEq)]
+pub enum SmolBehavior {
+    /// Filter build/test/runtime output → errors only. Most common delegation.
+    FilterErrors(FilterTask),
+    /// Collapse long output to N key points. For ch0nky pre-digestion.
+    Summarize { max_output_lines: usize },
+    /// Binary pass/fail: did this command succeed? Returns "ok" or first failure line.
+    CheckOutputOk,
+}
+
+/// Task-specific error filter templates. Each has a specialized system prompt.
+#[derive(Debug, Clone, PartialEq)]
+pub enum FilterTask {
+    Cargo,
+    Podman,
+    Systemd,
+    Hive,
+    General,
+}
+
+impl FilterTask {
+    fn as_str(&self) -> &'static str {
+        match self {
+            Self::Cargo => "cargo",
+            Self::Podman => "podman",
+            Self::Systemd => "systemd",
+            Self::Hive => "hive",
+            Self::General => "general",
+        }
+    }
+
+    fn system_prompt(&self) -> &'static str {
+        let _suffix =
+            " Return ONLY matching lines. If none: respond with exactly: -\nNo commentary.";
+        match self {
+            Self::Cargo => concat!(
+                "You are a Rust build/test log filter. ",
+                "Extract ONLY: compile errors (error[E*]), test failures (FAILED, panicked at), ",
+                "linker errors, missing crate errors. ",
+                "Deduplicate repeated error codes with ×N count suffix. ",
+                "Suppress: warnings, note:, help:, arrow source paths.",
+                " Return ONLY matching lines. If none: respond with exactly: -\nNo commentary."
+            ),
+            Self::Podman => concat!(
+                "You are a container runtime log filter. ",
+                "Extract ONLY: pull failures, image not found, permission denied, OOM killed, ",
+                "exit code non-zero, CDI errors, ERRO level lines.",
+                " Return ONLY matching lines. If none: respond with exactly: -\nNo commentary."
+            ),
+            Self::Systemd => concat!(
+                "You are a systemd/journalctl log filter. ",
+                "Extract ONLY: Failed, failed, Error, error, killed, segfault, start-limit-hit.",
+                " Return ONLY matching lines. If none: respond with exactly: -\nNo commentary."
+            ),
+            Self::Hive => concat!(
+                "You are a b00t hive log filter. ",
+                "Extract ONLY: resource gate failures, service start failures, ",
+                "exclusion group conflicts, guard BLOCK violations.",
+                " Return ONLY matching lines. If none: respond with exactly: -\nNo commentary."
+            ),
+            Self::General => concat!(
+                "You are a terse error extractor. ",
+                "Extract ONLY lines containing: error, failed, panic, fatal, denied, killed ",
+                "(case-insensitive). Deduplicate with ×N count suffix.",
+                " Return ONLY matching lines. If none: respond with exactly: -\nNo commentary."
+            ),
+        }
+    }
+}
+
+impl SmolBehavior {
+    fn system_prompt(&self) -> String {
+        match self {
+            Self::FilterErrors(task) => task.system_prompt().to_string(),
+            Self::Summarize { max_output_lines } => format!(
+                "You are a terse summarizer. Collapse the input to at most {max_output_lines} \
+                 bullet points covering only novel information. Remove duplicates. \
+                 Output bullets only, no preamble."
+            ),
+            Self::CheckOutputOk => concat!(
+                "You are a pass/fail checker. ",
+                "If the input shows a successful outcome with no errors: respond with exactly: ok\n",
+                "Otherwise: respond with the first failure line verbatim. No other output."
+            ).to_string(),
+        }
+    }
+
+    fn log_tag(&self) -> String {
+        match self {
+            Self::FilterErrors(t) => format!("filter-{}", t.as_str()),
+            Self::Summarize { .. } => "summarize".to_string(),
+            Self::CheckOutputOk => "check-ok".to_string(),
+        }
+    }
+}
+
+// ─── Endpoint discovery ───────────────────────────────────────────────────────
+
+/// Resolved sm0l endpoint. Cheap to clone; construction probes the network.
+#[derive(Debug, Clone)]
+pub struct SmolEndpoint {
+    pub base_url: String,
+    pub model: String,
+    pub api_key: String,
+    pub source: EndpointSource,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum EndpointSource {
+    EnvOverride,
+    LocalPort(u16),
+    HfInference,
+}
+
+impl fmt::Display for SmolEndpoint {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}({})", self.model, self.base_url)
+    }
+}
+
+impl SmolEndpoint {
+    /// Probe in priority order; return first live endpoint.
+    pub fn discover() -> Result<Self> {
+        Self::discover_with_env(|key| env::var(key).ok())
+    }
+
+    pub fn discover_with_env<F: Fn(&str) -> Option<String>>(env_fn: F) -> Result<Self> {
+        Self::discover_with(env_fn, Self::probe)
+    }
+
+    /// Full DI variant — both env lookup and port probe are injected. Used in tests.
+    pub fn discover_with<F, P>(env_fn: F, probe_fn: P) -> Result<Self>
+    where
+        F: Fn(&str) -> Option<String>,
+        P: Fn(&str) -> bool,
+    {
+        // 1. explicit override
+        if let Some(base_url) = env_fn("B00T_AI_SM0L_BASE") {
+            return Ok(SmolEndpoint {
+                model: env_fn("B00T_AI_SM0L_MODEL").unwrap_or_else(|| "sm0l".to_string()),
+                api_key: env_fn("B00T_AI_SM0L_KEY").unwrap_or_else(|| "local-b00t".to_string()),
+                base_url,
+                source: EndpointSource::EnvOverride,
+            });
+        }
+
+        // 2–3. probe local ports
+        for (port, model) in [(8001u16, "ch0nky"), (8000u16, "sm0l")] {
+            let url = format!("http://127.0.0.1:{port}/v1");
+            if probe_fn(&url) {
+                return Ok(SmolEndpoint {
+                    base_url: url,
+                    model: model.to_string(),
+                    api_key: "local-b00t".to_string(),
+                    source: EndpointSource::LocalPort(port),
+                });
+            }
+        }
+
+        // 4. HF Inference API
+        if let Some(token) = env_fn("HF_TOKEN") {
+            if !token.is_empty() {
+                return Ok(SmolEndpoint {
+                    base_url: "https://api-inference.huggingface.co/v1".to_string(),
+                    model: "Qwen/Qwen2.5-3B-Instruct".to_string(),
+                    api_key: token,
+                    source: EndpointSource::HfInference,
+                });
+            }
+        }
+
+        Err(anyhow!(
+            "SmolDispatch: no endpoint. Run: b00t hive activate inference-qwen36-27b-mtp-podman"
+        ))
+    }
+
+    fn probe(base_url: &str) -> bool {
+        for path in ["/health", "/v1/models"] {
+            let url = format!("{}{}", base_url.trim_end_matches('/'), path);
+            if let Ok(resp) = reqwest::blocking::Client::builder()
+                .timeout(std::time::Duration::from_secs(2))
+                .build()
+                .unwrap()
+                .get(&url)
+                .send()
+            {
+                if resp.status().as_u16() < 500 {
+                    return true;
+                }
+            }
+        }
+        false
+    }
+}
+
+// ─── Session logging ───────────────────────────────────────────────────────────
+
+/// Ephemeral session log directory. Persists on disk until explicit cleanup.
+/// ch0nky receives log_path in SmolOutput and MAY read the full I/O; ignores by default.
+pub struct SmolSession {
+    pub id: String,
+    pub dir: PathBuf,
+    counter: AtomicUsize,
+}
+
+impl SmolSession {
+    /// Create new session under /tmp/b00t-sm0l-<timestamp>-<pid>/
+    pub fn new() -> Self {
+        let ts = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|d| d.as_secs())
+            .unwrap_or(0);
+        let pid = std::process::id();
+        let id = format!("{ts}-{pid}");
+        let dir = PathBuf::from(format!("/tmp/b00t-sm0l-{id}"));
+        let _ = fs::create_dir_all(&dir);
+        Self {
+            id,
+            dir,
+            counter: AtomicUsize::new(0),
+        }
+    }
+
+    /// Load existing session by ID (for ch0nky to reference prior sm0l output).
+    pub fn load(id: &str) -> Option<Self> {
+        let dir = PathBuf::from(format!("/tmp/b00t-sm0l-{id}"));
+        if dir.exists() {
+            Some(Self {
+                id: id.to_string(),
+                dir,
+                counter: AtomicUsize::new(0),
+            })
+        } else {
+            None
+        }
+    }
+
+    fn next_n(&self) -> usize {
+        self.counter.fetch_add(1, Ordering::Relaxed)
+    }
+
+    fn write_log(&self, n: usize, tag: &str, kind: &str, content: &str) -> PathBuf {
+        let path = self.dir.join(format!("{n:04}-{tag}.{kind}"));
+        if let Ok(mut f) = fs::File::create(&path) {
+            let _ = f.write_all(content.as_bytes());
+        }
+        path
+    }
+
+    /// Log a sm0l interaction. Returns (prompt_path, input_path, output_path).
+    pub fn log(
+        &self,
+        tag: &str,
+        prompt: &str,
+        input: &str,
+        output: &str,
+    ) -> (PathBuf, PathBuf, PathBuf) {
+        let n = self.next_n();
+        let p = self.write_log(n, tag, "prompt", prompt);
+        let i = self.write_log(n, tag, "input", input);
+        let o = self.write_log(n, tag, "output", output);
+        (p, i, o)
+    }
+
+    /// Remove all session files. Call at session end.
+    pub fn cleanup(&self) {
+        let _ = fs::remove_dir_all(&self.dir);
+    }
+
+    /// Remove all sm0l session dirs older than max_age_secs.
+    pub fn cleanup_old(max_age_secs: u64) {
+        let tmp = Path::new("/tmp");
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|d| d.as_secs())
+            .unwrap_or(0);
+        let Ok(entries) = fs::read_dir(tmp) else {
+            return;
+        };
+        for entry in entries.flatten() {
+            let name = entry.file_name();
+            let name = name.to_string_lossy();
+            if !name.starts_with("b00t-sm0l-") {
+                continue;
+            }
+            if let Ok(meta) = entry.metadata() {
+                if let Ok(modified) = meta.modified() {
+                    if let Ok(age) = modified.duration_since(UNIX_EPOCH) {
+                        if now.saturating_sub(age.as_secs()) > max_age_secs {
+                            let _ = fs::remove_dir_all(entry.path());
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+impl Default for SmolSession {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+// ─── Dispatch output ──────────────────────────────────────────────────────────
+
+/// What ch0nky gets back from a sm0l delegation.
+#[derive(Debug)]
+pub struct SmolOutput {
+    /// Filtered/processed content. None = clean (no issues found).
+    pub result: Option<String>,
+    /// Path to the full I/O log. ch0nky reads this only if it needs to investigate.
+    pub log_path: Option<PathBuf>,
+    pub stats: SmolStats,
+    pub endpoint: String,
+}
+
+impl SmolOutput {
+    /// True if sm0l found no issues (result is None or sentinel "-").
+    pub fn is_clean(&self) -> bool {
+        match &self.result {
+            None => true,
+            Some(s) => s.trim() == "-",
+        }
+    }
+
+    /// One-line summary for executive context. Keeps frontier tokens minimal.
+    pub fn summary_line(&self) -> String {
+        if self.is_clean() {
+            format!(
+                "[sm0l:{}→{}] ✅ clean ({} raw → {} unique)",
+                self.endpoint, self.stats.raw_lines, self.stats.raw_lines, self.stats.unique_lines
+            )
+        } else {
+            let preview = self
+                .result
+                .as_deref()
+                .unwrap_or("")
+                .lines()
+                .next()
+                .unwrap_or("")
+                .chars()
+                .take(120)
+                .collect::<String>();
+            let log_ref = self
+                .log_path
+                .as_ref()
+                .map(|p| format!(" log:{}", p.display()))
+                .unwrap_or_default();
+            format!("[sm0l:{}] ⚠ {preview}…{log_ref}", self.endpoint)
+        }
+    }
+}
+
+#[derive(Debug, Default)]
+pub struct SmolStats {
+    pub raw_lines: usize,
+    pub unique_lines: usize,
+    pub was_truncated: bool,
+}
+
+// ─── Dispatch entry point ─────────────────────────────────────────────────────
+
+/// Main dispatch function. Deduplicate, call sm0l, log, return SmolOutput.
+pub fn dispatch(
+    behavior: &SmolBehavior,
+    input: &str,
+    session: Option<&SmolSession>,
+    max_input_bytes: usize,
+) -> Result<SmolOutput> {
+    let endpoint = SmolEndpoint::discover()?;
+    dispatch_with_endpoint(behavior, input, session, max_input_bytes, &endpoint)
+}
+
+pub fn dispatch_with_endpoint(
+    behavior: &SmolBehavior,
+    input: &str,
+    session: Option<&SmolSession>,
+    max_input_bytes: usize,
+    endpoint: &SmolEndpoint,
+) -> Result<SmolOutput> {
+    // 1. Preprocess: dedup + strip ANSI + truncate
+    let (processed, stats) = preprocess(input, max_input_bytes);
+    let system = behavior.system_prompt();
+    let tag = behavior.log_tag();
+
+    // 2. Call sm0l
+    let raw_result = call_endpoint(endpoint, &system, &processed)?;
+    let result = if raw_result.trim() == "-" || raw_result.trim().is_empty() {
+        None
+    } else {
+        Some(raw_result.clone())
+    };
+
+    // 3. Log to session if provided
+    let log_path = session.map(|s| {
+        let (_, _, out_path) = s.log(&tag, &system, &processed, &raw_result);
+        out_path
+    });
+
+    Ok(SmolOutput {
+        result,
+        log_path,
+        stats,
+        endpoint: endpoint.to_string(),
+    })
+}
+
+// ─── Internal helpers ─────────────────────────────────────────────────────────
+
+fn preprocess(raw: &str, max_bytes: usize) -> (String, SmolStats) {
+    // Strip ANSI escape sequences
+    let ansi_re = regex::Regex::new(r"\x1b\[[0-9;]*[mGKH]").unwrap();
+
+    let mut seen: std::collections::HashMap<[u8; 8], usize> = Default::default();
+    let mut order: Vec<String> = Vec::new();
+    let max_unique = 500;
+
+    for line in raw.lines() {
+        let norm = ansi_re.replace_all(line, "").trim().to_string();
+        if norm.is_empty() {
+            continue;
+        }
+        // 8-byte hash for dedup key
+        use std::hash::{Hash, Hasher};
+        let mut h = std::collections::hash_map::DefaultHasher::new();
+        norm.hash(&mut h);
+        let key = h.finish().to_le_bytes();
+
+        *seen.entry(key).or_insert(0) += 1;
+        if seen[&key] == 1 {
+            order.push(norm);
+        }
+        if order.len() >= max_unique {
+            break;
+        }
+    }
+
+    let raw_lines = raw.lines().count();
+    let unique_lines = order.len();
+    let was_truncated = unique_lines >= max_unique;
+
+    let mut text = String::new();
+    for line in &order {
+        use std::hash::{Hash, Hasher};
+        let mut h = std::collections::hash_map::DefaultHasher::new();
+        line.hash(&mut h);
+        let key = h.finish().to_le_bytes();
+        let n = seen[&key];
+        if n > 1 {
+            text.push_str(&format!("{line}  ×{n}\n"));
+        } else {
+            text.push_str(line);
+            text.push('\n');
+        }
+        if text.len() >= max_bytes {
+            break;
+        }
+    }
+
+    (
+        text,
+        SmolStats {
+            raw_lines,
+            unique_lines,
+            was_truncated,
+        },
+    )
+}
+
+fn call_endpoint(endpoint: &SmolEndpoint, system: &str, content: &str) -> Result<String> {
+    let payload = serde_json::json!({
+        "model": endpoint.model,
+        "messages": [
+            {"role": "system", "content": system},
+            {"role": "user",   "content": content},
+        ],
+        "max_tokens": 1024,
+        "temperature": 0.0,
+    });
+
+    let client = reqwest::blocking::Client::builder()
+        .timeout(std::time::Duration::from_secs(60))
+        .build()?;
+
+    let resp = client
+        .post(format!(
+            "{}/chat/completions",
+            endpoint.base_url.trim_end_matches('/')
+        ))
+        .header("Content-Type", "application/json")
+        .header("Authorization", format!("Bearer {}", endpoint.api_key))
+        .json(&payload)
+        .send()
+        .map_err(|e| anyhow!("sm0l endpoint call failed: {e}"))?;
+
+    let body: serde_json::Value = resp.json()?;
+    let text = body["choices"][0]["message"]["content"]
+        .as_str()
+        .unwrap_or("-")
+        .trim()
+        .to_string();
+    Ok(text)
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_filter_task_prompts_non_empty() {
+        for task in [
+            FilterTask::Cargo,
+            FilterTask::Podman,
+            FilterTask::Systemd,
+            FilterTask::Hive,
+            FilterTask::General,
+        ] {
+            let p = task.system_prompt();
+            assert!(!p.is_empty());
+            assert!(
+                p.contains("Return ONLY"),
+                "sentinel instruction missing for {:?}",
+                task
+            );
+        }
+    }
+
+    #[test]
+    fn test_smol_output_is_clean() {
+        let clean = SmolOutput {
+            result: None,
+            log_path: None,
+            stats: SmolStats::default(),
+            endpoint: "ch0nky(http://127.0.0.1:8001/v1)".to_string(),
+        };
+        assert!(clean.is_clean());
+
+        let sentinel = SmolOutput {
+            result: Some("-".to_string()),
+            log_path: None,
+            stats: SmolStats::default(),
+            endpoint: "ch0nky(http://127.0.0.1:8001/v1)".to_string(),
+        };
+        assert!(sentinel.is_clean());
+
+        let with_errors = SmolOutput {
+            result: Some("error[E0499]: cannot borrow".to_string()),
+            log_path: None,
+            stats: SmolStats::default(),
+            endpoint: "ch0nky(http://127.0.0.1:8001/v1)".to_string(),
+        };
+        assert!(!with_errors.is_clean());
+    }
+
+    #[test]
+    fn test_endpoint_discover_env_override() {
+        // Full DI: env + probe both injected — no network, no env mutation
+        let ep = SmolEndpoint::discover_with(
+            |key| match key {
+                "B00T_AI_SM0L_BASE" => Some("http://test:9999/v1".to_string()),
+                _ => None,
+            },
+            |_| false, // probe returns nothing live
+        )
+        .unwrap();
+        assert_eq!(ep.base_url, "http://test:9999/v1");
+        assert_eq!(ep.source, EndpointSource::EnvOverride);
+    }
+
+    #[test]
+    fn test_endpoint_discover_hf_fallback() {
+        // Full DI: probe returns false (no local ports live) → falls through to HF
+        let ep = SmolEndpoint::discover_with(
+            |key| match key {
+                "HF_TOKEN" => Some("hf_test_token".to_string()),
+                _ => None,
+            },
+            |_| false,
+        )
+        .unwrap();
+        assert_eq!(ep.source, EndpointSource::HfInference);
+        assert!(ep.base_url.contains("huggingface"));
+    }
+
+    #[test]
+    fn test_preprocess_dedup() {
+        let input = "error[E0499]: foo\nwarning: bar\nerror[E0499]: foo\n";
+        let (processed, stats) = preprocess(input, 65536);
+        assert_eq!(stats.raw_lines, 3);
+        assert_eq!(stats.unique_lines, 2); // foo deduped
+        assert!(processed.contains("×2"));
+    }
+
+    #[test]
+    fn test_smol_session_lifecycle() {
+        let session = SmolSession::new();
+        assert!(session.dir.exists());
+        let (_, _, out) = session.log("test", "system", "input", "output");
+        assert!(out.exists());
+        session.cleanup();
+        assert!(!session.dir.exists());
+    }
+
+    #[test]
+    fn test_behavior_log_tags() {
+        assert_eq!(
+            SmolBehavior::FilterErrors(FilterTask::Cargo).log_tag(),
+            "filter-cargo"
+        );
+        assert_eq!(SmolBehavior::CheckOutputOk.log_tag(), "check-ok");
+        assert_eq!(
+            SmolBehavior::Summarize {
+                max_output_lines: 5
+            }
+            .log_tag(),
+            "summarize"
+        );
+    }
+}

--- a/b00t-cli/src/lib.rs
+++ b/b00t-cli/src/lib.rs
@@ -25,9 +25,17 @@ pub mod ansi {
     pub fn bold(s: &str) -> String { if enabled() { format!("\x1b[1m{}\x1b[0m", s) } else { s.to_string() } }
 }
 
+// warn-once registry — one warning per unknown datum type string per process
+static DATUM_TYPE_WARNED: OnceLock<std::sync::Mutex<std::collections::HashSet<String>>> = OnceLock::new();
+
+/// Returns true if the value is a well-known content tag (not a typed datum).
+fn is_known_content_tag(s: &str) -> bool {
+    matches!(s, "okr" | "prd" | "pattern" | "datum" | "reference" | "learn" | "hardware" | "tomllmd")
+}
+
 /// Load incubating datum types from a runtime‑defined datum.
-/// The datum is expected at `$HOME/.b00t/incubating.tomllm` (or at the path
-/// defined by the `_B00T_Path` env var) with TOML shape:
+/// The datum is expected at `$_B00T_Path/incubating.tomllm` (default: `~/.b00t/_b00t_/incubating.tomllm`)
+/// with TOML shape:
 /// ```toml
 /// incubating = ["routing", "agent.cli", ...]
 /// ```
@@ -440,9 +448,7 @@ where
                         eprintln!(
                             "⚠️  b00t: unknown datum type token '{value}' — not a typed datum or known content-tag; silence: B00T_DATUM_WARN=0"
                         );
-                        crate::otel::record(crate::otel::MetricEvent::DatumTypeUnknown {
-                            type_str: value.clone(),
-                        });
+
                     }
                 }
             }
@@ -844,6 +850,35 @@ pub enum DatumType {
 }
 
 impl DatumType {
+    /// Map a TOML type token string to a DatumType variant; returns None for unknown tokens.
+    pub fn from_type_token(s: &str) -> Option<DatumType> {
+        match s {
+            "database" => Some(DatumType::Database),
+            "hive" | "hive_profile" => Some(DatumType::HiveProfile),
+            "agent" => Some(DatumType::Agent),
+            "config" => Some(DatumType::Config),
+            "docker" => Some(DatumType::Docker),
+            "skill" => Some(DatumType::Skill),
+            "stack" => Some(DatumType::Stack),
+            "repo" => Some(DatumType::Repo),
+            "role" => Some(DatumType::Role),
+            "bash" => Some(DatumType::Bash),
+            "vscode" => Some(DatumType::Vscode),
+            "k8s" => Some(DatumType::K8s),
+            "apt" => Some(DatumType::Apt),
+            "nix" => Some(DatumType::Nix),
+            "mcp" => Some(DatumType::Mcp),
+            "cli" => Some(DatumType::Cli),
+            "api" => Some(DatumType::Api),
+            "job" => Some(DatumType::Job),
+            "ai_model" | "model" => Some(DatumType::AiModel),
+            "ai" => Some(DatumType::Ai),
+            "justfile" => Some(DatumType::Justfile),
+            "unknown" => Some(DatumType::Unknown),
+            _ => None,
+        }
+    }
+
     pub fn all_base_suffixes() -> Vec<&'static str> {
         vec![
             ".database",

--- a/b00t-cli/src/lib.rs
+++ b/b00t-cli/src/lib.rs
@@ -3,6 +3,10 @@ use chrono::{DateTime, Utc};
 use regex::Regex;
 use std::io::Write;
 use std::process;
+use std::collections::HashSet;
+use std::sync::OnceLock;
+use toml;
+use shellexpand;
 
 // 🤓 write_event moved to b00t-c0re-lib::events — unified telemetry writer
 pub use b00t_c0re_lib::write_event;
@@ -21,8 +25,33 @@ pub mod ansi {
     pub fn bold(s: &str) -> String { if enabled() { format!("\x1b[1m{}\x1b[0m", s) } else { s.to_string() } }
 }
 
-/// Exit codes for b00t-cli — used by main.rs dispatch.
-/// Scripts can inspect $? to distinguish error classes.
+/// Load incubating datum types from a runtime‑defined datum.
+/// The datum is expected at `$HOME/.b00t/incubating.tomllm` (or at the path
+/// defined by the `_B00T_Path` env var) with TOML shape:
+/// ```toml
+/// incubating = ["routing", "agent.cli", ...]
+/// ```
+/// Missing or malformed files yield an empty set.
+fn get_incubating_set() -> &'static HashSet<String> {
+    static SET: OnceLock<HashSet<String>> = OnceLock::new();
+    SET.get_or_init(|| {
+        let base_path = std::env::var("_B00T_Path")
+            .unwrap_or_else(|_| "~/.b00t/_b00t_".to_string());
+        let expanded = shellexpand::tilde(&base_path).to_string();
+        let file_path = std::path::Path::new(&expanded).join("incubating.tomllm");
+        if let Ok(content) = std::fs::read_to_string(&file_path) {
+            #[derive(serde::Deserialize)]
+            struct Config {
+                incubating: Vec<String>,
+            }
+            if let Ok(cfg) = toml::from_str::<Config>(&content) {
+                return cfg.incubating.into_iter().collect();
+            }
+        }
+        HashSet::new()
+    })
+}
+
 pub mod exit_code {
     /// Generic / unknown error
     pub const ERROR: i32 = 1;
@@ -368,6 +397,19 @@ pub struct BootDatum {
     pub hook_uninstall: Option<String>,
 }
 
+/// Handle datum types that are marked as *incubating*.
+///
+/// Currently these types are treated as untyped content‑tags, but the
+/// function provides a single place to add bespoke logic when a concrete
+/// implementation becomes available.
+fn handle_incubating_type(value: &str) -> Option<DatumType> {
+    // Placeholder – return None to keep existing behaviour.
+    // When a real implementation is added, replace this stub with the
+    // appropriate mapping or side‑effects.
+    let _ = value; // silence unused‑variable warning.
+    None
+}
+
 fn deserialize_datum_type<'de, D>(
     deserializer: D,
 ) -> std::result::Result<Option<DatumType>, D::Error>
@@ -379,9 +421,33 @@ where
         None => Ok(None),
         Some(value) if value == "model" => Ok(Some(DatumType::AiModel)),
         Some(value) => {
-            DatumType::deserialize(StringDeserializer::<serde::de::value::Error>::new(value))
-                .map(Some)
-                .map_err(serde::de::Error::custom)
+            // Try hard-coded types first, then incubating placeholder.
+            let resolved = DatumType::from_type_token(&value)
+                .or_else(|| handle_incubating_type(&value));
+
+            if resolved.is_none()
+                && !is_known_content_tag(&value)
+                && !get_incubating_set().contains(&value)
+                && std::env::var("B00T_DATUM_WARN")
+                    .map(|v| v != "0")
+                    .unwrap_or(true)
+            {
+                let warned = DATUM_TYPE_WARNED
+                    .get_or_init(|| std::sync::Mutex::new(std::collections::HashSet::new()));
+                if let Ok(mut set) = warned.lock() {
+                    if set.insert(value.clone()) {
+                        // warn once per unknown type string per process
+                        eprintln!(
+                            "⚠️  b00t: unknown datum type token '{value}' — not a typed datum or known content-tag; silence: B00T_DATUM_WARN=0"
+                        );
+                        crate::otel::record(crate::otel::MetricEvent::DatumTypeUnknown {
+                            type_str: value.clone(),
+                        });
+                    }
+                }
+            }
+
+            Ok(resolved)
         }
     }
 }

--- a/b00t-l3dg3rr-viz/Cargo.toml
+++ b/b00t-l3dg3rr-viz/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "b00t-l3dg3rr-viz"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Generic l3dg3rr invariant graph contract with Mermaid and SVG visualization utilities"
+readme = "README.md"
+keywords = ["b00t", "l3dg3rr", "visualization", "invariants", "graph"]
+categories = ["visualization", "data-structures"]
+
+[dependencies]
+serde = { workspace = true, features = ["derive"] }
+
+[lints]
+workspace = true

--- a/b00t-l3dg3rr-viz/README.md
+++ b/b00t-l3dg3rr-viz/README.md
@@ -1,0 +1,18 @@
+# b00t-l3dg3rr-viz
+
+Generic visualization utilities for systems that implement the l3dg3rr invariant graph contract.
+
+The crate deliberately avoids l3dg3rr domain dependencies. A host system provides typed invariant nodes and edges, validates the resulting graph, then gets deterministic Mermaid and SVG renderers.
+
+```rust
+use b00t_l3dg3rr_viz::{InvariantEdge, InvariantGraph, InvariantNode, VisualizationRole};
+
+let graph = InvariantGraph::new("b00t")
+    .with_node(InvariantNode::new("datum", "Datum", VisualizationRole::Ingest))
+    .with_node(InvariantNode::new("verify", "Verify", VisualizationRole::Validate))
+    .with_edge(InvariantEdge::new("datum", "verify"));
+
+graph.validate().expect("graph is internally consistent");
+let mermaid = graph.to_mermaid();
+let svg = graph.to_svg();
+```

--- a/b00t-l3dg3rr-viz/src/lib.rs
+++ b/b00t-l3dg3rr-viz/src/lib.rs
@@ -1,0 +1,422 @@
+//! Generic l3dg3rr invariant graph utilities for b00t and peer systems.
+//!
+//! The upstream `PromptExecution/l3dg3rr` skills encode operational workflows
+//! around typed invariants, visual audit graphs, and supervised agent surfaces.
+//! This crate repackages the reusable part as a small host-neutral contract:
+//! implement or build an [`InvariantGraph`], validate its type invariants, then
+//! render Mermaid or deterministic SVG documentation.
+
+use serde::{Deserialize, Serialize};
+use std::collections::{HashMap, HashSet};
+
+/// Stable visual category shared by l3dg3rr docs and b00t capability graphs.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum VisualizationRole {
+    Ingest,
+    Validate,
+    Classify,
+    Review,
+    Reconcile,
+    Commit,
+    Decision,
+    Step,
+}
+
+impl VisualizationRole {
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Ingest => "ingest",
+            Self::Validate => "validate",
+            Self::Classify => "classify",
+            Self::Review => "review",
+            Self::Reconcile => "reconcile",
+            Self::Commit => "commit",
+            Self::Decision => "decision",
+            Self::Step => "step",
+        }
+    }
+
+    #[must_use]
+    pub const fn color(self) -> &'static str {
+        match self {
+            Self::Ingest => "#4fc3f7",
+            Self::Validate => "#66bb6a",
+            Self::Classify => "#ffa726",
+            Self::Review => "#8d6e63",
+            Self::Reconcile => "#26c6da",
+            Self::Commit => "#42a5f5",
+            Self::Decision => "#ef5350",
+            Self::Step => "#78909c",
+        }
+    }
+}
+
+impl std::fmt::Display for VisualizationRole {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// A typed invariant vertex. IDs are stable machine identifiers.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct InvariantNode {
+    pub id: String,
+    pub label: String,
+    pub role: VisualizationRole,
+    pub invariant: Option<String>,
+}
+
+impl InvariantNode {
+    #[must_use]
+    pub fn new(id: impl Into<String>, label: impl Into<String>, role: VisualizationRole) -> Self {
+        Self {
+            id: id.into(),
+            label: label.into(),
+            role,
+            invariant: None,
+        }
+    }
+
+    #[must_use]
+    pub fn with_invariant(mut self, invariant: impl Into<String>) -> Self {
+        self.invariant = Some(invariant.into());
+        self
+    }
+}
+
+/// A typed invariant edge. Endpoints MUST reference existing node IDs.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct InvariantEdge {
+    pub from: String,
+    pub to: String,
+    pub label: Option<String>,
+}
+
+impl InvariantEdge {
+    #[must_use]
+    pub fn new(from: impl Into<String>, to: impl Into<String>) -> Self {
+        Self {
+            from: from.into(),
+            to: to.into(),
+            label: None,
+        }
+    }
+
+    #[must_use]
+    pub fn with_label(mut self, label: impl Into<String>) -> Self {
+        self.label = Some(label.into());
+        self
+    }
+}
+
+/// Host-neutral graph for l3dg3rr-style invariant visualization.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct InvariantGraph {
+    pub name: String,
+    pub nodes: Vec<InvariantNode>,
+    pub edges: Vec<InvariantEdge>,
+}
+
+impl InvariantGraph {
+    #[must_use]
+    pub fn new(name: impl Into<String>) -> Self {
+        Self {
+            name: name.into(),
+            nodes: Vec::new(),
+            edges: Vec::new(),
+        }
+    }
+
+    #[must_use]
+    pub fn with_node(mut self, node: InvariantNode) -> Self {
+        self.nodes.push(node);
+        self
+    }
+
+    #[must_use]
+    pub fn with_edge(mut self, edge: InvariantEdge) -> Self {
+        self.edges.push(edge);
+        self
+    }
+
+    /// Verify graph invariants before rendering.
+    ///
+    /// Enforced invariants:
+    /// - graph name is non-empty
+    /// - node IDs are non-empty and unique
+    /// - every edge endpoint references a known node
+    /// - self-edges are rejected unless labelled, so docs expose the reason
+    pub fn validate(&self) -> Result<(), GraphValidationError> {
+        if self.name.trim().is_empty() {
+            return Err(GraphValidationError::EmptyGraphName);
+        }
+
+        let mut ids = HashSet::new();
+        for node in &self.nodes {
+            if node.id.trim().is_empty() {
+                return Err(GraphValidationError::EmptyNodeId);
+            }
+            if !ids.insert(node.id.as_str()) {
+                return Err(GraphValidationError::DuplicateNodeId(node.id.clone()));
+            }
+        }
+
+        for edge in &self.edges {
+            if !ids.contains(edge.from.as_str()) {
+                return Err(GraphValidationError::MissingEdgeEndpoint(edge.from.clone()));
+            }
+            if !ids.contains(edge.to.as_str()) {
+                return Err(GraphValidationError::MissingEdgeEndpoint(edge.to.clone()));
+            }
+            if edge.from == edge.to
+                && edge
+                    .label
+                    .as_deref()
+                    .is_none_or(|label| label.trim().is_empty())
+            {
+                return Err(GraphValidationError::UnlabelledSelfEdge(edge.from.clone()));
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Render a Mermaid flowchart. Call [`Self::validate`] first for strict CI.
+    #[must_use]
+    pub fn to_mermaid(&self) -> String {
+        let mut out = String::from("flowchart LR\n");
+        for node in &self.nodes {
+            out.push_str(&format!(
+                "  {}[\"{}\"]:::{}\n",
+                mermaid_id(&node.id),
+                escape_mermaid(&node.label),
+                node.role
+            ));
+        }
+        for edge in &self.edges {
+            let label = edge
+                .label
+                .as_ref()
+                .map_or(String::new(), |label| format!("|{}|", escape_mermaid(label)));
+            out.push_str(&format!(
+                "  {} -->{} {}\n",
+                mermaid_id(&edge.from),
+                label,
+                mermaid_id(&edge.to)
+            ));
+        }
+        for role in [
+            VisualizationRole::Ingest,
+            VisualizationRole::Validate,
+            VisualizationRole::Classify,
+            VisualizationRole::Review,
+            VisualizationRole::Reconcile,
+            VisualizationRole::Commit,
+            VisualizationRole::Decision,
+            VisualizationRole::Step,
+        ] {
+            out.push_str(&format!(
+                "  classDef {} fill:{},stroke:#263238,color:#111;\n",
+                role,
+                role.color()
+            ));
+        }
+        out
+    }
+
+    /// Render a standalone SVG with deterministic horizontal layout.
+    #[must_use]
+    pub fn to_svg(&self) -> String {
+        let width = (self.nodes.len().max(1) as i32 * 180 + 80).max(640);
+        let height = 220;
+        let mut out = format!(
+            r##"<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 {width} {height}" role="img" aria-label="{} invariant graph">"##,
+            escape_xml(&self.name)
+        );
+        out.push_str(r##"<rect width="100%" height="100%" fill="#f8fafc"/>"##);
+        out.push_str(r##"<defs><marker id="arrow" viewBox="0 0 10 10" refX="10" refY="5" markerWidth="7" markerHeight="7" orient="auto"><path d="M 0 0 L 10 5 L 0 10 Z" fill="#455a64"/></marker></defs>"##);
+
+        // Build a single O(N) lookup table so edge rendering is O(E) not O(E·N).
+        let node_index_map: HashMap<&str, usize> = self
+            .nodes
+            .iter()
+            .enumerate()
+            .map(|(i, n)| (n.id.as_str(), i))
+            .collect();
+
+        for edge in &self.edges {
+            // Fallback to index 0 is unreachable for validated graphs (validate()
+            // guarantees all edge endpoints reference known nodes).
+            let from = node_index_map.get(edge.from.as_str()).copied().unwrap_or(0);
+            let to = node_index_map.get(edge.to.as_str()).copied().unwrap_or(0);
+            let x1 = node_x(from) + 140;
+            let x2 = node_x(to);
+            let y = 110;
+            out.push_str(&format!(
+                r##"<path d="M {x1} {y} L {x2} {y}" stroke="#455a64" stroke-width="2" fill="none" marker-end="url(#arrow)"/>"##
+            ));
+            if let Some(label) = &edge.label {
+                let mid = (x1 + x2) / 2;
+                out.push_str(&format!(
+                    r##"<text x="{mid}" y="96" text-anchor="middle" font-family="monospace" font-size="11" fill="#37474f">{}</text>"##,
+                    escape_xml(label)
+                ));
+            }
+        }
+
+        for (index, node) in self.nodes.iter().enumerate() {
+            let x = node_x(index);
+            let y = 70;
+            out.push_str(&format!(
+                r##"<g><rect x="{x}" y="{y}" width="140" height="80" rx="10" fill="{}" stroke="#263238" stroke-width="1.5"/>"##,
+                node.role.color()
+            ));
+            out.push_str(&format!(
+                r##"<text x="{}" y="105" text-anchor="middle" font-family="monospace" font-size="14" font-weight="700" fill="#111">{}</text>"##,
+                x + 70,
+                escape_xml(&node.label)
+            ));
+            out.push_str(&format!(
+                r##"<text x="{}" y="126" text-anchor="middle" font-family="monospace" font-size="11" fill="#263238">{}</text></g>"##,
+                x + 70,
+                node.role
+            ));
+        }
+
+        out.push_str("</svg>");
+        out
+    }
+
+}
+
+/// A host system can implement this trait to provide visualization without
+/// depending on l3dg3rr domain crates.
+pub trait L3dg3rrVisualizable {
+    fn invariant_graph(&self) -> InvariantGraph;
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum GraphValidationError {
+    EmptyGraphName,
+    EmptyNodeId,
+    DuplicateNodeId(String),
+    MissingEdgeEndpoint(String),
+    UnlabelledSelfEdge(String),
+}
+
+impl std::fmt::Display for GraphValidationError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::EmptyGraphName => f.write_str("graph name is empty"),
+            Self::EmptyNodeId => f.write_str("node id is empty"),
+            Self::DuplicateNodeId(id) => write!(f, "duplicate node id: {id}"),
+            Self::MissingEdgeEndpoint(id) => write!(f, "edge endpoint does not exist: {id}"),
+            Self::UnlabelledSelfEdge(id) => write!(f, "unlabelled self-edge: {id}"),
+        }
+    }
+}
+
+impl std::error::Error for GraphValidationError {}
+
+fn node_x(index: usize) -> i32 {
+    40 + i32::try_from(index).unwrap_or(0) * 180
+}
+
+/// Produce a collision-free Mermaid node identifier.
+///
+/// Alphanumeric ASCII and `_` are kept verbatim.  Every other byte is
+/// hex-encoded as `_HH` so that `a-b` → `n_a_2db` and `a_b` → `n_a_b`
+/// — distinct, even though both contain a non-alphanumeric separator.
+fn mermaid_id(id: &str) -> String {
+    let mut value = String::from("n_");
+    for byte in id.bytes() {
+        if byte.is_ascii_alphanumeric() || byte == b'_' {
+            value.push(byte as char);
+        } else {
+            // nibble is always 0-15, so from_digit with radix 16 is infallible
+            value.push('_');
+            value.push(char::from_digit((byte >> 4) as u32, 16).expect("nibble 0-15"));
+            value.push(char::from_digit((byte & 0xf) as u32, 16).expect("nibble 0-15"));
+        }
+    }
+    value
+}
+
+fn escape_mermaid(value: &str) -> String {
+    value.replace('\\', "\\\\").replace('"', "\\\"")
+}
+
+fn escape_xml(value: &str) -> String {
+    value
+        .replace('&', "&amp;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
+        .replace('"', "&quot;")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn valid_graph_renders_mermaid_and_svg() {
+        let graph = InvariantGraph::new("b00t")
+            .with_node(InvariantNode::new("datum", "Datum", VisualizationRole::Ingest))
+            .with_node(InvariantNode::new(
+                "verify",
+                "Verify",
+                VisualizationRole::Validate,
+            ))
+            .with_edge(InvariantEdge::new("datum", "verify").with_label("checked"));
+
+        assert_eq!(graph.validate(), Ok(()));
+        assert!(graph.to_mermaid().contains("flowchart LR"));
+        assert!(graph.to_mermaid().contains("n_datum -->|checked| n_verify"));
+        assert!(graph.to_svg().contains("b00t invariant graph"));
+    }
+
+    #[test]
+    fn duplicate_nodes_are_rejected() {
+        let graph = InvariantGraph::new("bad")
+            .with_node(InvariantNode::new("same", "A", VisualizationRole::Step))
+            .with_node(InvariantNode::new("same", "B", VisualizationRole::Step));
+
+        assert_eq!(
+            graph.validate(),
+            Err(GraphValidationError::DuplicateNodeId("same".into()))
+        );
+    }
+
+    #[test]
+    fn missing_edge_endpoint_is_rejected() {
+        let graph = InvariantGraph::new("bad")
+            .with_node(InvariantNode::new("a", "A", VisualizationRole::Step))
+            .with_edge(InvariantEdge::new("a", "missing"));
+
+        assert_eq!(
+            graph.validate(),
+            Err(GraphValidationError::MissingEdgeEndpoint("missing".into()))
+        );
+    }
+
+    #[test]
+    fn labelled_self_edge_is_allowed_for_explicit_invariants() {
+        let graph = InvariantGraph::new("loop")
+            .with_node(InvariantNode::new("a", "A", VisualizationRole::Decision))
+            .with_edge(InvariantEdge::new("a", "a").with_label("retry budget"));
+
+        assert_eq!(graph.validate(), Ok(()));
+    }
+
+    #[test]
+    fn mermaid_ids_are_collision_free() {
+        // "a-b" and "a_b" would both map to "n_a_b" with the old naive encoder;
+        // with hex encoding "a-b" becomes "n_a_2db" (dash = 0x2d).
+        assert_ne!(mermaid_id("a-b"), mermaid_id("a_b"));
+        assert_eq!(mermaid_id("a-b"), "n_a_2db");
+        assert_eq!(mermaid_id("a_b"), "n_a_b");
+        // Pure alphanumeric IDs are unchanged.
+        assert_eq!(mermaid_id("datum"), "n_datum");
+    }
+}

--- a/b00t-l3dg3rr-viz/tests/visualization_contract.rs
+++ b/b00t-l3dg3rr-viz/tests/visualization_contract.rs
@@ -1,0 +1,37 @@
+use b00t_l3dg3rr_viz::{
+    InvariantEdge, InvariantGraph, InvariantNode, L3dg3rrVisualizable, VisualizationRole,
+};
+
+struct B00tDatumFlow;
+
+impl L3dg3rrVisualizable for B00tDatumFlow {
+    fn invariant_graph(&self) -> InvariantGraph {
+        InvariantGraph::new("b00t datum flow")
+            .with_node(InvariantNode::new("load", "Load", VisualizationRole::Ingest))
+            .with_node(InvariantNode::new(
+                "classify",
+                "Classify",
+                VisualizationRole::Classify,
+            ))
+            .with_node(InvariantNode::new(
+                "visualize",
+                "Visualize",
+                VisualizationRole::Commit,
+            ))
+            .with_edge(InvariantEdge::new("load", "classify"))
+            .with_edge(InvariantEdge::new("classify", "visualize").with_label("valid"))
+    }
+}
+
+#[test]
+fn implementors_get_visualization_after_invariant_validation() {
+    let graph = B00tDatumFlow.invariant_graph();
+
+    graph.validate().expect("sample graph satisfies l3dg3rr invariants");
+
+    let mermaid = graph.to_mermaid();
+    let svg = graph.to_svg();
+
+    assert!(mermaid.contains("n_classify -->|valid| n_visualize"));
+    assert!(svg.contains("Visualize"));
+}

--- a/incubating.tomllm
+++ b/incubating.tomllm
@@ -1,0 +1,13 @@
+incubating = [
+    "routing",
+    "agent.cli",
+    "inference_provider",
+    "datum",
+    "project",
+    "schema",
+    "wow",
+    "mcp_server",
+    "github_org",
+    "ai_provider",
+    "install"
+]

--- a/k0mmand3r/tests/test_k0mmand3r.ts
+++ b/k0mmand3r/tests/test_k0mmand3r.ts
@@ -32,7 +32,7 @@ describe('Wasm Tests', () => {
         const result = KmdLineWasm.parse('/tagverb --tag1 --tag2');
         assert.strictEqual(result.verb(), 'tagverb');
         // Parse JSON to compare objects — HashMap ordering is non-deterministic in Rust/Wasm
-        const params = JSON.parse(result.params());
+        const params = JSON.parse(result.params()!);
         assert.deepStrictEqual(params, { tag1: '', tag2: '' });
       });
 

--- a/k0mmand3r/tests/test_k0mmand3r.ts
+++ b/k0mmand3r/tests/test_k0mmand3r.ts
@@ -31,7 +31,9 @@ describe('Wasm Tests', () => {
       it('should correctly parse command with tags', () => {
         const result = KmdLineWasm.parse('/tagverb --tag1 --tag2');
         assert.strictEqual(result.verb(), 'tagverb');
-        assert.strictEqual(result.params(), '{"tag1":"","tag2":""}');
+        // Parse JSON to compare objects — HashMap ordering is non-deterministic in Rust/Wasm
+        const params = JSON.parse(result.params());
+        assert.deepStrictEqual(params, { tag1: '', tag2: '' });
       });
 
   // Additional test cases


### PR DESCRIPTION
## Summary

RTX3090 MTP inference stack, SmolDispatch cognitive tier, CI hardening, and Copilot review resolution.

### Core Features
- **RTX3090 MTP inference**: Qwen3.6-27B with Multi-Token Prediction via llama.cpp podman profile (`_b00t_/inference-qwen36-27b-mtp-podman.hive.toml`); ~40 TPS on RTX3090; verified 2026-06-14
- **SmolDispatch**: Rust abstraction for sm0l cognitive tier routing (`b00t-c0re-lib/src/sm0l_dispatch.rs`) — endpoint discovery chain, ANSI stripping, deduplication, DI for tests
- **sm0l-filter pipe-agent**: Python script (`_b00t_/scripts/sm0l-filter.py`) routing noisy process output through sm0l local LLM; task templates: cargo/podman/systemd/hive/general
- **OpenHarness**: b00t-openharness integration for local CI/CD workflow evaluation

### CI Fixes
- Restored `b00t-l3dg3rr-viz/` (was workspace member but deleted from git; restored from commit `6b7faea`)
- Added `vendor/embed-anything-b00t` to submodule init in `.github/workflows/rust-k0mmand3r.yml`
- Pinned Node.js to v20 LTS (v26 breaks CJS/ESM boundary in mocha+ts-node)
- Fixed HashMap JSON key ordering non-determinism in TypeScript test (`deepStrictEqual` on parsed object)

### Copilot Review Fixes (10 issues)
- `DatumType::from_type_token()` — new method mapping TOML type tokens to `DatumType` enum
- `is_known_content_tag()` — new function for content tag validation
- `DATUM_TYPE_WARNED` — `OnceLock<Mutex<HashSet<String>>>` for warn-once deduplication
- Removed non-existent `crate::otel::record()` call from `deserialize_datum_type()`
- `SmolDispatch::summary_line()` — fixed double-printing `raw_lines` stat
- `ANSI_RE` — `OnceLock<regex::Regex>` for compiled ANSI strip regex
- `probe()` — fail-closed on `reqwest::Client::builder()` errors
- `call_endpoint()` — HTTP status check before JSON parse
- `sm0l-filter.py` — proper `HTTPError` / `URLError` / `JSONDecodeError` exception handling
- `inference-qwen36-27b.hive.toml` — replaced stale GGUF preflight with AWQ-correct check

### wrkflw Datum
- `_b00t_/wrkflw.cli.toml` — local GitHub Actions runner (no Docker); `b00t install wrkflw` uses `gh release download` with `gh` CLI as mandatory prerequisite

## Test plan
- [x] `cargo test` — all Rust tests pass
- [x] `npm test` (k0mmand3r TypeScript) — passes on Node.js v20 LTS
- [x] Python tests pass
- [x] `b00t install wrkflw` — installs correctly; `wrkflw --version` confirms v0.8.0
- [x] CI `run-tests`: pass (3m53s)
- [x] CI `build (ubuntu-latest, x64)`: pass
- [x] CI `docker`: pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)