### PR TITLE
fix(learn): classify NeumannStore lock failures as actionable harness bugs

### DIFF
--- a/b00t-c0re-lib/src/lfmf.rs
+++ b/b00t-c0re-lib/src/lfmf.rs
@@ -518,6 +518,58 @@ impl LfmfSystem {
     }
 }
 
+/// Classify an [`LfmfSystem::initialize`] error into a structured harness degradation message.
+///
+/// Returns `(category, actionable_message)` suitable for user-facing output.
+/// Detects NeumannStore lock conflicts, missing binaries, and backend connectivity failures.
+pub fn classify_init_failure(e: &anyhow::Error) -> (&'static str, String) {
+    let msg = format!("{:#}", e);
+    let msg_lower = msg.to_lowercase();
+
+    if msg_lower.contains("lock")
+        || msg_lower.contains("could not set lock")
+        || msg_lower.contains("conflicting lock")
+        || msg_lower.contains("failed to acquire")
+    {
+        (
+            "NEUMANN_LOCK",
+            format!(
+                "⚠️  HARNESS BUG [NEUMANN_LOCK]: NeumannStore persistent memory is locked.\n                    Details: {}\n                    Fix: kill conflicting b00t/irontology processes, or:\n                    rm -f ~/.b00t/neumann/default/*.lock\n                    ↳ memory degraded → filesystem-only fallback active",
+                msg
+            ),
+        )
+    } else if msg_lower.contains("no such file or directory")
+        || msg_lower.contains("failed to spawn")
+        || msg_lower.contains("(os error 2)")
+        || msg_lower.contains("cannot find binary")
+    {
+        (
+            "BINARY_MISSING",
+            "⚠️  HARNESS BUG [BINARY_MISSING]: irontology-mcp binary not found.\n                Fix: b00t install irontology-mcp  (or: cargo build -p irontology-mcp)\n                ↳ persistent memory unavailable → filesystem-only fallback active"
+                .to_string(),
+        )
+    } else if msg_lower.contains("connection refused")
+        || msg_lower.contains("qdrant")
+        || msg_lower.contains("failed to connect")
+    {
+        (
+            "BACKEND_DOWN",
+            format!(
+                "🔄 Persistent memory backend unavailable ({}).\n                    Fix: b00t hive activate inference-qwen36-27b  (or start Qdrant)\n                    ↳ filesystem-only fallback active",
+                msg
+            ),
+        )
+    } else {
+        (
+            "GENERIC",
+            format!(
+                "⚠️  Persistent memory unavailable: {}\n                    ↳ filesystem-only fallback active",
+                msg
+            ),
+        )
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -589,4 +641,38 @@ learn_dir = "custom_learn"
             home.join(".b00t/_b00t_/learn").to_string_lossy()
         );
     }
+    #[test]
+    fn test_classify_init_failure_neumann_lock() {
+        let e = anyhow::anyhow!("Could not set lock on file /home/user/.b00t/neumann/default/lock: Conflicting lock held by PID 12345");
+        let (cat, msg) = classify_init_failure(&e);
+        assert_eq!(cat, "NEUMANN_LOCK");
+        assert!(msg.contains("HARNESS BUG"));
+        assert!(msg.contains("filesystem-only fallback"));
+    }
+
+    #[test]
+    fn test_classify_init_failure_binary_missing() {
+        let e = anyhow::anyhow!("Failed to spawn irontology-mcp at /usr/local/bin/irontology-mcp: No such file or directory (os error 2)");
+        let (cat, msg) = classify_init_failure(&e);
+        assert_eq!(cat, "BINARY_MISSING");
+        assert!(msg.contains("HARNESS BUG"));
+        assert!(msg.contains("b00t install irontology-mcp"));
+    }
+
+    #[test]
+    fn test_classify_init_failure_backend_down() {
+        let e = anyhow::anyhow!("Failed to connect to irontology-mcp: connection refused");
+        let (cat, _msg) = classify_init_failure(&e);
+        assert_eq!(cat, "BACKEND_DOWN");
+    }
+
+    #[test]
+    fn test_classify_init_failure_generic() {
+        let e = anyhow::anyhow!("some unexpected initialization problem occurred");
+        let (cat, msg) = classify_init_failure(&e);
+        assert_eq!(cat, "GENERIC");
+        assert!(msg.contains("filesystem-only fallback"));
+    }
+
+
 }

--- a/b00t-cli/src/commands/learn.rs
+++ b/b00t-cli/src/commands/learn.rs
@@ -3,7 +3,7 @@
 //! Combines LFMF lessons, curated docs, man pages, and RAG into one command
 
 use anyhow::{Context, Result};
-use b00t_c0re_lib::{DisplayOpts, GrokClient, KnowledgeSource, LfmfSystem, ManPage};
+use b00t_c0re_lib::{lfmf::classify_init_failure, DisplayOpts, GrokClient, KnowledgeSource, LfmfSystem, ManPage};
 use clap::Parser;
 use std::fs;
 use tiktoken_rs::o200k_base;
@@ -355,12 +355,10 @@ async fn handle_record(path: &str, topic: Option<&str>, lesson: &str, global: bo
     let lookup = crate::datum_utils::B00tDatumLookup::new(path.to_string());
     lfmf_system.set_datum_lookup(lookup);
 
-    // Try to initialize vector database (non-fatal if fails)
+    // Try to initialize vector database; classify failure for actionable harness output
     if let Err(e) = lfmf_system.initialize().await {
-        println!(
-            "⚠️  Vector database unavailable: {}. Lesson will be saved to filesystem only.",
-            e
-        );
+        let (_, msg) = classify_init_failure(&e);
+        println!("{}", msg);
     }
 
     let scope = if global { "global" } else { "repo" };
@@ -386,12 +384,10 @@ async fn handle_search(path: &str, topic: Option<&str>, query: &str, limit: usiz
     let lookup = crate::datum_utils::B00tDatumLookup::new(path.to_string());
     lfmf_system.set_datum_lookup(lookup);
 
-    // Initialize vector DB (non-fatal if fails)
+    // Initialize vector DB; classify failure for actionable harness output
     if let Err(e) = lfmf_system.initialize().await {
-        println!(
-            "🔄 Vector database unavailable ({}), using filesystem fallback",
-            e
-        );
+        let (_, msg) = classify_init_failure(&e);
+        println!("{}", msg);
     }
 
     let results = if query.eq_ignore_ascii_case("list") {


### PR DESCRIPTION
## Summary

Fixes b00t task #42: `b00t learn --record` and `b00t learn --search` previously swallowed all `LfmfSystem::initialize()` errors with a generic message like "Vector database unavailable". This gave agents no signal about *what* failed or *how* to fix it.

## Changes

- **`b00t-c0re-lib/src/lfmf.rs`**: New `classify_init_failure(e: &anyhow::Error) -> (&'static str, String)` function — classifies persistent-memory init errors into 4 structured modes:
  | Category | Detection | Actionable fix emitted |
  |---|---|---|
  | `NEUMANN_LOCK` | "lock" / "conflicting lock" / "failed to acquire" | `rm -f ~/.b00t/neumann/default/*.lock` |
  | `BINARY_MISSING` | "no such file" / "failed to spawn" / `(os error 2)` | `b00t install irontology-mcp` |
  | `BACKEND_DOWN` | "connection refused" / "qdrant" / "failed to connect" | `b00t hive activate inference-qwen36-27b` |
  | `GENERIC` | anything else | generic degradation notice |
  All modes end with `↳ filesystem-only fallback active`

- **`b00t-cli/src/commands/learn.rs`**: `handle_record` + `handle_search` now call `classify_init_failure(&e)` instead of printing generic strings

## Test plan
- [x] `test_classify_init_failure_neumann_lock` → NEUMANN_LOCK category, contains "HARNESS BUG"
- [x] `test_classify_init_failure_binary_missing` → BINARY_MISSING, contains "b00t install"
- [x] `test_classify_init_failure_backend_down` → BACKEND_DOWN
- [x] `test_classify_init_failure_generic` → GENERIC fallback
- [x] `cargo check --package b00t-c0re-lib --package b00t-cli` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)