### PR TITLE
fix(datum): split github MCP datum — GitHub API vs local git CLI

### DIFF
--- a/_b00t_/git-local.mcp.toml
+++ b/_b00t_/git-local.mcp.toml
@@ -1,0 +1,41 @@
+[b00t]
+name = "git-local"
+type = "mcp"
+hint = "Local git CLI operations via MCP (add, commit, push, branch, stash, rebase, etc.)"
+lfmf_category = "git-local-mcp"
+hook_detect = "gates"
+
+[b00t.learn]
+topic = "git-local-mcp"
+auto_digest = true
+
+# 🤓: github-mcp-server by jungchihoon — local git CLI wrapper via MCP
+# 29 git operations + 11 workflow combos. Runs git commands locally, no GitHub API token needed.
+# ⚠️ NOTE: This is NOT the official GitHub MCP server (ghcr.io/github/github-mcp-server).
+# ⚠️ BROKEN on Node v22 (Zod v4 parse error). Use git CLI directly as fallback.
+[[b00t.mcp.stdio]]
+priority = 0
+command = "npx"
+requires = ["node", "git"]
+transport = "stdio"
+args = ["-y", "github-mcp-server", "mcp"]
+
+[[b00t.gate]]
+command = "git"
+hint = "git required for local git operations"
+
+[[b00t.gate]]
+rhai = "command_exists(\"npx\")"
+hint = "npx required to run github-mcp-server"
+
+[[b00t.usage]]
+description = "Run local git MCP server"
+command = "npx -y github-mcp-server mcp"
+
+[[b00t.references]]
+name = "github-mcp-server (jungchihoon)"
+url = "https://github.com/jungchihoon/github-mcp-server"
+
+[[b00t.references]]
+name = "MCP GitHub Documentation"
+url = "https://modelcontextprotocol.io/llms-full.txt"

--- a/_b00t_/github.mcp.toml
+++ b/_b00t_/github.mcp.toml
@@ -1,7 +1,7 @@
 [b00t]
 name = "github"
 type = "mcp"
-hint = "GitHub MCP server"
+hint = "GitHub REST API MCP server (issues, PRs, repos, search, actions, code scanning)"
 lfmf_category = "github-mcp"
 hook_detect = "gates"
 
@@ -9,67 +9,59 @@ hook_detect = "gates"
 topic = "github-mcp"
 auto_digest = true
 
-# 🤓: PREFERRED - Official github-mcp-server with toolsets support
-# Requires GITHUB_PERSONAL_ACCESS_TOKEN (use `gh auth token` to avoid storing PATs)
-# Use env.GITHUB_TOOLSETS to enable specific toolsets
+# 🤓: PREFERRED — @modelcontextprotocol/server-github (Anthropic, works on Node v22)
+# 26 tools: issues, PRs, repos, search, forks, reviews, branches, commits
+# Requires GITHUB_TOKEN env var (or GITHUB_PERSONAL_ACCESS_TOKEN)
+# Use `export GITHUB_TOKEN=$(gh auth token)` to avoid storing PATs
 [[b00t.mcp.stdio]]
 priority = 0
-command = "npx"
-requires = ["node", "gh"]
-transport = "stdio"
-args = ["-y", "github-mcp-server"]
-pre_start = "github-auth-validate.rhai"
-
-# 🤓: RHAI validation script runs before MCP server starts
-# Validates/retrieves GITHUB_PERSONAL_ACCESS_TOKEN from gh CLI or env
-# Fails fast if credentials unavailable (prevents entire stack failure)
-[b00t.mcp.stdio.env]
-# 🤓: Use gh CLI to get token dynamically (avoids storing PAT as security vector)
-# In shell: export GITHUB_PERSONAL_ACCESS_TOKEN="$(gh auth token)"
-# GITHUB_PERSONAL_ACCESS_TOKEN = ""  # Set via environment or use gh auth token
-# 🤓: Enable specific toolsets: repos,issues,pull_requests,actions,code_security,experiments
-# Use "all" to enable everything, "default" for baseline (context,repos,issues,pull_requests,users)
-GITHUB_TOOLSETS = "issues,pull_requests,actions"
-
-# 🤓: FALLBACK - Archived @modelcontextprotocol/server-github (no toolsets support)
-[[b00t.mcp.stdio]]
-priority = 10
 command = "npx"
 requires = ["node"]
 transport = "stdio"
 args = ["-y", "@modelcontextprotocol/server-github"]
 
-[[b00t.gate]]
-command = "gh"
-hint = "GitHub CLI (gh) required for auth"
+# 🤓: ALTERNATIVE — Official GitHub MCP server (Go binary, Docker only)
+# From github.com/github/github-mcp-server. Supports --toolsets for granular control.
+# Uses GITHUB_PERSONAL_ACCESS_TOKEN env var (not GITHUB_TOKEN).
+# Toolsets: context,repos,issues,pull_requests,actions,code_security,copilot,dependabot,discussions,gists,git,labels,notifications,orgs,projects,secret_protection,security_advisories,stargazers,users
+[[b00t.mcp.stdio]]
+priority = 10
+command = "docker"
+requires = ["docker", "gh"]
+transport = "stdio"
+args = ["run", "-i", "--rm", "-e", "GITHUB_PERSONAL_ACCESS_TOKEN", "ghcr.io/github/github-mcp-server"]
+pre_start = "github-auth-validate.rhai"
+
+[b00t.mcp.stdio.env]
+GITHUB_TOOLSETS = "issues,pull_requests,actions"
 
 [[b00t.gate]]
-env = "GITHUB_TOOLSETS"
-hint = "Set GITHUB_TOOLSETS in .env (e.g. issues,pull_requests,actions)"
+command = "gh"
+hint = "GitHub CLI (gh) for secure token retrieval"
+
+[[b00t.gate]]
+env = "GITHUB_TOKEN"
+hint = "Set GITHUB_TOKEN (e.g. export GITHUB_TOKEN=$(gh auth token))"
 
 [[b00t.gate]]
 rhai = "command_exists(\"npx\")"
-hint = "npx required to run github-mcp-server"
+hint = "npx required"
 
 [[b00t.usage]]
-description = "Run with gh CLI token (avoids storing PAT)"
-command = "GITHUB_PERSONAL_ACCESS_TOKEN=\"$(gh auth token)\" GITHUB_TOOLSETS=\"all\" npx -y github-mcp-server"
+description = "Primary: Anthropic server with gh CLI token"
+command = "GITHUB_TOKEN=\"$(gh auth token)\" npx -y @modelcontextprotocol/server-github"
 
 [[b00t.usage]]
-description = "Enable specific toolsets (issues, PRs, actions)"
-command = "GITHUB_PERSONAL_ACCESS_TOKEN=\"$(gh auth token)\" GITHUB_TOOLSETS=\"issues,pull_requests,actions\" npx -y github-mcp-server"
-
-[[b00t.usage]]
-description = "Extend default toolsets"
-command = "GITHUB_PERSONAL_ACCESS_TOKEN=\"$(gh auth token)\" GITHUB_TOOLSETS=\"default,code_security,experiments\" npx -y github-mcp-server"
-
-[[b00t.usage]]
-description = "Run with docker (all toolsets, uses gh CLI token)"
+description = "Alternative: Official GitHub server via Docker with toolsets"
 command = "docker run -i --rm -e GITHUB_PERSONAL_ACCESS_TOKEN=\"$(gh auth token)\" -e GITHUB_TOOLSETS=\"all\" ghcr.io/github/github-mcp-server"
 
 [[b00t.references]]
-name = "Official GitHub MCP Server"
+name = "Official GitHub MCP Server (Go)"
 url = "https://github.com/github/github-mcp-server"
+
+[[b00t.references]]
+name = "@modelcontextprotocol/server-github (Anthropic)"
+url = "https://github.com/modelcontextprotocol/servers/tree/main/src/github"
 
 [[b00t.references]]
 name = "MCP GitHub Documentation"

--- a/_b00t_/learn/github-mcp.md
+++ b/_b00t_/learn/github-mcp.md
@@ -6,7 +6,7 @@ Master GitHub API access through Model Context Protocol with granular toolset co
 
 GitHub MCP Server enables AI tools to interact with GitHub APIs. Toolsets provide granular control over which GitHub capabilities are exposed to the AI agent.
 
-**Recommended**: Use official `github-mcp-server` (supports toolsets) instead of archived `@modelcontextprotocol/server-github`
+**Recommended**: Use `@modelcontextprotocol/server-github` (Anthropic, actively maintained, Node v22 compatible)
 
 ## Authentication (Security First!)
 
@@ -170,33 +170,31 @@ GITHUB_PERSONAL_ACCESS_TOKEN="$(gh auth token)" \
 
 ## Server Implementations
 
-### Official github-mcp-server (Recommended)
+### @modelcontextprotocol/server-github (Recommended)
 
-**Package**: `github-mcp-server` (official GitHub implementation)
+**Package**: `@modelcontextprotocol/server-github` (Anthropic, actively maintained)
 
 **Features:**
-- ✅ Full toolsets support
-- ✅ Active development
-- ✅ All configuration options
+- ✅ Works on Node v22
+- ✅ 26 GitHub REST API tools
+- ✅ Simple env: `GITHUB_TOKEN`
 - ✅ Production ready
 
 ```bash
-npx -y github-mcp-server
+GITHUB_TOKEN="$(gh auth token)" npx -y @modelcontextprotocol/server-github
 ```
 
-### @modelcontextprotocol/server-github (Fallback)
+### Official GitHub MCP Server (Docker)
 
-**Package**: `@modelcontextprotocol/server-github` (archived)
+**Package**: `ghcr.io/github/github-mcp-server` (Go binary, Docker only)
 
-**Use only when:**
-- Official server unavailable
-- Legacy compatibility needed
-- No toolsets required
-
-⚠️ **Limitations**: No toolsets support, archived repository
+**Features:**
+- ✅ 20+ toolsets with granular control
+- ✅ GitHub Actions, Copilot, Dependabot, code scanning
+- ✅ Active development by GitHub
 
 ```bash
-npx -y @modelcontextprotocol/server-github
+docker run -i --rm -e GITHUB_PERSONAL_ACCESS_TOKEN="$(gh auth token)" ghcr.io/github/github-mcp-server
 ```
 
 ## Common Patterns
@@ -204,11 +202,11 @@ npx -y @modelcontextprotocol/server-github
 ### b00t MCP Configuration
 
 The `_b00t_/github.mcp.toml` already configures:
-- ✅ Official github-mcp-server (priority 0, preferred)
-- ✅ Fallback to @modelcontextprotocol/server-github (priority 10)
-- ✅ Default toolsets: `issues,pull_requests,actions`
+- ✅ @modelcontextprotocol/server-github (priority 0, no npm `github-mcp-server`)
+- ✅ Official GitHub MCP Server via Docker (priority 10, alternative)
+- ✅ Default toolsets for Docker version: `issues,pull_requests,actions`
 - ✅ gh CLI requirement for secure token access
-- ✅ **RHAI pre-start validation** (fail-fast credential check)
+- ⚠️ The npm `github-mcp-server` package is NOT the official GitHub tool — it's a local git CLI by a community author, has a different name in b00t: `git-local`
 
 **RHAI Validation Script:**
 
@@ -429,7 +427,7 @@ Record lessons about GitHub MCP configuration:
 ```bash
 # Security best practices
 b00t lfmf github-mcp "gh CLI token: Use \$(gh auth token) instead of storing PATs (eliminates security vector)"
-b00t lfmf github-mcp "server preference: Use official github-mcp-server (toolsets support) over archived @modelcontextprotocol/server-github"
+b00t lfmf github-mcp "server preference: Use @modelcontextprotocol/server-github (active, compatible) — NOT npm github-mcp-server (different package, crashes on Node v22)"
 
 # RHAI validation pattern
 b00t lfmf github-mcp "pre-start validation: Use pre_start rhai script for fail-fast credential checks before MCP server starts"

--- a/_b00t_/learn/mcp.md
+++ b/_b00t_/learn/mcp.md
@@ -1,0 +1,5 @@
+---
+narrow surface for sub-agents: impl_mcp_tool! keeps all tool structs compilable but create_full_mcp_registry() is debug-only; create_mcp_registry() MUST stay at 5 tools — sandboxed sub-agents get b00t_exec + b00t_discover as their only entry points
+
+---
+github-mcp(2026-06-17): github-mcp-server npm pkg (jungchihoon) is local git CLI NOT GitHub API. b00t datum split: github.mcp.toml → @modelcontextprotocol/server-github (API). git-local.mcp.toml → github-mcp-server (local git, broken on Node v22).

--- a/_b00t_/scripts/github-auth-validate.rhai
+++ b/_b00t_/scripts/github-auth-validate.rhai
@@ -1,5 +1,5 @@
 // GitHub Authentication Validator for MCP Server
-// Ensures GITHUB_PERSONAL_ACCESS_TOKEN is available before starting github-mcp-server
+// Ensures GITHUB_PERSONAL_ACCESS_TOKEN and GITHUB_TOKEN are available before starting MCP servers
 //
 // Returns:
 //   - Token string if successful
@@ -95,11 +95,13 @@ if !token.starts_with("ghp_") && !token.starts_with("gho_") && !token.starts_wit
 }
 
 // Set token in environment for MCP server
+// Both GITHUB_TOKEN (for @modelcontextprotocol/server-github) and GITHUB_PERSONAL_ACCESS_TOKEN (for official Docker server)
 set_env("GITHUB_PERSONAL_ACCESS_TOKEN", token);
+set_env("GITHUB_TOKEN", token);
 
 log_success("✅ GitHub token retrieved successfully from gh CLI");
 log_info(`ℹ️  Token prefix: ${token.sub_string(0, 8)}...`);
-log_info("ℹ️  Token available for github-mcp-server startup");
+log_info("ℹ️  Token available for GitHub MCP servers (GITHUB_TOKEN + GITHUB_PERSONAL_ACCESS_TOKEN)");
 
 // Return token for use by caller
 return token;


### PR DESCRIPTION
## Summary

The `github` MCP datum pointed to the npm `github-mcp-server` package (by jungchihoon) which is a **local git CLI wrapper**, not a GitHub API server. It also crashed on Node v22.

## Changes

- **`git mv _b00t_/github.mcp.toml → _b00t_/git-local.mcp.toml`** — local git CLI gets its own name
- **New `_b00t_/github.mcp.toml`** — GitHub REST API via `@modelcontextprotocol/server-github` (priority 0) + Docker `ghcr.io/github/github-mcp-server` (priority 10)
- **`_b00t_/learn/github-mcp.md`** — Fixed recommended server, removed incorrect claim about npm package being "official"
- **`_b00t_/learn/mcp.md`** — Updated lfmf entry
- **`_b00t_/scripts/github-auth-validate.rhai`** — Sets both GITHUB_TOKEN and GITHUB_PERSONAL_ACCESS_TOKEN

## Key Discovery

| npm package | What it is | Status |
|---|---|---|
| `github-mcp-server` (jungchihoon) | Local git CLI | ❌ Crashes Node v22 |
| `@modelcontextprotocol/server-github` (Anthropic) | GitHub REST API | ✅ Works |
| `ghcr.io/github/github-mcp-server` (GitHub) | Official Go binary, Docker | ✅ 20+ toolsets |