### PR TITLE
fix(ci): make irontology vendor mods optional to unblock GHCR pipeline

### DIFF
--- a/justfile
+++ b/justfile
@@ -13,8 +13,8 @@ mod sudo 'b00t-service.just'
 # this is an antipattern (litellm is early-stage AI infra, skip for now)
 mod litellm '_b00t_/litellm/justfile'
 mod b00t-mcp-npm
-mod irontology-publish 'vendor/irontology-mcp/irontology-publish.just'
-mod irontology 'vendor/irontology-mcp/irontology.just'
+mod? irontology-publish 'vendor/irontology-mcp/irontology-publish.just'
+mod? irontology 'vendor/irontology-mcp/irontology.just'
 
 # Datum justfiles (install recipes for core tech stacks)
 mod python '_b00t_/python.🐍/justfile'


### PR DESCRIPTION
## Summary
- `just --list` was failing in CI because `vendor/irontology-mcp/*.just` files are in a git submodule that isn't initialized during `checkout@v4`
- This blocked the entire `b00t-cli-container.yml` workflow before the Docker build step ever ran
- Changed `mod` → `mod?` for both irontology module references (optional syntax, silently no-ops when file missing)

## Root Cause
```
error: could not find source file for module `irontology-publish`
  justfile:16:5
  16 | mod irontology-publish 'vendor/irontology-mcp/irontology-publish.just'
```

## Test plan
- [ ] CI `just --list` step passes on this branch
- [ ] `just --list` continues to work locally (submodule present)
- [ ] Docker build proceeds past the `just --list` gate

🤖 Generated with [Claude Code](https://claude.com/claude-code)