### PR TITLE
feat(ralph): OODA loop mode — autonomous, no user interruption, 🍰 reward

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -274,8 +274,9 @@ pip-log.txt
 pip-wheel-metadata/
 profile_default/
 raglight/
-ralph/
+/ralph/
 ralphs/ralph-v1
+# _b00t_/ralph/ is the embedded ralph Python source — tracked, not ignored
 report.[0-9]*.[0-9]*.[0-9]*.[0-9]*.json
 rustc-ice-*.txt
 sdist/

--- a/_b00t_/ralph/ralph/entrypoint.py
+++ b/_b00t_/ralph/ralph/entrypoint.py
@@ -109,6 +109,23 @@ def _parse_args(argv: list[str]) -> argparse.Namespace:
     parser.add_argument("--agent", choices=("amp", "claude", "codex", "opencode"))
     parser.add_argument("max_iterations", nargs="?", type=int, default=10)
     parser.add_argument(
+        "--ooda",
+        action="store_true",
+        help="OODA loop mode: run until <promise>COMPLETE</promise> or stuck; no hard iteration cap",
+    )
+    parser.add_argument(
+        "--mission",
+        default=None,
+        help="Mission goal description (logged at start of OODA loop)",
+    )
+    parser.add_argument(
+        "--max-idle",
+        type=int,
+        default=3,
+        dest="max_idle",
+        help="OODA mode: stop after N iterations with identical output (stuck detector). Default: 3",
+    )
+    parser.add_argument(
         "--version",
         action="version",
         version=f"%(prog)s {__version__}",
@@ -155,6 +172,106 @@ def _run_and_capture(cmd: list[str], stdin_path: Path | None = None) -> str:
             stdin.close()
 
 
+def _run_ooda_loop(args: argparse.Namespace, root: Path) -> int:
+    """
+    OODA loop: Observe → Orient → Decide → Act until mission complete or stuck.
+
+    Termination conditions (no hard iteration cap):
+    - <promise>COMPLETE</promise> found in output → success, emit 🍰
+    - Same output hash for --max-idle consecutive iterations → stuck, exit 2
+    - Tool execution error → exit 1
+
+    Sets B00T_K0MMAND3R_PREFIX=! so embedded k0mmand3r commands use sshbang idiom.
+    """
+    import hashlib
+
+    mission = args.mission or "complete all pending tasks"
+    max_idle = args.max_idle
+
+    os.environ.setdefault("B00T_K0MMAND3R_PREFIX", "!")
+
+    LOGGER.info("🔄 OODA loop starting")
+    LOGGER.info("   Mission : %s", mission)
+    LOGGER.info("   Agent   : %s", args.agent)
+    LOGGER.info("   Idle cap: %d identical iterations", max_idle)
+    LOGGER.info("   Prefix  : %s (k0mmand3r sshbang mode)", os.environ["B00T_K0MMAND3R_PREFIX"])
+
+    codex_model = os.environ.get("CODEX_MODEL", "gpt-5.2-codex")
+    codex_reasoning_effort = os.environ.get("CODEX_REASONING_EFFORT", "high")
+    codex_sandbox = os.environ.get("CODEX_SANDBOX", "workspace-write")
+    codex_extra_args = os.environ.get("CODEX_EXTRA_ARGS", "")
+
+    progress_file = root / "progress.txt"
+    _ensure_progress_file(progress_file)
+
+    iteration = 0
+    idle_count = 0
+    last_hash: str | None = None
+
+    while True:
+        iteration += 1
+
+        # ── OBSERVE ────────────────────────────────────────────────────────
+        LOGGER.info("")
+        LOGGER.info("=" * 63)
+        LOGGER.info("  OODA Iteration %d  [idle %d/%d]  mission: %s", iteration, idle_count, max_idle, mission[:40])
+        LOGGER.info("=" * 63)
+
+        try:
+            if args.agent == "amp":
+                output = _run_and_capture(["amp", "--dangerously-allow-all"], stdin_path=root / "prompt.md")
+            elif args.agent == "opencode":
+                output = _run_and_capture(["opencode"], stdin_path=root / "prompt.md")
+            elif args.agent == "codex":
+                codex_args = [
+                    "codex", "exec", "-m", codex_model,
+                    "--config", f'model_reasoning_effort="{codex_reasoning_effort}"',
+                    "--sandbox", codex_sandbox,
+                    "--dangerously-bypass-approvals-and-sandbox",
+                    "--cd", str(root),
+                ]
+                if codex_extra_args:
+                    codex_args.extend(shlex.split(codex_extra_args))
+                codex_args.append("@ralph-next")
+                output = _run_and_capture(codex_args)
+            else:  # claude (default)
+                output = _run_and_capture(
+                    ["claude", "--model", "sonnet", "--dangerously-skip-permissions", "--print"],
+                    stdin_path=root / "CLAUDE.md",
+                )
+        except Exception as exc:
+            LOGGER.error("❌ Tool execution failed: %s", exc)
+            return 1
+
+        # ── ORIENT ────────────────────────────────────────────────────────
+        current_hash = hashlib.sha256(output.encode()).hexdigest()[:16]
+        if current_hash == last_hash:
+            idle_count += 1
+            LOGGER.warning("⚠️  No change detected (idle=%d/%d)", idle_count, max_idle)
+        else:
+            idle_count = 0
+            last_hash = current_hash
+
+        # ── DECIDE ────────────────────────────────────────────────────────
+        if "<promise>COMPLETE</promise>" in output:
+            # MISSION ACCOMPLISHED — emit reward
+            LOGGER.info("")
+            LOGGER.info("🍰 MISSION COMPLETE 🍰")
+            LOGGER.info("   ralph: accomplished in %d OODA iteration(s)", iteration)
+            print("🍰 ralph: MISSION COMPLETE 🍰", flush=True)
+            return 0
+
+        if idle_count >= max_idle:
+            LOGGER.warning("")
+            LOGGER.warning("⚠️  STUCK: no progress for %d consecutive iterations. Stopping.", max_idle)
+            LOGGER.warning("   Check %s for state.", progress_file)
+            return 2
+
+        # ── ACT ───────────────────────────────────────────────────────────
+        LOGGER.info("Iteration %d complete. Continuing OODA loop...", iteration)
+        time.sleep(2)
+
+
 def main(argv: list[str] | None = None) -> int:
     """
     Ralph runtime execution.
@@ -179,6 +296,10 @@ def main(argv: list[str] | None = None) -> int:
 
     if not _require_tasks(root):
         return 1
+
+    # OODA loop mode: no hard iteration cap; runs until complete or stuck
+    if args.ooda:
+        return _run_ooda_loop(args, root)
 
     progress_file = root / "progress.txt"
     _ensure_progress_file(progress_file)

--- a/_b00t_/ralph/tests/test_entrypoint.py
+++ b/_b00t_/ralph/tests/test_entrypoint.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 from collections.abc import Sequence
 from pathlib import Path
 from unittest.mock import MagicMock
@@ -100,3 +101,95 @@ def test_main_mcp_calls_run_with_http(monkeypatch: pytest.MonkeyPatch) -> None:
 
     assert rc == 0
     mock_mcp_run.assert_called_once_with(transport="http", host="0.0.0.0", port=9000)
+
+
+# ── OODA loop tests ──────────────────────────────────────────────────────────
+
+def _make_tasks_dir(tmp_path: Path) -> None:
+    (tmp_path / ".taskmaster" / "tasks").mkdir(parents=True)
+    (tmp_path / ".taskmaster" / "tasks" / "tasks.json").write_text(
+        '{"tasks":[{"id":"t1","title":"t","description":"d","status":"pending","priority":1}],'
+        '"metadata":{"project":"test","branchName":"b","taskMasterVersion":"1.0"}}'
+    )
+    (tmp_path / "CLAUDE.md").write_text("# mission\n")
+    (tmp_path / "prompt.md").write_text("# mission\n")
+
+
+def test_ooda_flag_parsed() -> None:
+    args = entrypoint._parse_args(["--agent", "claude", "--ooda"])
+    assert args.ooda is True
+    assert args.max_idle == 3  # default
+
+
+def test_ooda_mission_flag_parsed() -> None:
+    args = entrypoint._parse_args(["--agent", "claude", "--ooda", "--mission", "fix the bug"])
+    assert args.mission == "fix the bug"
+
+
+def test_ooda_max_idle_flag_parsed() -> None:
+    args = entrypoint._parse_args(["--agent", "claude", "--ooda", "--max-idle", "5"])
+    assert args.max_idle == 5
+
+
+def test_ooda_completes_on_promise(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """OODA loop should return 0 and print 🍰 when COMPLETE marker found."""
+    monkeypatch.chdir(tmp_path)
+    _make_tasks_dir(tmp_path)
+
+    monkeypatch.setattr(entrypoint, "_run_and_capture", lambda *_a, **_kw: "<promise>COMPLETE</promise>")
+    monkeypatch.setattr("ralph.entrypoint.time.sleep", lambda _: None)
+
+    rc = entrypoint.main(["--agent", "claude", "--ooda", "--mission", "unit test mission"])
+    assert rc == 0
+
+
+def test_ooda_stuck_detector_exits_2(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """OODA loop should return 2 when output doesn't change for max_idle iterations."""
+    monkeypatch.chdir(tmp_path)
+    _make_tasks_dir(tmp_path)
+
+    monkeypatch.setattr(entrypoint, "_run_and_capture", lambda *_a, **_kw: "same output every time")
+    monkeypatch.setattr("ralph.entrypoint.time.sleep", lambda _: None)
+
+    rc = entrypoint.main(["--agent", "claude", "--ooda", "--max-idle", "2"])
+    assert rc == 2
+
+
+def test_ooda_resets_idle_on_new_output(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Idle counter should reset when output changes, then trigger on subsequent identical output."""
+    monkeypatch.chdir(tmp_path)
+    _make_tasks_dir(tmp_path)
+
+    outputs = ["output A", "output B", "output B", "output B"]
+    call_idx = [0]
+
+    def fake_run(*_a: object, **_kw: object) -> str:
+        out = outputs[min(call_idx[0], len(outputs) - 1)]
+        call_idx[0] += 1
+        return out
+
+    monkeypatch.setattr(entrypoint, "_run_and_capture", fake_run)
+    monkeypatch.setattr("ralph.entrypoint.time.sleep", lambda _: None)
+
+    # max_idle=2: A→B resets; B→B→B triggers stuck at idle=2
+    rc = entrypoint.main(["--agent", "claude", "--ooda", "--max-idle", "2"])
+    assert rc == 2
+    assert call_idx[0] >= 4  # consumed all outputs before deciding stuck
+
+
+def test_ooda_sets_sshbang_prefix_env(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """OODA loop should set B00T_K0MMAND3R_PREFIX=! env before executing."""
+    monkeypatch.chdir(tmp_path)
+    _make_tasks_dir(tmp_path)
+
+    captured_env: dict[str, str] = {}
+
+    def fake_run(*_a: object, **_kw: object) -> str:
+        captured_env["prefix"] = os.environ.get("B00T_K0MMAND3R_PREFIX", "")
+        return "<promise>COMPLETE</promise>"
+
+    monkeypatch.setattr(entrypoint, "_run_and_capture", fake_run)
+    monkeypatch.setattr("ralph.entrypoint.time.sleep", lambda _: None)
+
+    entrypoint.main(["--agent", "claude", "--ooda"])
+    assert captured_env.get("prefix") == "!"


### PR DESCRIPTION
## Summary
- Add `--ooda` flag: ralph runs until `<promise>COMPLETE</promise>` found — no hard max_iterations cap
- Add `--mission <str>`: log goal description at loop start
- Add `--max-idle <n>` (default 3): stop with exit 2 if N consecutive iterations produce identical output (stuck detector)
- Emit `🍰 MISSION COMPLETE 🍰` + return 0 on success
- Set `B00T_K0MMAND3R_PREFIX=!` before first iteration → embedded k0mmand3r commands use sshbang idiom
- Fix `.gitignore` `ralph/` → `/ralph/` so `_b00t_/ralph/` Python source is tracked

## Usage
```bash
# Run until done — no user interruption
ralph --agent claude --ooda --mission "fix all failing tests"

# With stuck detector tuning (stop if 5 identical outputs)
ralph --agent opencode --ooda --max-idle 5 --mission "implement feature X"
```

## Test plan
- [x] 7 new OODA tests: flag parsing, complete on COMPLETE marker, stuck→exit 2, idle reset, sshbang env set
- [x] 16 total entrypoint tests pass

Closes task 50.

🤖 Generated with [Claude Code](https://claude.com/claude-code)