### PR TITLE
chore(deps): upgrade kube 2→4 + rmcp 0.8→1.7

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -107,6 +107,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "annotate-snippets"
+version = "0.12.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f211a51805bc641f3ad5b7664c77d2547af685cc33b4cd8d31964027a46f13f1"
+dependencies = [
+ "anstyle",
+ "memchr",
+ "unicode-width 0.2.2",
+]
+
+[[package]]
 name = "anstream"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -276,6 +287,12 @@ dependencies = [
  "quote",
  "syn 2.0.118",
 ]
+
+[[package]]
+name = "arraydeque"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d902e3d592a523def97af8f317b08ce16b7ab854c1985a0c671e6f15cebc236"
 
 [[package]]
 name = "arrayvec"
@@ -2523,6 +2540,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
+dependencies = [
+ "darling_core 0.23.0",
+ "darling_macro 0.23.0",
+]
+
+[[package]]
 name = "darling_core"
 version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2551,6 +2578,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling_core"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
+dependencies = [
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.118",
+]
+
+[[package]]
 name = "darling_macro"
 version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2568,6 +2608,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
 dependencies = [
  "darling_core 0.21.3",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
+dependencies = [
+ "darling_core 0.23.0",
  "quote",
  "syn 2.0.118",
 ]
@@ -3044,6 +3095,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "encoding_rs_io"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cc3c5651fb62ab8aa3103998dade57efdd028544bd300516baa31840c252a83"
+dependencies = [
+ "encoding_rs",
 ]
 
 [[package]]
@@ -4259,6 +4319,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "granit-parser"
+version = "0.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f50ba32164f9e098d5da618776a32afbb32270adcbe3d3d006107dae11e37c91"
+dependencies = [
+ "arraydeque",
+ "smallvec 1.15.2",
+]
+
+[[package]]
 name = "group"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5254,9 +5324,9 @@ dependencies = [
 
 [[package]]
 name = "jsonpath-rust"
-version = "0.7.5"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c00ae348f9f8fd2d09f82a98ca381c60df9e0820d8d79fce43e649b4dc3128b"
+checksum = "633a7320c4bb672863a3782e89b9094ad70285e097ff6832cddd0ec615beadfa"
 dependencies = [
  "pest",
  "pest_derive",
@@ -5315,12 +5385,12 @@ dependencies = [
 
 [[package]]
 name = "k8s-openapi"
-version = "0.26.1"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06d9e5e61dd037cdc51da0d7e2b2be10f497478ea7e120d85dad632adb99882b"
+checksum = "d9c6922f6afe80418dd6019818af5d0d34584c371780ff09b9752370c25b4abb"
 dependencies = [
  "base64 0.22.1",
- "chrono",
+ "jiff",
  "serde",
  "serde_json",
 ]
@@ -5356,9 +5426,9 @@ dependencies = [
 
 [[package]]
 name = "kube"
-version = "2.0.1"
+version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48e7bb0b6a46502cc20e4575b6ff401af45cfea150b34ba272a3410b78aa014e"
+checksum = "4bb9108095346a7096d11feeaff419c75dddcac1b2f59acb38d7bf3d13c3e146"
 dependencies = [
  "k8s-openapi",
  "kube-client",
@@ -5369,16 +5439,14 @@ dependencies = [
 
 [[package]]
 name = "kube-client"
-version = "2.0.1"
+version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4987d57a184d2b5294fdad3d7fc7f278899469d21a4da39a8f6ca16426567a36"
+checksum = "d0f628e05bc2264c21fe10d3d675117dc9b43ea3bf4fb07262a222679757537b"
 dependencies = [
  "base64 0.22.1",
  "bytes",
- "chrono",
  "either",
  "futures",
- "home",
  "http 1.4.2",
  "http-body",
  "http-body-util",
@@ -5386,6 +5454,7 @@ dependencies = [
  "hyper-rustls",
  "hyper-timeout",
  "hyper-util",
+ "jiff",
  "jsonpath-rust",
  "k8s-openapi",
  "kube-core",
@@ -5393,8 +5462,8 @@ dependencies = [
  "rustls",
  "secrecy",
  "serde",
+ "serde-saphyr",
  "serde_json",
- "serde_yaml",
  "thiserror 2.0.18",
  "tokio",
  "tokio-util",
@@ -5405,14 +5474,14 @@ dependencies = [
 
 [[package]]
 name = "kube-core"
-version = "2.0.1"
+version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "914bbb770e7bb721a06e3538c0edd2babed46447d128f7c21caa68747060ee73"
+checksum = "c1b02f5933ba06140d58c7d6727f6c319f0962ec6a344aa5e21e475e891deaa8"
 dependencies = [
- "chrono",
  "derive_more 2.1.1",
  "form_urlencoded",
  "http 1.4.2",
+ "jiff",
  "json-patch",
  "k8s-openapi",
  "schemars",
@@ -5424,11 +5493,11 @@ dependencies = [
 
 [[package]]
 name = "kube-derive"
-version = "2.0.1"
+version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03dee8252be137772a6ab3508b81cd797dee62ee771112a2453bc85cbbe150d2"
+checksum = "fe171898707dadf1818ef94e81ef57f6beb7edf9ba87b9e814c045dad356c7aa"
 dependencies = [
- "darling 0.21.3",
+ "darling 0.23.0",
  "proc-macro2",
  "quote",
  "serde",
@@ -5438,9 +5507,9 @@ dependencies = [
 
 [[package]]
 name = "kube-runtime"
-version = "2.0.1"
+version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6aea4de4b562c5cc89ab10300bb63474ae1fa57ff5a19275f2e26401a323e3fd"
+checksum = "99ddec66c540c7cf29a5b41fe4a657a53687f95c346e03bdf00585b70a1bab21"
 dependencies = [
  "ahash",
  "async-broadcast",
@@ -5448,7 +5517,7 @@ dependencies = [
  "backon",
  "educe",
  "futures",
- "hashbrown 0.15.5",
+ "hashbrown 0.16.1",
  "hostname",
  "json-patch",
  "k8s-openapi",
@@ -6036,6 +6105,12 @@ checksum = "418abd1b6d34fbf6cae440dc874771b0525a604428704c76e48b29a5e67b8003"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "nohash-hasher"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bf50223579dc7cdcfb3bfcacf7069ff68243f8c363f62ffa99cf000a6b9c451"
 
 [[package]]
 name = "nom"
@@ -8580,6 +8655,25 @@ checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
  "serde_derive",
+]
+
+[[package]]
+name = "serde-saphyr"
+version = "0.0.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5897b4c3faadadd35fdb6689f015641f3bc481d5adaaac56231ea15aeb243db3"
+dependencies = [
+ "ahash",
+ "annotate-snippets",
+ "base64 0.22.1",
+ "encoding_rs_io",
+ "getrandom 0.3.4",
+ "granit-parser",
+ "nohash-hasher",
+ "num-traits",
+ "serde",
+ "smallvec 1.15.2",
+ "zmij",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -734,7 +734,7 @@ dependencies = [
  "log",
  "num-rational",
  "num-traits",
- "pastey",
+ "pastey 0.1.1",
  "rayon",
  "thiserror 2.0.18",
  "v_frame",
@@ -2011,7 +2011,7 @@ dependencies = [
  "num-traits",
  "serde",
  "wasm-bindgen",
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -2531,16 +2531,6 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.21.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cdf337090841a411e2a7f3deb9187445851f91b309c0c0a29e05f74a00a48c0"
-dependencies = [
- "darling_core 0.21.3",
- "darling_macro 0.21.3",
-]
-
-[[package]]
-name = "darling"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
@@ -2554,20 +2544,6 @@ name = "darling_core"
 version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
-dependencies = [
- "fnv",
- "ident_case",
- "proc-macro2",
- "quote",
- "strsim",
- "syn 2.0.118",
-]
-
-[[package]]
-name = "darling_core"
-version = "0.21.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1247195ecd7e3c85f83c8d2a366e4210d588e802133e1e355180a9870b517ea4"
 dependencies = [
  "fnv",
  "ident_case",
@@ -2597,17 +2573,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
  "darling_core 0.20.11",
- "quote",
- "syn 2.0.118",
-]
-
-[[package]]
-name = "darling_macro"
-version = "0.21.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
-dependencies = [
- "darling_core 0.21.3",
  "quote",
  "syn 2.0.118",
 ]
@@ -4547,7 +4512,7 @@ checksum = "617aaa3557aef3810a6369d0a99fac8a080891b68bd9f9812a1eeda0c0730cbd"
 dependencies = [
  "cfg-if",
  "libc",
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -4765,7 +4730,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.62.2",
+ "windows-core",
 ]
 
 [[package]]
@@ -5582,7 +5547,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
 dependencies = [
  "cfg-if",
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -5592,7 +5557,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "754ca22de805bb5744484a5b151a9e1a8e837d5dc232c2d7d8c2e3492edc8b60"
 dependencies = [
  "cfg-if",
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -6063,9 +6028,9 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.30.1"
+version = "0.31.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
+checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
 dependencies = [
  "bitflags 2.13.0",
  "cfg-if",
@@ -6886,7 +6851,7 @@ dependencies = [
  "libc",
  "redox_syscall 0.5.18",
  "smallvec 1.15.2",
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -6909,6 +6874,12 @@ name = "pastey"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "35fb2e5f958ec131621fdd531e9fc186ed768cbe395337403ae56c17a74c68ec"
+
+[[package]]
+name = "pastey"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ee67f1008b1ba2321834326597b8e186293b049a023cdef258527550b9935b4"
 
 [[package]]
 name = "pdf-extract"
@@ -7359,9 +7330,9 @@ dependencies = [
 
 [[package]]
 name = "process-wrap"
-version = "8.2.1"
+version = "9.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3ef4f2f0422f23a82ec9f628ea2acd12871c81a9362b02c43c1aa86acfc3ba1"
+checksum = "2e842efad9119158434d193c6682e2ebee4b44d6ad801d7b349623b3f57cdf55"
 dependencies = [
  "futures",
  "indexmap 2.14.0",
@@ -8230,10 +8201,11 @@ dependencies = [
 
 [[package]]
 name = "rmcp"
-version = "0.8.5"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5947688160b56fb6c827e3c20a72c90392a1d7e9dec74749197aa1780ac42ca"
+checksum = "0810a9f717d9828f475fe1f629f4c305c8464b7f496c3a854b58d29e65f4058e"
 dependencies = [
+ "async-trait",
  "base64 0.22.1",
  "bytes",
  "chrono",
@@ -8241,10 +8213,10 @@ dependencies = [
  "http 1.4.2",
  "http-body",
  "http-body-util",
- "paste",
+ "pastey 0.2.3",
  "pin-project-lite",
  "process-wrap",
- "rand 0.9.4",
+ "rand 0.10.1",
  "rmcp-macros",
  "schemars",
  "serde",
@@ -8261,11 +8233,11 @@ dependencies = [
 
 [[package]]
 name = "rmcp-macros"
-version = "0.8.5"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01263441d3f8635c628e33856c468b96ebbce1af2d3699ea712ca71432d4ee7a"
+checksum = "6aefac48c364756e97f04c0401ba3231e8607882c7c1d92da0437dc16307904d"
 dependencies = [
- "darling 0.21.3",
+ "darling 0.23.0",
  "proc-macro2",
  "quote",
  "serde_json",
@@ -11083,37 +11055,23 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows"
-version = "0.61.3"
+version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
+checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
 dependencies = [
  "windows-collections",
- "windows-core 0.61.2",
+ "windows-core",
  "windows-future",
- "windows-link 0.1.3",
  "windows-numerics",
 ]
 
 [[package]]
 name = "windows-collections"
-version = "0.2.0"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
+checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
 dependencies = [
- "windows-core 0.61.2",
-]
-
-[[package]]
-name = "windows-core"
-version = "0.61.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
-dependencies = [
- "windows-implement",
- "windows-interface",
- "windows-link 0.1.3",
- "windows-result 0.3.4",
- "windows-strings 0.4.2",
+ "windows-core",
 ]
 
 [[package]]
@@ -11124,19 +11082,19 @@ checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
 dependencies = [
  "windows-implement",
  "windows-interface",
- "windows-link 0.2.1",
- "windows-result 0.4.1",
- "windows-strings 0.5.1",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
 ]
 
 [[package]]
 name = "windows-future"
-version = "0.2.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
+checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
 dependencies = [
- "windows-core 0.61.2",
- "windows-link 0.1.3",
+ "windows-core",
+ "windows-link",
  "windows-threading",
 ]
 
@@ -11164,24 +11122,18 @@ dependencies = [
 
 [[package]]
 name = "windows-link"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
-
-[[package]]
-name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-numerics"
-version = "0.2.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
+checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
 dependencies = [
- "windows-core 0.61.2",
- "windows-link 0.1.3",
+ "windows-core",
+ "windows-link",
 ]
 
 [[package]]
@@ -11190,18 +11142,9 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
 dependencies = [
- "windows-link 0.2.1",
- "windows-result 0.4.1",
- "windows-strings 0.5.1",
-]
-
-[[package]]
-name = "windows-result"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
-dependencies = [
- "windows-link 0.1.3",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
 ]
 
 [[package]]
@@ -11210,16 +11153,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
 dependencies = [
- "windows-link 0.2.1",
-]
-
-[[package]]
-name = "windows-strings"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
-dependencies = [
- "windows-link 0.1.3",
+ "windows-link",
 ]
 
 [[package]]
@@ -11228,7 +11162,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
 dependencies = [
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -11273,7 +11207,7 @@ version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -11313,7 +11247,7 @@ version = "0.53.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
 dependencies = [
- "windows-link 0.2.1",
+ "windows-link",
  "windows_aarch64_gnullvm 0.53.1",
  "windows_aarch64_msvc 0.53.1",
  "windows_i686_gnu 0.53.1",
@@ -11326,11 +11260,11 @@ dependencies = [
 
 [[package]]
 name = "windows-threading"
-version = "0.1.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b66463ad2e0ea3bbf808b7f1d371311c80e115c0b71d60efc142cafbcfb057a6"
+checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
 dependencies = [
- "windows-link 0.1.3",
+ "windows-link",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,7 +55,7 @@ regex = "1.11"
 anyhow = "1.0"
 chrono = { version = "0.4", features = ["serde"] }
 tokio = { version = "1.44", features = ["full"] }
-rmcp = { version = "0.8", features = ["client", "transport-io", "server", "macros", "schemars", "transport-streamable-http-server", "transport-worker", "transport-child-process"] }
+rmcp = { version = "1", features = ["client", "transport-io", "server", "macros", "schemars", "transport-streamable-http-server", "transport-worker", "transport-child-process"] }
 tracing = "0.1"
 opentelemetry = { version = "0.31", features = ["trace"] }
 async-trait = "0.1"

--- a/b00t-azure-cp/src/main.rs
+++ b/b00t-azure-cp/src/main.rs
@@ -27,7 +27,7 @@ use azure_data_tables::clients::TableServiceClient;
 use azure_identity::AppServiceManagedIdentityCredential;
 use chrono::{DateTime, Utc};
 use rmcp::handler::server::{tool::ToolRouter, wrapper::Parameters};
-use rmcp::model::{CallToolResult, Content, ServerCapabilities, ServerInfo};
+use rmcp::model::{CallToolResult, Content, Implementation, ServerCapabilities, ServerInfo};
 use rmcp::schemars::JsonSchema;
 use rmcp::transport::streamable_http_server::{
     StreamableHttpServerConfig, StreamableHttpService, session::local::LocalSessionManager,
@@ -660,17 +660,13 @@ impl AzureCpServer {
 #[tool_handler]
 impl ServerHandler for AzureCpServer {
     fn get_info(&self) -> ServerInfo {
-        ServerInfo {
-            server_info: rmcp::model::Implementation {
-                name: "b00t-azure-cp".into(),
-                version: env!("CARGO_PKG_VERSION").into(),
-                title: None,
-                icons: None,
-                website_url: None,
-            },
-            capabilities: ServerCapabilities::builder().enable_tools().build(),
-            ..Default::default()
-        }
+        let mut server_info = Implementation::from_build_env();
+        server_info.name = "b00t-azure-cp".into();
+        server_info.version = env!("CARGO_PKG_VERSION").into();
+        let mut info = ServerInfo::default();
+        info.server_info = server_info;
+        info.capabilities = ServerCapabilities::builder().enable_tools().build();
+        info
     }
 }
 

--- a/b00t-c0re-lib/src/grok.rs
+++ b/b00t-c0re-lib/src/grok.rs
@@ -8,7 +8,7 @@ use anyhow::Result;
 use dirs;
 use rmcp::{
     ServiceExt,
-    model::CallToolRequestParam,
+    model::CallToolRequestParams,
     service::RunningService,
     transport::{ConfigureCommandExt, TokioChildProcess},
 };
@@ -242,10 +242,7 @@ impl GrokClient {
                     json!(format!("grok:digest:{}", topic)),
                 );
                 params.insert("topic".to_string(), json!(topic));
-                let request = CallToolRequestParam {
-                    name: Cow::Borrowed("repo.index"),
-                    arguments: Some(params),
-                };
+                let request = CallToolRequestParams::new("repo.index").with_arguments(params);
                 let response = client.call_tool(request).await?;
                 self.parse_irontology_digest_response(response, topic, content)
             }
@@ -253,10 +250,7 @@ impl GrokClient {
                 let mut params = Map::new();
                 params.insert("topic".to_string(), json!(topic));
                 params.insert("content".to_string(), json!(content));
-                let request = CallToolRequestParam {
-                    name: Cow::Borrowed("grok_digest"),
-                    arguments: Some(params),
-                };
+                let request = CallToolRequestParams::new("grok_digest").with_arguments(params);
                 let response = client.call_tool(request).await?;
                 self.parse_digest_response(response)
             }
@@ -285,10 +279,7 @@ impl GrokClient {
                 if let Some(k) = limit {
                     params.insert("top_k".to_string(), json!(k));
                 }
-                let request = CallToolRequestParam {
-                    name: Cow::Borrowed("repo.search"),
-                    arguments: Some(params),
-                };
+                let request = CallToolRequestParams::new("repo.search").with_arguments(params);
                 let response = client.call_tool(request).await?;
                 self.parse_irontology_ask_response(response, query)
             }
@@ -301,10 +292,7 @@ impl GrokClient {
                 if let Some(limit) = limit {
                     params.insert("limit".to_string(), json!(limit));
                 }
-                let request = CallToolRequestParam {
-                    name: Cow::Borrowed("grok_ask"),
-                    arguments: Some(params),
-                };
+                let request = CallToolRequestParams::new("grok_ask").with_arguments(params);
                 let response = client.call_tool(request).await?;
                 self.parse_ask_response(response)
             }
@@ -324,10 +312,7 @@ impl GrokClient {
                 let mut params = Map::new();
                 params.insert("content".to_string(), json!(content));
                 params.insert("source".to_string(), json!(src));
-                let request = CallToolRequestParam {
-                    name: Cow::Borrowed("repo.index"),
-                    arguments: Some(params),
-                };
+                let request = CallToolRequestParams::new("repo.index").with_arguments(params);
                 let response = client.call_tool(request).await?;
                 self.parse_irontology_learn_response(response, src)
             }
@@ -337,10 +322,7 @@ impl GrokClient {
                 if let Some(source) = source {
                     params.insert("source".to_string(), json!(source));
                 }
-                let request = CallToolRequestParam {
-                    name: Cow::Borrowed("grok_learn"),
-                    arguments: Some(params),
-                };
+                let request = CallToolRequestParams::new("grok_learn").with_arguments(params);
                 let response = client.call_tool(request).await?;
                 self.parse_learn_response(response)
             }
@@ -362,10 +344,7 @@ impl GrokClient {
             anyhow::anyhow!("GrokClient not initialized - call initialize() first")
         })?;
 
-        let request = CallToolRequestParam {
-            name: Cow::Borrowed("grok_status"),
-            arguments: None,
-        };
+        let request = CallToolRequestParams::new("grok_status");
         let response = client.call_tool(request).await?;
 
         let content_text = response

--- a/b00t-cli/Cargo.toml
+++ b/b00t-cli/Cargo.toml
@@ -47,8 +47,8 @@ semver = "1.0"
 tera = "1.20"
 dirs = "6.0"
 once_cell = "1.20"
-kube = { version = "2.0", features = ["runtime", "derive"] }
-k8s-openapi = { version = "0.26", features = ["v1_30"] }
+kube = { version = "4.0", features = ["runtime", "derive"] }
+k8s-openapi = { version = "0.28", features = ["v1_32"] }
 snafu = "0.8"
 tokio = { version = "1.34.0", features = ["full"] }
 serde_yaml = "0.9"

--- a/b00t-mcp/src/clap_reflection.rs
+++ b/b00t-mcp/src/clap_reflection.rs
@@ -22,15 +22,12 @@ pub trait McpReflection: CommandFactory {
             .map(|s| s.to_string())
             .unwrap_or_else(|| format!("b00t-cli {}", Self::command_path().join(" ")));
 
-        Tool {
-            name: name.clone().into(),
-            title: Some(name),
-            description: Some(description.into()),
-            input_schema: std::sync::Arc::new(Self::generate_json_schema()),
-            output_schema: None,
-            annotations: None,
-            icons: None,
-        }
+        let mut tool = Tool::default();
+        tool.name = name.clone().into();
+        tool.title = Some(name);
+        tool.description = Some(description.into());
+        tool.input_schema = std::sync::Arc::new(Self::generate_json_schema());
+        tool
     }
 
     /// Generate JSON schema from CLAP command structure

--- a/b00t-mcp/src/mcp_server_rusty.rs
+++ b/b00t-mcp/src/mcp_server_rusty.rs
@@ -3,7 +3,7 @@ use rmcp::{
     handler::server::ServerHandler,
     model::{
         Annotated,
-        CallToolRequestParam,
+        CallToolRequestParams,
         CallToolResult,
         Content,
         ErrorData as McpError,
@@ -110,20 +110,19 @@ impl ServerHandler for B00tMcpServerRusty {
     }
 
     fn get_info(&self) -> ServerInfo {
-        ServerInfo {
-            protocol_version: ProtocolVersion::default(), // Uses LATEST (2025-03-26)
-            server_info: Implementation::from_build_env(),
-            instructions: Some(
-                "🦀 Rusty MCP server for b00t-cli with compile-time generated tools. \
-                 Features type-safe command dispatch, zero runtime parsing failures, \
-                 and full CLAP structure synchronization."
-                    .into(),
-            ),
-            capabilities: ServerCapabilities::builder()
-                .enable_tools()
-                .enable_resources()
-                .build(),
-        }
+        let mut info = ServerInfo::default();
+        info.server_info = Implementation::from_build_env();
+        info.instructions = Some(
+            "🦀 Rusty MCP server for b00t-cli with compile-time generated tools. \
+             Features type-safe command dispatch, zero runtime parsing failures, \
+             and full CLAP structure synchronization."
+                .into(),
+        );
+        info.capabilities = ServerCapabilities::builder()
+            .enable_tools()
+            .enable_resources()
+            .build();
+        info
     }
 
     async fn list_tools(
@@ -147,12 +146,13 @@ impl ServerHandler for B00tMcpServerRusty {
         Ok(ListToolsResult {
             tools,
             next_cursor: None,
+            meta: None,
         })
     }
 
     async fn call_tool(
         &self,
-        request: CallToolRequestParam,
+        request: CallToolRequestParams,
         context: RequestContext<RoleServer>,
     ) -> Result<CallToolResult, McpError> {
         let tool_name = request.name.as_ref();
@@ -244,6 +244,7 @@ impl ServerHandler for B00tMcpServerRusty {
         Ok(ListResourcesResult {
             resources,
             next_cursor: None,
+            meta: None,
         })
     }
 
@@ -261,9 +262,9 @@ impl ServerHandler for B00tMcpServerRusty {
                 info!("📚 Reading b00t skill: {}", topic);
 
                 match self.read_b00t_skill(topic).await {
-                    Ok(content) => Ok(ReadResourceResult {
-                        contents: vec![ResourceContents::text(content, uri)],
-                    }),
+                    Ok(content) => Ok(ReadResourceResult::new(
+                        vec![ResourceContents::text(content, uri)],
+                    )),
                     Err(e) => {
                         error!("❌ Failed to read b00t skill {}: {}", topic, e);
                         let error_msg = format!("Failed to read skill: {}", e);
@@ -275,14 +276,14 @@ impl ServerHandler for B00tMcpServerRusty {
                 info!("🎯 Reading current b00t context");
 
                 match self.read_current_context().await {
-                    Ok(content) => Ok(ReadResourceResult {
-                        contents: vec![ResourceContents::TextResourceContents {
+                    Ok(content) => Ok(ReadResourceResult::new(
+                        vec![ResourceContents::TextResourceContents {
                             uri: uri.clone(),
                             mime_type: Some("application/json".to_string()),
                             text: content,
                             meta: None,
                         }],
-                    }),
+                    )),
                     Err(e) => {
                         error!("❌ Failed to read current context: {}", e);
                         let error_msg = format!("Failed to read context: {}", e);
@@ -295,9 +296,9 @@ impl ServerHandler for B00tMcpServerRusty {
                 info!("📁 Reading file resource: {}", file_path);
 
                 match std::fs::read_to_string(file_path) {
-                    Ok(content) => Ok(ReadResourceResult {
-                        contents: vec![ResourceContents::text(content, uri)],
-                    }),
+                    Ok(content) => Ok(ReadResourceResult::new(
+                        vec![ResourceContents::text(content, uri)],
+                    )),
                     Err(e) => {
                         error!("❌ Failed to read file {}: {}", file_path, e);
                         let error_msg = format!("Failed to read file: {}", e);


### PR DESCRIPTION
## Summary

Combined Rust dependency upgrades — kube and rmcp major versions.

### kube 2.0 → 4.0
- k8s-openapi: 0.26 (v1_30) → 0.28 (v1_32)
- **No API changes needed** in b00t-cli/src/k8s/client.rs
- Client::try_from, Api::namespaced, Config::from_custom_kubeconfig all compatible

### rmcp 0.8 → 1.7
| Change | Impact |
|--------|--------|
| `CallToolRequestParam` → `CallToolRequestParams` | Rename + `#[non_exhaustive]` → use `::new(name).with_arguments()` |
| `Tool` struct | `#[non_exhaustive]` → use `Default+field mutation` |
| `ServerInfo = InitializeResult` | Type alias, `#[non_exhaustive]` |
| Results types | `ListToolsResult`, `ListResourcesResult`, `ReadResourceResult` all need `meta` field |

### Files changed
- `b00t-c0re-lib/src/grok.rs` — 7 CallToolRequestParams constructors refactored
- `b00t-mcp/src/mcp_server_rusty.rs` — Results with meta, ServerInfo pattern
- `b00t-mcp/src/clap_reflection.rs` — Tool::default() pattern
- `b00t-azure-cp/src/main.rs` — ServerInfo::default() + Implementation import

### Verification
- ✅ `cargo check` — full workspace compiles cleanly