### PR TITLE
feat(k0mmand3r): ! sshbang idiom as primary prefix; / retained as legacy

### DIFF
--- a/b00t-cli/src/k0mmand3r/mod.rs
+++ b/b00t-cli/src/k0mmand3r/mod.rs
@@ -9,7 +9,72 @@ use std::collections::BTreeMap;
 // Re-export emoji registry from k0mmand3r crate for compile-time datum embedding
 pub use k0mmand3r::emoji_registry;
 
-/// Legacy k0mmand3r command: slash command for agent coordination
+/// Command prefix idiom.
+/// Sshbang (`!`) is the primary mode; Slash (`/`) is legacy and kept behind
+/// `B00T_K0MMAND3R_PREFIX=/` env var or explicit config.
+/// Both are always accepted by the parser for backward compatibility.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub enum CommandPrefix {
+    /// `!verb` — sshbang idiom (default, aligns with `!cmd` in Claude Code CLI)
+    Sshbang,
+    /// `/verb` — legacy slash syntax
+    Slash,
+}
+
+impl CommandPrefix {
+    pub fn as_char(&self) -> char {
+        match self {
+            Self::Sshbang => '!',
+            Self::Slash => '/',
+        }
+    }
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Sshbang => "!",
+            Self::Slash => "/",
+        }
+    }
+}
+
+impl Default for CommandPrefix {
+    fn default() -> Self {
+        Self::Sshbang
+    }
+}
+
+/// Runtime config for k0mmand3r prefix mode.
+/// Set `B00T_K0MMAND3R_PREFIX=/` to use legacy slash mode.
+#[derive(Debug, Clone)]
+pub struct K0mmand3rConfig {
+    pub prefix: CommandPrefix,
+}
+
+impl Default for K0mmand3rConfig {
+    fn default() -> Self {
+        Self {
+            prefix: CommandPrefix::Sshbang,
+        }
+    }
+}
+
+impl K0mmand3rConfig {
+    /// Read prefix preference from `B00T_K0MMAND3R_PREFIX` env var.
+    /// Defaults to `!` (Sshbang) if unset or any value other than `/`.
+    pub fn from_env() -> Self {
+        let prefix = if std::env::var("B00T_K0MMAND3R_PREFIX").as_deref() == Ok("/") {
+            CommandPrefix::Slash
+        } else {
+            CommandPrefix::Sshbang
+        };
+        Self { prefix }
+    }
+
+    pub fn preferred_prefix(&self) -> &'static str {
+        self.prefix.as_str()
+    }
+}
+
+/// k0mmand3r command: supports both `!verb` (sshbang, default) and `/verb` (legacy)
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct K0mmand {
     pub verb: String,   // negotiate, vote, delegate, status, etc.
@@ -18,17 +83,18 @@ pub struct K0mmand {
 }
 
 impl K0mmand {
-    /// Parse k0mmand3r command string
+    /// Parse k0mmand3r command string.
+    /// Accepts both `!verb` (sshbang, preferred) and `/verb` (legacy).
     /// Examples:
-    ///   /negotiate blessing:observe-infrastructure
-    ///   /vote on blessing:execute-transition-safely
-    ///   /delegate step:apply-transitions to agent:b00t-sandbox
-    ///   /status from agent:executive
+    ///   !negotiate blessing:observe-infrastructure
+    ///   !vote on blessing:execute-transition-safely
+    ///   !delegate step:apply-transitions to agent:b00t-sandbox
+    ///   !status from agent:executive
     pub fn parse(cmd: &str) -> Result<Self, String> {
         let cmd = cmd.trim();
 
-        if !cmd.starts_with('/') {
-            return Err("k0mmand3r command must start with /".to_string());
+        if !cmd.starts_with('!') && !cmd.starts_with('/') {
+            return Err("k0mmand3r command must start with ! (or legacy /)".to_string());
         }
 
         let parts: Vec<&str> = cmd[1..].split_whitespace().collect();
@@ -214,10 +280,12 @@ impl LoopSpec {
 }
 
 impl K0mmand3rCmd {
+    /// Parse typed k0mmand3r command.
+    /// Accepts both `!verb` (sshbang, preferred) and `/verb` (legacy).
     pub fn parse(cmd: &str) -> Result<Self, String> {
         let cmd = cmd.trim();
-        if !cmd.starts_with('/') {
-            return Err("k0mmand3r command must start with /".to_string());
+        if !cmd.starts_with('!') && !cmd.starts_with('/') {
+            return Err("k0mmand3r command must start with ! (or legacy /)".to_string());
         }
         let parts: Vec<&str> = cmd[1..].split_whitespace().collect();
         if parts.is_empty() {
@@ -286,7 +354,7 @@ impl K0mmand3rCmd {
                         modifiers,
                     })
                 } else {
-                    Err("Usage: /negotiate <resource> <id> or /negotiate blessing:<id>".to_string())
+                    Err("Usage: !negotiate <resource> <id> or !negotiate blessing:<id>".to_string())
                 }
             }
             "vote" => {
@@ -298,7 +366,7 @@ impl K0mmand3rCmd {
                     .or_else(|| {
                         on_value.as_ref().and_then(|v| v.split_whitespace().next().map(|s| s.to_string()))
                     })
-                    .ok_or("Usage: /vote <proposal> <yes|no|abstain>")?;
+                    .ok_or("Usage: !vote <proposal> <yes|no|abstain>")?;
                 let choice_str = positional
                     .get(1)
                     .map(|s| s.to_string())
@@ -358,7 +426,7 @@ impl K0mmand3rCmd {
                     .map(|s| s.to_string())
                     .or_else(|| modifiers.remove("agent"))
                     .or_else(|| modifiers.remove("to"))
-                    .ok_or("Usage: /delegate <agent> <budget>")?;
+                    .ok_or("Usage: !delegate <agent> <budget>")?;
                 let budget_str = positional
                     .get(1)
                     .map(|s| s.to_string())
@@ -387,7 +455,7 @@ impl K0mmand3rCmd {
                             v
                         })
                     })
-                    .ok_or("Usage: /handshake <agent>")?;
+                    .ok_or("Usage: !handshake <agent>")?;
                 let proposal = if positional.len() > 1 {
                     Some(positional[1..].join(" "))
                 } else {
@@ -403,7 +471,7 @@ impl K0mmand3rCmd {
                     .first()
                     .map(|s| s.to_string())
                     .or_else(|| modifiers.remove("action"))
-                    .ok_or("Usage: /crew <form|join|leave>")?;
+                    .ok_or("Usage: !crew <form|join|leave>")?;
                 let action = match action_str.to_lowercase().as_str() {
                     "form" => CrewAction::Form,
                     "join" => CrewAction::Join,
@@ -434,7 +502,7 @@ impl K0mmand3rCmd {
                     .first()
                     .map(|s| s.to_string())
                     .or_else(|| modifiers.remove("role"))
-                    .ok_or("Usage: /ahoy <role> <budget> <skills> <description>")?;
+                    .ok_or("Usage: !ahoy <role> <budget> <skills> <description>")?;
                 let budget_str = positional
                     .get(1)
                     .map(|s| s.to_string())
@@ -469,7 +537,7 @@ impl K0mmand3rCmd {
                     .first()
                     .map(|s| s.to_string())
                     .or_else(|| modifiers.remove("ahoy_id"))
-                    .ok_or("Usage: /apply <ahoy_id> <pitch>")?;
+                    .ok_or("Usage: !apply <ahoy_id> <pitch>")?;
                 let pitch = if positional.len() > 1 {
                     positional[1..].join(" ")
                 } else {
@@ -485,7 +553,7 @@ impl K0mmand3rCmd {
                     .first()
                     .map(|s| s.to_string())
                     .or_else(|| modifiers.remove("ahoy_id"))
-                    .ok_or("Usage: /award <ahoy_id> <winner>")?;
+                    .ok_or("Usage: !award <ahoy_id> <winner>")?;
                 let winner = positional
                     .get(1)
                     .map(|s| s.to_string())
@@ -519,7 +587,7 @@ impl K0mmand3rCmd {
                 .split_whitespace()
                 .next()
                 .unwrap_or("unknown")
-                .trim_start_matches('/')
+                .trim_start_matches(&['!', '/'][..])
                 .to_string(),
         }
     }

--- a/b00t-cli/src/k0mmand3r/tests.rs
+++ b/b00t-cli/src/k0mmand3r/tests.rs
@@ -396,4 +396,69 @@ mod k0mmand3r_typed_cmd_tests {
             _ => panic!("Expected Handshake"),
         }
     }
+
+    // ── Sshbang idiom tests ──────────────────────────────────────────────────
+
+    #[test]
+    fn test_sshbang_negotiate_parses() {
+        let cmd = K0mmand::parse("!negotiate blessing:observe-infrastructure").unwrap();
+        assert_eq!(cmd.verb, "negotiate");
+        assert_eq!(cmd.object, "blessing:observe-infrastructure");
+    }
+
+    #[test]
+    fn test_sshbang_vote_parses() {
+        let cmd = K0mmand::parse("!vote on blessing:execute-transition-safely").unwrap();
+        assert_eq!(cmd.verb, "vote");
+    }
+
+    #[test]
+    fn test_sshbang_typed_negotiate() {
+        let cmd = K0mmand3rCmd::parse("!negotiate blessing:observe-infra").unwrap();
+        assert_eq!(cmd.verb(), "negotiate");
+    }
+
+    #[test]
+    fn test_sshbang_typed_vote() {
+        let cmd = K0mmand3rCmd::parse("!vote proposal-123 yes").unwrap();
+        assert_eq!(cmd.verb(), "vote");
+    }
+
+    #[test]
+    fn test_sshbang_typed_loop() {
+        let cmd = K0mmand3rCmd::parse("!loop goal:deploy metric:uptime verify:healthcheck max:5").unwrap();
+        assert_eq!(cmd.verb(), "loop");
+    }
+
+    #[test]
+    fn test_sshbang_and_slash_both_accepted() {
+        // Parser accepts either prefix — backward compat guaranteed
+        let bang = K0mmand::parse("!negotiate blessing:foo").unwrap();
+        let slash = K0mmand::parse("/negotiate blessing:foo").unwrap();
+        assert_eq!(bang.verb, slash.verb);
+        assert_eq!(bang.object, slash.object);
+    }
+
+    #[test]
+    fn test_config_sshbang_default() {
+        let cfg = K0mmand3rConfig::default();
+        assert_eq!(cfg.preferred_prefix(), "!");
+    }
+
+    #[test]
+    fn test_config_slash_via_env() {
+        // SAFETY: test-only env mutation; tests run single-threaded in this suite
+        unsafe { std::env::set_var("B00T_K0MMAND3R_PREFIX", "/") };
+        let cfg = K0mmand3rConfig::from_env();
+        assert_eq!(cfg.preferred_prefix(), "/");
+        unsafe { std::env::remove_var("B00T_K0MMAND3R_PREFIX") };
+    }
+
+    #[test]
+    fn test_invalid_prefix_rejected() {
+        let result = K0mmand::parse("@negotiate blessing:foo");
+        assert!(result.is_err());
+        let msg = result.unwrap_err();
+        assert!(msg.contains('!') || msg.contains('/'));
+    }
 }


### PR DESCRIPTION
## Summary
- Parser accepts both `!verb` (sshbang, new primary) and `/verb` (legacy, backward compat) in both `K0mmand::parse` and `K0mmand3rCmd::parse`
- Add `CommandPrefix` enum (`Sshbang` default, `Slash` legacy) and `K0mmand3rConfig` struct
- `K0mmand3rConfig::from_env()` reads `B00T_K0MMAND3R_PREFIX=/` to enable slash legacy mode
- All Usage error strings updated to show `!` prefix
- `trim_start_matches` updated to strip either `!` or `/`

## Rationale
The `/` prefix felt wrong in CLI dynamic context — `!` aligns with the existing `! <command>` idiom in Claude Code and the sshbang/shebang convention. `/` is preserved behind an env flag for any tooling that already emits slash commands.

## Test plan
- [x] 9 new sshbang tests: parse `!negotiate`, `!vote`, `!loop`, both-accepted parity, `K0mmand3rConfig` default/env
- [x] All 38 k0mmand3r tests pass
- [x] Existing `/` tests continue to pass (backward compat)

Closes task 49.

🤖 Generated with [Claude Code](https://claude.com/claude-code)