### PR TITLE
feat(hive): accelerator probe chain + soul node context + HW drift detection

### DIFF
--- a/_b00t_/rk3588.gpu.hardware.tomllmd
+++ b/_b00t_/rk3588.gpu.hardware.tomllmd
@@ -1,0 +1,103 @@
+# b00t hardware datum — Rockchip RK3588 Mali-G610 GPU subsystem (Rock 5C node: rock-5c)
+# 🤓 namespace: <soc>.<subsystem>.hardware — sibling to rk3588.npu.hardware.tomllmd.
+#    RK3588's GPU (Mali-G610 MP4) is a distinct subsystem from the NPU; integrated,
+#    shares system DDR (no dedicated VRAM).
+# Discovered: 2026-06-15 on rock-5c (Armbian 25.11.2, kernel 6.1.115-vendor-rk35xx)
+
+[b00t]
+name   = "rk3588-gpu"
+type   = "hardware"
+status = "active"
+hint   = "RK3588 Mali-G610 MP4 iGPU — display + OpenCL/Vulkan; shared DDR, ch0nky/sm0l display tier"
+
+[b00t.hardware]
+vendor     = "ARM"
+soc        = "RK3588"
+subsystem  = "GPU"
+ip         = "Mali-G610"
+variant    = "MP4"          # 4 execution cores
+driver     = "panfrost"     # mainline; vendor kernel may ship mali-bifrost blob
+vram_kind  = "shared-ddr"   # integrated — no dedicated VRAM
+
+# 🤓 Mali exposes DRM render/card nodes; /dev/mali0 is the vendor char device.
+[b00t.hardware.device_nodes]
+mali_char  = "/dev/mali0"
+dri_card0  = "/dev/dri/card0"
+dri_card1  = "/dev/dri/card1"
+dri_render = "/dev/dri/renderD128"   # primary render node
+by_path    = "/dev/dri/by-path/platform-display-subsystem-render"
+
+[b00t.hardware.thermal]
+zone   = "gpu-thermal"
+idle_c = 51          # observed 2026-06-15, rock-5c idle
+path   = "/sys/class/thermal/thermal_zone*/temp"
+
+# ─── Inference budget ─────────────────────────────────────────────────────────
+[b00t.hardware.inference_budget]
+# 🤓 Mali is NOT the inference path on RK3588 — the NPU (rk3588.npu.hardware) is.
+#    Mali can do OpenCL/Vulkan compute for small models but is bandwidth-bound on
+#    shared DDR. Leave uncalibrated; route LLM inference to the NPU datum.
+inference_path = "not-recommended"
+use_instead    = "rk3588.npu.hardware"
+
+# ─── Supported workloads ──────────────────────────────────────────────────────
+[b00t.hardware.engines]
+panfrost    = { supported = true, notes = "mainline open driver; OpenGL ES 3.2, Vulkan 1.3" }
+mali_blob   = { supported = "vendor", notes = "Rockchip vendor blob; may be required for some media CODECs" }
+opencl      = { supported = true, notes = "via panfrost; light compute offload only" }
+
+# ─── b00t hive resource gate alignment ─────────────────────────────────────────
+[b00t.hardware.hive_gate]
+# iGPU has no VRAM; like the NPU, profiles gate on shared DDR RAM headroom.
+accelerator_kind = "mali-igpu"
+ram_free_gb_display_stack = 2.0   # Wayland + browser headroom
+
+# ─── Detection (b00t up / hive status) ─────────────────────────────────────────
+[b00t.hardware.detect]
+# 🤓 matched by hive's probe_mali() (P1) — presence of /dev/mali0.
+devnode = "test -e /dev/mali0"
+drm     = "ls /dev/dri/by-path/platform-display-subsystem-render 2>/dev/null"
+
+# ─── Current workload ──────────────────────────────────────────────────────────
+[b00t.hardware.workloads]
+primary_use = "display (Wayland/GNOME)"
+compute_use = ""   # TODO if OpenCL offload is configured
+
+# ─── Entanglements ─────────────────────────────────────────────────────────────
+entangled_cli    = ["b00t hive"]
+entangled_datums = ["rk3588.npu.hardware.tomllmd", "rk3588.thermal.hardware.tomllmd"]
+entangled_agents = []
+sibling_socs     = ["rk3576", "rk3588s"]
+
+# ─── Usages ────────────────────────────────────────────────────────────────────
+[[b00t.usages]]
+description = "Confirm Mali device node"
+command     = "ls -l /dev/mali0 /dev/dri/renderD128"
+
+[[b00t.usages]]
+description = "Check GPU thermal"
+command     = "cat /sys/class/thermal/thermal_zone*/temp"  # zone type gpu-thermal"
+
+[[b00t.usages]]
+description = "List DRM nodes (card + render)"
+command     = "ls -l /dev/dri/by-path/"
+
+# ─── References ────────────────────────────────────────────────────────────────
+[[b00t.references]]
+name = "Mali-G610 (Valhall, 4th gen Arch)"
+url  = "https://developer.arm.com/processors/graphics-processors"
+
+[[b00t.references]]
+name = "Panfrost (mainline Mali driver)"
+url  = "https://docs.mesa3d.org/drivers/panfrost.html"
+
+[[b00t.references]]
+name = "Radxa Rock 5C docs"
+url  = "https://wiki.radxa.com/Rock5"
+
+# b00t:map v1
+# summary: RK3588 Mali-G610 MP4 iGPU hardware datum — shared DDR, display+light-compute; NOT the inference path (use NPU)
+# tags: hardware, rk3588, gpu, mali, mali-g610, panfrost, igpu, display, rockchip, rock-5c, armbian
+# tier: sm0l
+# cmds: ls /dev/mali0, cat /sys/class/thermal/thermal_zone*/temp, b00t hive status
+# complexity: 3

--- a/_b00t_/rk3588.npu.hardware.tomllmd
+++ b/_b00t_/rk3588.npu.hardware.tomllmd
@@ -1,0 +1,117 @@
+# b00t hardware datum — Rockchip RK3588 NPU subsystem (Rock 5C node: rock-5c)
+# 🤓 namespace rationale: <soc>.<subsystem>.hardware — RK3588 has NPU + Mali GPU + CPU
+#    subsystems, each warranting its own hardware datum. Sibling SoCs (RK3576/RK3588S)
+#    and boards (Rock5C/5B/H88K/OPi5) reuse the dotted taxonomy without collision.
+# Discovered: 2026-06-15 on rock-5c (Armbian 25.11.2, kernel 6.1.115-vendor-rk35xx)
+
+[b00t]
+name   = "rk3588-npu"
+type   = "hardware"
+status = "active"
+hint   = "RK3588 NPU — 3-core RKNPU2 6 TOPS INT8; edge inference node; ch0nky/sm0l tier"
+
+[b00t.hardware]
+vendor        = "Rockchip"
+soc           = "RK3588"
+subsystem     = "NPU"
+driver_pkg    = "rknpu2-rk3588"
+driver_ver    = "2.3.0"
+cores         = 3
+tops_int8     = 6          # 3 cores × 2 TOPS @ INT8 (vendor spec — verify per board)
+tops_fp16     = 3          # INT8/2 — FP16 throughput, vendor-quoted
+runtime       = "rknn_server"
+python_sdk    = "python3-rknnlite2"
+model_format = ".rknn"
+
+# 🤓 RK3588 NPU exposes as DRM nodes (newer vendor kernel), NOT the legacy /dev/rknpu char dev
+[b00t.hardware.device_nodes]
+dri_card   = "/dev/dri/platform-fdab0000.npu-card"
+dri_render = "/dev/dri/platform-fdab0000.npu-render"
+legacy     = "/dev/rknpu"  # absent on this kernel; driver loaded via rknpu2 pkg
+
+[b00t.hardware.thermal]
+zone   = "npu-thermal"
+idle_c = 52          # observed 2026-06-15, rock-5c idle
+path   = "/sys/class/thermal/thermal_zone*/temp"
+# 🤓 pair with rk3588.thermal.hardware.tomllmd when authored
+
+# ─── Inference budget (UNCALIBRATED — needs on-device benchmark) ───────────────
+[b00t.hardware.inference_budget]
+# ⚠️ TODO: calibrate on rock-5c. Unlike the rtx3090 datum (club-3090 KV_MATH), no
+#    published NPU KV budget exists. Fill after running rknn benchmarks.
+#    RKNN is weight-stationary on-chip — VRAM model not applicable; capacity is
+#    model-size-bound by DDR4 shared RAM + NPU SRAM.
+calibrated            = false
+max_model_param_int8  = "TODO"   # e.g. ~7B INT8 fits if DDR permits
+recommended_quant     = "INT8"   # NPU prefers INT8; FP16 supported at lower TOPS
+
+# ─── Supported inference engines ───────────────────────────────────────────────
+[b00t.hardware.engines]
+# 🤓 RKNN is the ONLY path to the NPU; vLLM/llamacpp run on CPU/GPU, not NPU.
+rknn_toolkit_lite2 = { supported = true, ver = "2.3.0", notes = "python3-rknnlite2 in-process; on-device inference" }
+rknn_server        = { supported = true, ver = "2.3.0", notes = "NPU runtime daemon; serves .rknn models" }
+rknn_toolkit2      = { supported = "host-only", notes = "model conversion PC toolchain → .rknn; NOT on-device" }
+
+# ─── b00t hive resource gate alignment ─────────────────────────────────────────
+[b00t.hardware.hive_gate]
+# 🤓 NPU has no VRAM; gate on shared DDR RAM headroom for model weights instead.
+#    Profiles targeting this NPU should declare ram_free_gb, not gpu_free_mb.
+ram_free_gb_for_7b_int8 = 8.0    # rough: 7B INT8 ≈ 4GB weights + runtime
+accelerator_kind        = "rknn-npu"
+
+# ─── Detection (b00t up / hive status) ─────────────────────────────────────────
+[b00t.hardware.detect]
+# 🤓 these are the probes hive's SystemSnapshot SHOULD run (see P1: query_nvidia_smi
+#    is currently the only accelerator probe — blind to this NPU).
+dpkg    = "dpkg -l | grep -E 'rknpu2-rk3588|python3-rknnlite2'"
+binary  = "command -v rknn_server"
+devnode = "test -e /dev/dri/platform-fdab0000.npu-render || ls /dev/dri/by-path/*npu*"
+
+# ─── Current workload ──────────────────────────────────────────────────────────
+[b00t.hardware.workloads]
+# TODO: set when an .rknn model is deployed to this node
+primary_model = ""    # e.g. "Qwen2.5-3B-INTRON.rknn"
+served_as     = ""    # e.g. "sm0l"
+
+# ─── Entanglements ─────────────────────────────────────────────────────────────
+entangled_cli    = ["b00t hive", "rknn_server", "python3 -c 'from rknnlite.rknnlite import RKNNLite'"]
+entangled_datums = ["rk3588.gpu.hardware.tomllmd", "rk3588.thermal.hardware.tomllmd"]
+entangled_agents = ["pi-agent", "sm0l"]
+sibling_socs     = ["rk3576", "rk3588s"]
+
+# ─── Usages ────────────────────────────────────────────────────────────────────
+[[b00t.usages]]
+description = "Confirm NPU driver + SDK installed"
+command     = "dpkg -l | grep -E 'rknpu2-rk3588|python3-rknnlite2'"
+
+[[b00t.usages]]
+description = "Check NPU thermal (should be <70°C under load)"
+command     = "cat /sys/class/thermal/thermal_zone*/temp"  # zone type npu-thermal"
+
+[[b00t.usages]]
+description = "Verify rknn_server runtime"
+command     = "command -v rknn_server && systemctl status rknn_server 2>/dev/null || rknn_server --version"
+
+[[b00t.usages]]
+description = "List NPU DRM nodes"
+command     = "ls -l /dev/dri/by-path/*npu*"
+
+# ─── References ────────────────────────────────────────────────────────────────
+[[b00t.references]]
+name = "Rockchip RKNPU2 wiki"
+url  = "https://github.com/airockchip/rknn_model_repo"
+
+[[b00t.references]]
+name = "RKNN-Toolkit2 (host conversion)"
+url  = "https://github.com/airockchip/rknn-toolkit2"
+
+[[b00t.references]]
+name = "Rockchip Linux SDK — NPU"
+url  = "https://wiki.radxa.com/Rock5"
+
+# b00t:map v1
+# summary: RK3588 NPU subsystem hardware datum — RKNPU2 2.3.0, 6 TOPS INT8, rknn_server; rock-5c node; inference budget UNCALIBRATED
+# tags: hardware, rk3588, npu, rknpu2, rknn, rockchip, rock-5c, edge-inference, int8, armbian
+# tier: ch0nky
+# cmds: dpkg -l | grep rknpu2, cat /sys/class/thermal/thermal_zone*/temp, b00t hive status
+# complexity: 4

--- a/b00t-cli/src/commands/hive.rs
+++ b/b00t-cli/src/commands/hive.rs
@@ -15,6 +15,50 @@ use crate::hive::{
     discover_profiles, hive_stacks_status, load_profile,
 };
 
+/// Detect + record hardware drift between the live snapshot and soul `node.*` (P3).
+///
+/// Compares the snapshot's stable [`SystemSnapshot::fingerprint`] against the
+/// previously-recorded `node.fingerprint`. On change (or first observation) it:
+///   1. emits a `hw_drift` event to `~/.b00t/events.jsonl`
+///   2. refreshes soul `node.fingerprint` + the accelerator identity keys
+///      (`node.gpu`, `node.npu`) so `whoami` (P2) stays current.
+///
+/// Returns a short human description of the drift, or `None` if hardware is
+/// unchanged from a prior observation. Best-effort: all errors are swallowed
+/// (telemetry/memoisation must never break `hive status`).
+fn record_hardware_drift(snapshot: &SystemSnapshot) -> Option<String> {
+    use crate::memory_provider::{MemoryProvider, file_provider};
+
+    let mem = file_provider();
+    let live = snapshot.fingerprint();
+    let prev = mem.read("node.fingerprint").ok().flatten();
+
+    // Refresh accelerator identity keys from the live probe (deterministic).
+    // Only these two are derivable from the snapshot; static identity keys
+    // (node.board/soc/arch/os/...) are left as seeded — see P4 datums.
+    if let Some(n) = snapshot.accelerators.iter().find(|a| a.is_npu()).map(|a| &a.name) {
+        let _ = mem.write("node.npu", n);
+    }
+    if let Some(g) = snapshot.accelerators.iter().find(|a| a.is_gpu()).map(|a| &a.name) {
+        let _ = mem.write("node.gpu", g);
+    }
+    let _ = mem.write("node.fingerprint", &live);
+
+    match prev {
+        Some(prev) if prev == live => None,
+        Some(prev) => {
+            let detail = format!("{prev} → {live}");
+            crate::write_event("hw_drift", &detail);
+            Some(detail)
+        }
+        None => {
+            let detail = format!("initial: {live}");
+            crate::write_event("hw_drift", &detail);
+            Some(detail)
+        }
+    }
+}
+
 #[derive(Parser)]
 pub enum HiveCommands {
     #[clap(
@@ -148,6 +192,9 @@ pub fn handle_hive_command(cmd: &HiveCommands, path: &str) -> Result<()> {
         HiveCommands::Status { json, guards } => {
             let (json, guards) = (*json, *guards);
             let snapshot = SystemSnapshot::capture()?;
+            // 🤓 P3: detect hardware drift vs soul — emits hw_drift event +
+            //    refreshes node.* regardless of output mode (deterministic).
+            let drift = record_hardware_drift(&snapshot);
 
             if json {
                 println!("{}", serde_json::to_string_pretty(&snapshot)?);
@@ -164,17 +211,22 @@ pub fn handle_hive_command(cmd: &HiveCommands, path: &str) -> Result<()> {
                 "  Swap:  {:.1}GB free / {:.1}GB total",
                 snapshot.swap_free_gb, snapshot.swap_total_gb
             );
-            if let (Some(name), Some(free), Some(total)) = (
-                &snapshot.gpu_name,
-                snapshot.gpu_free_mb,
-                snapshot.gpu_total_mb,
-            ) {
-                println!("  GPU:   {} — {}MB free / {}MB total", name, free, total);
+            // 🤓 list every detected accelerator (discrete GPU, iGPU, NPU); the
+            //    legacy gpu_* fields only surface the first GPU-class entry.
+            if snapshot.accelerators.is_empty() {
+                println!("  Accel: none detected");
             } else {
-                println!("  GPU:   none detected");
+                for a in &snapshot.accelerators {
+                    println!("  {}:  {}", a.class.to_uppercase(), a.summary());
+                }
             }
             println!("  CPU:   {} cores", snapshot.cpu_cores);
             println!();
+
+            if let Some(d) = drift {
+                println!("  ⚠️  HW drift: {}  (soul node.* + events.jsonl updated)", d);
+                println!();
+            }
 
             match &snapshot.active_profile {
                 Some(p) => println!("  Profile:  {}", p),

--- a/b00t-cli/src/commands/whatismy.rs
+++ b/b00t-cli/src/commands/whatismy.rs
@@ -237,6 +237,9 @@ impl WhatismyCommands {
                             "inferred_skills".to_string(),
                             serde_json::json!(inferred_skills),
                         );
+                        if let Some(node) = crate::memory_provider::node_summary_from_soul() {
+                            obj.insert("node".to_string(), serde_json::json!(node));
+                        }
                         if let Some(s) = &supplement {
                             obj.insert("role_supplement".to_string(), serde_json::json!(s));
                         }
@@ -245,6 +248,13 @@ impl WhatismyCommands {
                 } else {
                     println!("🎭 Role: {}", role);
                     println!("🤖 Agent: {}", agent);
+
+                    // 🤓 context-efficiency: one-line node identity from soul (P2).
+                    //    Emits only highest-signal facts; agent runs `b00t soul get
+                    //    node.<key>` for detail instead of receiving a full dump.
+                    if let Some(node) = crate::memory_provider::node_summary_from_soul() {
+                        println!("🥾 Node: {}  (detail: b00t soul get node.*)", node);
+                    }
 
                     if let Some(s) = &supplement {
                         println!("\n{}", s);

--- a/b00t-cli/src/hive.rs
+++ b/b00t-cli/src/hive.rs
@@ -30,6 +30,66 @@ pub struct PeerEntry {
     pub last_seen: String,
 }
 
+// ─── Accelerator ─────────────────────────────────────────────────────────────
+
+/// A detected hardware accelerator (discrete GPU, integrated GPU, or NPU).
+///
+/// Probe chain: nvidia-smi → Mali device node → RKNPU2 driver package.
+/// A node may surface several (e.g. an RK3588 reports both a Mali GPU and an RKNN NPU).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct Accelerator {
+    /// Coarse class: `"gpu"` (dedicated/integrated graphics) or `"npu"` (neural proc).
+    pub class: String,
+    /// How it was detected: `"nvidia-smi"` | `"mali-devnode"` | `"rknpu2-pkg"`.
+    pub kind: String,
+    /// Human-readable model name.
+    pub name: String,
+    /// Vendor (NVIDIA, ARM, Rockchip, …).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub vendor: Option<String>,
+    /// Total VRAM in MB — `None` for shared-memory accelerators (NPU, iGPU).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub vram_total_mb: Option<u32>,
+    /// Free VRAM in MB — `None` for shared-memory accelerators (NPU, iGPU).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub vram_free_mb: Option<u32>,
+}
+
+impl Accelerator {
+    /// True if this is a graphics-class accelerator.
+    pub fn is_gpu(&self) -> bool {
+        self.class == "gpu"
+    }
+    /// True if this is a neural-processing-unit (shared DDR, no VRAM).
+    pub fn is_npu(&self) -> bool {
+        self.class == "npu"
+    }
+    /// One-line summary for the hive status display.
+    pub fn summary(&self) -> String {
+        match (self.vram_free_mb, self.vram_total_mb) {
+            (Some(free), Some(total)) => {
+                format!("{} — {}MB free / {}MB total", self.name, free, total)
+            }
+            _ => self.name.clone(),
+        }
+    }
+}
+
+/// Derive the legacy single-GPU fields from a list of accelerators.
+///
+/// Prefers a GPU with its own VRAM (discrete). Returns `(name, total_mb, free_mb)`.
+/// Pure helper so it is unit-testable independently of live probing.
+fn derive_legacy_gpu_fields(accels: &[Accelerator]) -> (Option<String>, Option<u32>, Option<u32>) {
+    let pick = accels
+        .iter()
+        .find(|a| a.is_gpu() && a.vram_total_mb.is_some())
+        .or_else(|| accels.iter().find(|a| a.is_gpu()));
+    match pick {
+        Some(a) => (Some(a.name.clone()), a.vram_total_mb, a.vram_free_mb),
+        None => (None, None, None),
+    }
+}
+
 // ─── System Snapshot ─────────────────────────────────────────────────────────
 
 /// Real-time system resource snapshot
@@ -39,9 +99,14 @@ pub struct SystemSnapshot {
     pub ram_available_gb: f32,
     pub swap_total_gb: f32,
     pub swap_free_gb: f32,
+    /// Legacy single-GPU fields — kept for backwards-compatible JSON/serde.
+    /// Derived from [`SystemSnapshot::accelerators`] (first GPU-class entry).
     pub gpu_name: Option<String>,
     pub gpu_total_mb: Option<u32>,
     pub gpu_free_mb: Option<u32>,
+    /// All detected accelerators (discrete GPU, iGPU, NPU, …).
+    #[serde(default)]
+    pub accelerators: Vec<Accelerator>,
     pub cpu_cores: u32,
     pub active_downloads: Vec<String>, // PIDs/paths of active HF downloads
     pub active_services: Vec<String>,  // running systemd --user units
@@ -61,7 +126,10 @@ impl SystemSnapshot {
         let swap_free_kb = parse_meminfo_kb(&meminfo, "SwapFree");
 
         let cpu_cores = read_cpu_count();
-        let (gpu_name, gpu_total_mb, gpu_free_mb) = query_nvidia_smi();
+        let accelerators = detect_accelerators();
+        // 🤓 back-compat: surface the first GPU-class accelerator into the legacy
+        //    gpu_* fields so existing JSON consumers + gate logic keep working.
+        let (gpu_name, gpu_total_mb, gpu_free_mb) = derive_legacy_gpu_fields(&accelerators);
         let active_downloads = find_active_downloads();
         let active_services = query_systemd_user_services();
         let active_profile = read_active_profile();
@@ -74,6 +142,7 @@ impl SystemSnapshot {
             gpu_name,
             gpu_total_mb,
             gpu_free_mb,
+            accelerators,
             cpu_cores,
             active_downloads,
             active_services,
@@ -111,15 +180,38 @@ impl SystemSnapshot {
 
     /// Human-readable resource summary line
     pub fn summary_line(&self) -> String {
-        let gpu = match (&self.gpu_name, self.gpu_free_mb, self.gpu_total_mb) {
-            (Some(name), Some(free), Some(total)) => {
-                format!(" | GPU {} {}/{}MB free", name, free, total)
-            }
-            _ => String::from(" | GPU: n/a"),
+        let accel = if self.accelerators.is_empty() {
+            String::new()
+        } else {
+            let npus = self.accelerators.iter().filter(|a| a.is_npu()).count();
+            let gpus = self.accelerators.iter().filter(|a| a.is_gpu()).count();
+            format!(" | accel {}gpu/{}npu", gpus, npus)
         };
         format!(
             "RAM {:.1}/{:.1}GB avail{} | CPU {}c",
-            self.ram_available_gb, self.ram_total_gb, gpu, self.cpu_cores
+            self.ram_available_gb, self.ram_total_gb, accel, self.cpu_cores
+        )
+    }
+
+    /// Stable hardware-identity fingerprint for drift detection (P3).
+    ///
+    /// Captures *identity* only — CPU cores, total RAM, and the set of
+    /// accelerator classes/kinds. Excludes volatile values (free RAM, temps,
+    /// driver versions) so routine load/driver updates don't trigger false drift.
+    /// Two snapshots with the same fingerprint represent the same hardware.
+    pub fn fingerprint(&self) -> String {
+        let mut accels: Vec<String> = self
+            .accelerators
+            .iter()
+            .map(|a| format!("{}:{}", a.class, a.kind))
+            .collect();
+        accels.sort();
+        accels.dedup();
+        format!(
+            "{}c/{:.0}GB/{}",
+            self.cpu_cores,
+            self.ram_total_gb,
+            accels.join(",")
         )
     }
 }
@@ -1212,28 +1304,135 @@ fn read_cpu_count() -> u32 {
         .unwrap_or(1)
 }
 
-fn query_nvidia_smi() -> (Option<String>, Option<u32>, Option<u32>) {
+/// Detect all hardware accelerators on this node.
+///
+/// Probe chain (every probe runs; a node may report several accelerators):
+/// 1. NVIDIA discrete GPU — `nvidia-smi`
+/// 2. ARM Mali integrated GPU — `/dev/mali0` device node
+/// 3. Rockchip RKNN NPU — `rknpu2` driver package / DRM `*npu*` render node
+pub fn detect_accelerators() -> Vec<Accelerator> {
+    let mut accels = Vec::new();
+    if let Some(a) = probe_nvidia_smi() {
+        accels.push(a);
+    }
+    if let Some(a) = probe_mali() {
+        accels.push(a);
+    }
+    if let Some(a) = probe_rknn_npu() {
+        accels.push(a);
+    }
+    accels
+}
+
+/// NVIDIA discrete GPU via `nvidia-smi`. Returns None if nvidia-smi is absent/fails.
+fn probe_nvidia_smi() -> Option<Accelerator> {
     let output = Command::new("nvidia-smi")
         .args([
             "--query-gpu=name,memory.total,memory.free",
             "--format=csv,noheader,nounits",
         ])
-        .output();
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let line = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    if line.is_empty() {
+        return None;
+    }
+    let parts: Vec<&str> = line.splitn(3, ',').collect();
+    if parts.len() != 3 {
+        return None;
+    }
+    let name = parts[0].trim().to_string();
+    let total: u32 = parts[1].trim().parse().unwrap_or(0);
+    let free: u32 = parts[2].trim().parse().unwrap_or(0);
+    Some(Accelerator {
+        class: "gpu".into(),
+        kind: "nvidia-smi".into(),
+        name,
+        vendor: Some("NVIDIA".into()),
+        vram_total_mb: Some(total),
+        vram_free_mb: Some(free),
+    })
+}
 
-    match output {
-        Ok(o) if o.status.success() => {
-            let stdout = String::from_utf8_lossy(&o.stdout);
-            let line = stdout.trim();
-            let parts: Vec<&str> = line.splitn(3, ',').collect();
-            if parts.len() == 3 {
-                let name = parts[0].trim().to_string();
-                let total: u32 = parts[1].trim().parse().unwrap_or(0);
-                let free: u32 = parts[2].trim().parse().unwrap_or(0);
-                return (Some(name), Some(total), Some(free));
-            }
-            (None, None, None)
-        }
-        _ => (None, None, None),
+/// ARM Mali integrated GPU via `/dev/mali0` device-node presence.
+/// 🤓 Mali has no standard VRAM query; it shares system RAM → vram fields are None.
+fn probe_mali() -> Option<Accelerator> {
+    if Path::new("/dev/mali0").exists() {
+        return Some(Accelerator {
+            class: "gpu".into(),
+            kind: "mali-devnode".into(),
+            name: "ARM Mali (integrated)".into(),
+            vendor: Some("ARM".into()),
+            vram_total_mb: None,
+            vram_free_mb: None,
+        });
+    }
+    None
+}
+
+/// Rockchip RKNN NPU (RK3588/RK3576/…).
+///
+/// 🤓 Detection signals (either is sufficient):
+/// - DRM render node whose name contains `npu` (vendor kernel exposes the NPU as
+///   `/dev/dri/platform-fdab0000.npu-render` on RK3588); the legacy `/dev/rknpu`
+///   char device is often absent.
+/// - `rknn_server` runtime binary on PATH.
+/// The driver version is read best-effort from dpkg (`rknpu2-rk3588` / `rknpu2`).
+/// NPU shares DDR → no VRAM fields.
+fn probe_rknn_npu() -> Option<Accelerator> {
+    let has_drm_npu = fs::read_dir("/dev/dri")
+        .ok()
+        .map(|entries| {
+            entries
+                .filter_map(|e| e.ok())
+                .any(|e| e.file_name().to_string_lossy().contains("npu"))
+        })
+        .unwrap_or(false);
+    let has_rknn_server = which("rknn_server");
+    if !has_drm_npu && !has_rknn_server {
+        return None;
+    }
+    let ver = dpkg_version("rknpu2-rk3588").or_else(|| dpkg_version("rknpu2"));
+    let name = match ver {
+        Some(v) => format!("Rockchip RKNPU2 NPU ({v})"),
+        None => "Rockchip RKNN NPU".to_string(),
+    };
+    Some(Accelerator {
+        class: "npu".into(),
+        kind: "rknpu2-pkg".into(),
+        name,
+        vendor: Some("Rockchip".into()),
+        vram_total_mb: None,
+        vram_free_mb: None,
+    })
+}
+
+/// `true` if `bin` resolves on PATH (non-throwing `command -v`).
+fn which(bin: &str) -> bool {
+    Command::new("sh")
+        .args(["-c", &format!("command -v {bin}")])
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+/// Best-effort installed version of a dpkg package, or None if absent/unknown.
+fn dpkg_version(pkg: &str) -> Option<String> {
+    let out = Command::new("dpkg-query")
+        .args(["-W", "-f=${Version}", pkg])
+        .output()
+        .ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    let v = String::from_utf8_lossy(&out.stdout).trim().to_string();
+    if v.is_empty() {
+        None
+    } else {
+        Some(v)
     }
 }
 
@@ -1280,6 +1479,169 @@ fn query_systemd_user_services() -> Vec<String> {
 mod tests {
     use super::*;
     use std::path::PathBuf;
+
+    // ─── Accelerator probe logic ───────────────────────────────────────────────
+
+    fn gpu(name: &str, total: u32, free: u32) -> Accelerator {
+        Accelerator {
+            class: "gpu".into(),
+            kind: "nvidia-smi".into(),
+            name: name.into(),
+            vendor: Some("NVIDIA".into()),
+            vram_total_mb: Some(total),
+            vram_free_mb: Some(free),
+        }
+    }
+
+    fn npu(name: &str) -> Accelerator {
+        Accelerator {
+            class: "npu".into(),
+            kind: "rknpu2-pkg".into(),
+            name: name.into(),
+            vendor: Some("Rockchip".into()),
+            vram_total_mb: None,
+            vram_free_mb: None,
+        }
+    }
+
+    #[test]
+    fn accelerator_class_predicates() {
+        assert!(gpu("x", 1, 1).is_gpu());
+        assert!(!gpu("x", 1, 1).is_npu());
+        assert!(npu("y").is_npu());
+        assert!(!npu("y").is_gpu());
+    }
+
+    #[test]
+    fn accelerator_summary_with_vram() {
+        assert_eq!(gpu("RTX 3090", 24576, 8000).summary(), "RTX 3090 — 8000MB free / 24576MB total");
+    }
+
+    #[test]
+    fn accelerator_summary_without_vram() {
+        // NPU / iGPU: no VRAM → name only
+        assert_eq!(npu("Rockchip RKNPU2 NPU (2.3.0)").summary(), "Rockchip RKNPU2 NPU (2.3.0)");
+    }
+
+    #[test]
+    fn legacy_gpu_fields_prefer_discrete_gpu() {
+        // RK3588 node: an NPU + an integrated Mali (no VRAM). Legacy fields stay None
+        // because no GPU has its own VRAM — gate logic must not falsely report free VRAM.
+        let mali = Accelerator {
+            class: "gpu".into(), kind: "mali-devnode".into(),
+            name: "ARM Mali".into(), vendor: Some("ARM".into()),
+            vram_total_mb: None, vram_free_mb: None,
+        };
+        let accels = vec![npu("RKNPU2"), mali];
+        let (name, total, free) = derive_legacy_gpu_fields(&accels);
+        // Mali is a GPU but has no VRAM → we still surface its name, but VRAM stays None
+        assert_eq!(name.as_deref(), Some("ARM Mali"));
+        assert_eq!(total, None);
+        assert_eq!(free, None);
+    }
+
+    #[test]
+    fn legacy_gpu_fields_picks_nvidia_over_npu() {
+        // A node with BOTH an NVIDIA GPU and an NPU: legacy fields must reflect the GPU.
+        let accels = vec![gpu("RTX 3090", 24576, 8000), npu("RKNPU2")];
+        let (name, total, free) = derive_legacy_gpu_fields(&accels);
+        assert_eq!(name.as_deref(), Some("RTX 3090"));
+        assert_eq!(total, Some(24576));
+        assert_eq!(free, Some(8000));
+    }
+
+    #[test]
+    fn legacy_gpu_fields_none_when_only_npu() {
+        let accels = vec![npu("RKNPU2")];
+        let (name, total, free) = derive_legacy_gpu_fields(&accels);
+        assert_eq!(name, None);
+        assert_eq!(total, None);
+        assert_eq!(free, None);
+    }
+
+    #[test]
+    fn snapshot_summary_line_counts_accelerators() {
+        let snap = SystemSnapshot {
+            ram_total_gb: 16.0, ram_available_gb: 14.0,
+            swap_total_gb: 0.0, swap_free_gb: 0.0,
+            gpu_name: None, gpu_total_mb: None, gpu_free_mb: None,
+            accelerators: vec![gpu("Mali", 0, 0), npu("RKNPU2")],
+            cpu_cores: 8,
+            active_downloads: vec![], active_services: vec![],
+            active_profile: None, hive_ledger_path: None,
+            timestamp: "t".into(),
+        };
+        assert!(snap.summary_line().contains("1gpu/1npu"));
+    }
+
+    #[test]
+    fn fingerprint_is_stable_and_sorted() {
+        // a Mali iGPU (as probe_mali() would emit) + an RKNN NPU
+        let mali = Accelerator {
+            class: "gpu".into(), kind: "mali-devnode".into(),
+            name: "ARM Mali".into(), vendor: Some("ARM".into()),
+            vram_total_mb: None, vram_free_mb: None,
+        };
+        // same hardware → same fingerprint, regardless of accel vector order
+        let mk = |accels: Vec<Accelerator>| SystemSnapshot {
+            ram_total_gb: 16.0, ram_available_gb: 1.0,
+            swap_total_gb: 0.0, swap_free_gb: 0.0,
+            gpu_name: None, gpu_total_mb: None, gpu_free_mb: None,
+            accelerators: accels, cpu_cores: 8,
+            active_downloads: vec![], active_services: vec![],
+            active_profile: None, hive_ledger_path: None, timestamp: "t".into(),
+        };
+        let a = mk(vec![npu("RKNPU2"), mali.clone()]);
+        let b = mk(vec![mali, npu("RKNPU2")]);
+        assert_eq!(a.fingerprint(), b.fingerprint());
+        assert!(a.fingerprint().contains("8c/16GB/"));
+        // class:kind only — versions excluded so driver updates don't drift
+        assert!(a.fingerprint().contains("gpu:mali-devnode"));
+        assert!(a.fingerprint().contains("npu:rknpu2-pkg"));
+    }
+
+    #[test]
+    fn fingerprint_excludes_volatile_values() {
+        // free RAM differs wildly between two captures of the same hardware →
+        // fingerprint must be identical (it tracks total, not free).
+        let base = || SystemSnapshot {
+            ram_total_gb: 16.0, ram_available_gb: 14.0,
+            swap_total_gb: 0.0, swap_free_gb: 0.0,
+            gpu_name: None, gpu_total_mb: None, gpu_free_mb: None,
+            accelerators: vec![npu("RKNPU2")], cpu_cores: 8,
+            active_downloads: vec![], active_services: vec![],
+            active_profile: None, hive_ledger_path: None, timestamp: "t".into(),
+        };
+        let mut loaded = base();
+        loaded.ram_available_gb = 2.0; // nearly full RAM
+        assert_eq!(base().fingerprint(), loaded.fingerprint());
+    }
+
+    #[test]
+    fn snapshot_summary_line_no_accelerators() {
+        let snap = SystemSnapshot {
+            ram_total_gb: 16.0, ram_available_gb: 14.0,
+            swap_total_gb: 0.0, swap_free_gb: 0.0,
+            gpu_name: None, gpu_total_mb: None, gpu_free_mb: None,
+            accelerators: vec![],
+            cpu_cores: 8,
+            active_downloads: vec![], active_services: vec![],
+            active_profile: None, hive_ledger_path: None,
+            timestamp: "t".into(),
+        };
+        assert!(!snap.summary_line().contains("accel"));
+    }
+
+    #[test]
+    fn detect_accelerators_does_not_panic() {
+        // Live probe on whatever host runs the test — must never panic, may be empty.
+        let accels = detect_accelerators();
+        // every entry must be self-consistent
+        for a in &accels {
+            assert!(a.is_gpu() || a.is_npu());
+            assert!(!a.name.is_empty());
+        }
+    }
 
     #[test]
     fn test_guard_warn() {
@@ -1743,6 +2105,7 @@ message = "use uv"
             gpu_name: None,
             gpu_total_mb: None,
             gpu_free_mb: None,
+            accelerators: vec![],
             cpu_cores: 4,
             active_downloads: vec![],
             active_services: vec![],

--- a/b00t-cli/src/memory_provider.rs
+++ b/b00t-cli/src/memory_provider.rs
@@ -232,6 +232,60 @@ pub fn file_provider() -> FileMemory {
     FileMemory::new(soul_path())
 }
 
+// ─── Node identity summary (context-efficient) ────────────────────────────────
+
+/// Compose a compressed one-line node identity from soul `node.*` keys.
+///
+/// Emits only the highest-signal facts (board · soc arch | ram | NPU | GPU | os).
+/// Returns `None` when no node identity is recorded, so callers (e.g. `whoami`)
+/// leave their output unchanged on nodes without soul node data.
+///
+/// 🤓 context-efficiency: agents run `b00t soul get node.npu` for full detail
+///    instead of receiving a full key dump in every whoami.
+pub fn compose_node_summary(mem: &dyn MemoryProvider) -> Option<String> {
+    let get = |k: &str| mem.read(k).ok().flatten();
+    // board is the anchor — without it there is no node identity to summarise.
+    let board = get("node.board")?;
+    let soc = get("node.soc");
+    let arch = get("node.arch");
+    let ram = get("node.ram_gb");
+    let npu = get("node.npu");
+    let gpu = get("node.gpu");
+    let os = get("node.os");
+
+    let mut head = board;
+    if let Some(s) = &soc {
+        head.push_str(&format!(" · {s}"));
+    }
+    if let Some(a) = &arch {
+        head.push_str(&format!(" {a}"));
+    }
+    if let Some(r) = &ram {
+        head.push_str(&format!(" | {r}GB"));
+    }
+    if let Some(n) = &npu {
+        head.push_str(&format!(" | NPU: {}", shorten_accel(n)));
+    }
+    if let Some(g) = &gpu {
+        head.push_str(&format!(" | GPU: {}", shorten_accel(g)));
+    }
+    if let Some(o) = &os {
+        head.push_str(&format!(" | {o}"));
+    }
+    Some(head)
+}
+
+/// Read the global SOUL.tomllm and return the node summary, if recorded.
+pub fn node_summary_from_soul() -> Option<String> {
+    compose_node_summary(&file_provider())
+}
+
+/// Shorten an accelerator description for a one-line summary.
+/// "RKNPU2 2.3.0 + rknn_server + python3-rknnlite2" → "RKNPU2 2.3.0"
+fn shorten_accel(s: &str) -> String {
+    s.split('+').next().unwrap_or(s).trim().to_string()
+}
+
 // ─── Tests ────────────────────────────────────────────────────────────────────
 
 #[cfg(test)]
@@ -322,6 +376,51 @@ mod tests {
     #[test]
     fn test_is_copaw_available_no_panic() {
         let _ = is_copaw_available();
+    }
+
+    // ─── node summary composition ──────────────────────────────────────────────
+
+    #[test]
+    fn test_node_summary_full() {
+        let dir = tempfile::tempdir().unwrap();
+        let mem = FileMemory::new(dir.path().join("SOUL.tomllm"));
+        for (k, v) in [
+            ("node.board", "rock-5c"),
+            ("node.soc", "rk3588"),
+            ("node.arch", "aarch64"),
+            ("node.ram_gb", "16"),
+            ("node.npu", "RKNPU2 2.3.0 + rknn_server + python3-rknnlite2"),
+            ("node.gpu", "Mali (/dev/mali0, dri renderD128/129)"),
+            ("node.os", "armbian-25.11.2 (ubuntu-24.04 noble)"),
+        ] {
+            mem.write(k, v).unwrap();
+        }
+        let s = compose_node_summary(&mem).unwrap();
+        // highest-signal facts present, accelerator descriptions shortened
+        assert!(s.starts_with("rock-5c · rk3588 aarch64 | 16GB"));
+        assert!(s.contains("NPU: RKNPU2 2.3.0"));
+        assert!(s.contains("GPU: Mali (/dev/mali0, dri renderD128/129)"));
+        assert!(s.contains("armbian-25.11.2"));
+        // the trailing tail of the NPU value must NOT leak unshortened
+        assert!(!s.contains("rknn_server"));
+    }
+
+    #[test]
+    fn test_node_summary_none_without_board() {
+        let dir = tempfile::tempdir().unwrap();
+        let mem = FileMemory::new(dir.path().join("SOUL.tomllm"));
+        // no node.board → None (whoami output unchanged)
+        mem.write("node.soc", "rk3588").unwrap();
+        assert!(compose_node_summary(&mem).is_none());
+    }
+
+    #[test]
+    fn test_node_summary_minimal() {
+        let dir = tempfile::tempdir().unwrap();
+        let mem = FileMemory::new(dir.path().join("SOUL.tomllm"));
+        mem.write("node.board", "pi5").unwrap();
+        // only board present → just the board, no separators
+        assert_eq!(compose_node_summary(&mem).as_deref(), Some("pi5"));
     }
 }
 

--- a/b00t-cli/src/whoami.rs
+++ b/b00t-cli/src/whoami.rs
@@ -58,6 +58,13 @@ pub fn whoami(path: &str, role_override: Option<String>, with_skills: bool, skil
 
     println!("{}", rendered);
 
+    // 🤓 P2: one-line node identity from soul — context-efficient preamble.
+    //    Emits only highest-signal facts; agent runs `b00t soul get node.<key>`
+    //    for detail. Silently omitted when no node identity is recorded.
+    if let Some(node) = crate::memory_provider::node_summary_from_soul() {
+        println!("🥾 Node: {}  (detail: b00t soul get node.*)", node);
+    }
+
     // Append role supplement (AGENTS/--role=<role>.md) BEFORE role datum summary
     let role = resolve_role(role_override.clone());
     let role_name = role.name();

--- a/justfile
+++ b/justfile
@@ -423,6 +423,49 @@ ra_run:
 test:
     cargo test -- --nocapture
 
+# 🤓 deterministic hive accelerator/soul verification (P1–P3).
+#    Builds the test binary ONCE (--no-run), then runs hive tests directly —
+#    avoids re-linking the full workspace test binary on every invocation.
+verify-hive:
+    #!/bin/bash
+    set -euo pipefail
+    cargo test --release --no-run -p b00t-cli
+    # locate the test harness that actually contains hive::tests (not the main bin)
+    bin=""
+    for c in $(find target/release/deps -maxdepth 1 -name 'b00t_cli-*' -type f ! -name '*.d' ! -name '*.o'); do
+        if "$c" --list 2>/dev/null | grep -q "hive::tests::"; then bin="$c"; break; fi
+    done
+    [ -n "$bin" ] || { echo "❌ no test harness with hive::tests found"; exit 1; }
+    echo "▶ test binary: $bin"
+    "$bin" hive::tests --nocapture
+
+# Distil a session transcript into persistent soul memory (P5).
+# 🤓 deterministic: prewritten so the agent runs one command, never invents it.
+#   just distill session.log          # from a file (sm0l tier, default)
+#   just distill session.log ch0nky   # from a file, ch0nky tier
+#   just distill -                    # from stdin (pipe a transcript in)
+distill file tier="sm0l":
+    #!/bin/bash
+    set -euo pipefail
+    if [ "{{file}}" = "-" ]; then
+        b00t soul distill --model {{tier}}
+    elif [ -f "{{file}}" ]; then
+        b00t soul distill --model {{tier}} < "{{file}}"
+    else
+        echo "usage: just distill <file|-> [tier=sm0l|ch0nky|frontier]" >&2
+        exit 1
+    fi
+
+# Deterministic node snapshot: refresh soul node.* + HW-drift check (P3),
+# then show the compressed node identity line (P2).
+node-snapshot:
+    @b00t hive status
+    @echo
+    @echo "--- whoami node line (P2) ---"
+    @b00t whoami --role=operator 2>/dev/null | grep -E '^🥾 Node:' || echo "(node identity not yet recorded — run: b00t hive status)"
+
+
+
 # trigger & run any action ci/action locally
 # don't specify workflow or job then script will display ./github/workflows using fzf
 gh-action workflow="" job="":


### PR DESCRIPTION
## What

Closes the gap where `b00t hive status` reported `GPU: none detected` on non-NVIDIA nodes (RK3588/Rock-5C). Adds a multi-vendor accelerator probe, a context-efficient node-identity line in `whoami`, and self-maintaining hardware-drift detection.

## Changes

**P1 — accelerator probe chain** (`hive.rs`, `commands/hive.rs`)
- Replaces nvidia-only `query_nvidia_smi()` with `detect_accelerators()`: `nvidia-smi` → Mali (`/dev/mali0`) → RKNN (`rknpu2` pkg / DRM `*npu*` node).
- New `Accelerator` struct; `SystemSnapshot` gains `accelerators: Vec<Accelerator>` (`#[serde(default)]`) while keeping back-compat `gpu_*` fields via `derive_legacy_gpu_fields()`.
- `hive status` now prints every detected accelerator (e.g. `GPU: ARM Mali` + `NPU: RKNPU2`).

**P2 — compressed node summary in whoami** (`whoami.rs`, `memory_provider.rs`, `whatismy.rs`)
- `compose_node_summary()` reads soul `node.*` and emits a single line (`rock-5c · rk3588 aarch64 | 16GB | NPU:… | GPU:… | armbian-25.11.2`).
- Emits **highest-signal facts only** — detail via `b00t soul get node.<key>`. No full key dump.

**P3 — hardware drift detection** (`hive.rs`, `commands/hive.rs`)
- `SystemSnapshot::fingerprint()` = identity-only (`8c/16GB/gpu:mali-devnode,npu:rknpu2-pkg`); excludes volatile values (free RAM, temps, versions).
- `record_hardware_drift()`: on `hive status`, diffs live vs soul `node.fingerprint`; on change emits `hw_drift` event to `events.jsonl` + auto-refreshes `node.gpu`/`node.npu`.

**P4 — RK3588 hardware datums** (`_b00t_/rk3588.{npu,gpu}.hardware.tomllmd`)
- `<soc>.<subsystem>.hardware.tomllmd` namespace for the RK3588 variant space (sibling SoCs RK3576/RK3588S, boards Rock5C/5B/H88K/OPi5).

**P5 — deterministic just recipes** (`justfile`)
- `verify-hive`, `distill`, `node-snapshot` — prewritten modules (agents run one command instead of inventing it).

## Test evidence
- `hive::tests`: **26 pass / 1 fail** — the failure (`test_guard_expr_coverage_all_shipped_datums`) is **pre-existing & unrelated** (`${USER}` TOML-escape bug in `inference-qwen36-27b-mtp-podman.hive.toml:191`).
- `memory_provider::tests`: **13 pass / 0 fail** (3 new node-summary tests).
- Release build clean on aarch64 (Rock-5C).

## Live verification (rock-5c node)
```
$ b00t hive status
HIVE STATUS  RAM 12.8/15.6GB avail | accel 1gpu/1npu | CPU 8c
  GPU:  ARM Mali (integrated)
  NPU:  Rockchip RKNPU2 NPU (2.3.0-1)
$ b00t whoami --role=operator | grep '^🥾 Node:'
🥾 Node: rock-5c · rk3588 aarch64 | 16GB | NPU: Rockchip RKNPU2 NPU (2.3.0-1) | GPU: ARM Mali (integrated) | armbian-25.11.2
```
First `hive status` emitted `hw_drift: initial`; second run = stable (no noise).

## Out of scope (flagged for follow-up)
- Pre-existing TOML-escape bug in `inference-qwen36-27b-mtp-podman.hive.toml`.
- `justfile` `mod ledgrrr` uninitialised on dev nodes (needs submodule init).