### PR TITLE
feat(assimilate): enhanced pipeline — sm0l crawl + concept extraction + hybrid index

### DIFF
--- a/b00t-cli/Cargo.toml
+++ b/b00t-cli/Cargo.toml
@@ -32,7 +32,6 @@ chrono = { workspace = true, features = ["serde"] }
 diffy = { workspace = true }
 tempfile = "3.13.0"
 thiserror = "2"
-diffy = { workspace = true }
 
 # b00t-cli specific dependencies
 rhai = { workspace = true }

--- a/b00t-cli/src/assimilate/concept_extractor.rs
+++ b/b00t-cli/src/assimilate/concept_extractor.rs
@@ -35,7 +35,7 @@ pub struct ConceptExtraction {
 
 /// Extracts concepts and links from text using a sm0l model.
 pub struct ConceptExtractor {
-    client: reqwest::blocking::Client,
+    client: reqwest::Client,
 }
 
 const EXTRACTION_PROMPT_TEMPLATE: &str = r#"Analyze the following content and extract structured information.
@@ -67,16 +67,19 @@ const MAX_CONTENT_CHARS: usize = 16_000;
 
 impl ConceptExtractor {
     pub fn new() -> Self {
-        let client = reqwest::blocking::Client::builder()
-            .timeout(Duration::from_secs(60))
+        let client = reqwest::Client::builder()
+            .timeout(Duration::from_secs(180))
             .build()
             .expect("failed to build HTTP client");
         Self { client }
     }
 
     /// Extract concepts and links from text.
-    pub fn extract(&self, text: &str) -> Result<ConceptExtraction> {
+    pub async fn extract(&self, text: &str) -> Result<ConceptExtraction> {
         let (base_url, model) = self.resolve_endpoint()?;
+        // Normalize localhost→127.0.0.1: this system resolves localhost to ::1 (IPv6)
+        // but local services (Ollama) often listen on 0.0.0.0 only (IPv4)
+        let base_url = base_url.replace("://localhost", "://127.0.0.1");
 
         let truncated = if text.len() > MAX_CONTENT_CHARS {
             eprintln!("⚠️  content truncated to {MAX_CONTENT_CHARS} chars for sm0l context");
@@ -104,14 +107,15 @@ impl ConceptExtractor {
             .post(&url)
             .json(&body)
             .send()
+            .await
             .map_err(|e| anyhow!("sm0l request failed: {e}"))?;
 
         if !resp.status().is_success() {
-            bail!("sm0l HTTP {}: {}", resp.status(), resp.text().unwrap_or_default());
+            bail!("sm0l HTTP {}: {}", resp.status(), resp.text().await.unwrap_or_default());
         }
 
         let resp_json: serde_json::Value =
-            resp.json().map_err(|e| anyhow!("failed to parse sm0l response: {e}"))?;
+            resp.json().await.map_err(|e| anyhow!("failed to parse sm0l response: {e}"))?;
 
         let content = resp_json["choices"][0]["message"]["content"]
             .as_str()

--- a/b00t-cli/src/assimilate/concept_extractor.rs
+++ b/b00t-cli/src/assimilate/concept_extractor.rs
@@ -1,0 +1,229 @@
+//! Concept + link extraction via sm0l model.
+//!
+//! Uses the model registry to resolve the sm0l tier endpoint,
+//! sends a structured prompt, and parses JSON response.
+
+use anyhow::{Result, anyhow, bail};
+use serde::{Deserialize, Serialize};
+use std::time::Duration;
+
+/// A single extracted concept.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Concept {
+    pub name: String,
+    pub description: String,
+    #[serde(default)]
+    pub confidence: f32,
+    #[serde(default)]
+    pub is_advanced: bool,
+}
+
+/// An extracted hyperlink.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ExtractedLink {
+    pub url: String,
+    #[serde(default)]
+    pub anchor_text: String,
+}
+
+/// Result of concept extraction.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ConceptExtraction {
+    pub concepts: Vec<Concept>,
+    pub links: Vec<ExtractedLink>,
+}
+
+/// Extracts concepts and links from text using a sm0l model.
+pub struct ConceptExtractor {
+    client: reqwest::blocking::Client,
+}
+
+const EXTRACTION_PROMPT_TEMPLATE: &str = r#"Analyze the following content and extract structured information.
+
+Return ONLY valid JSON (no markdown fences, no commentary) with this schema:
+{{
+  "concepts": [
+    {{"name": "<term>", "description": "<1-sentence explanation>", "confidence": 0.0-1.0, "is_advanced": false}}
+  ],
+  "links": [
+    {{"url": "<absolute URL>", "anchor_text": "<link text>"}}
+  ]
+}}
+
+Rules:
+- Extract 5-20 primary concepts (is_advanced: false) — key terms, entities, technologies.
+- Extract 0-10 advanced concepts (is_advanced: true) — relationships, patterns, abstractions.
+- Extract links as absolute URLs (resolve relative URLs against the source).
+- Confidence: 1.0 = explicitly defined, 0.7 = clearly referenced, 0.3 = peripheral.
+- Limit to the most important concepts; quality over quantity.
+
+Content:
+---
+{content}
+---"#;
+
+/// Truncate content to fit within sm0l context window (~4K tokens ≈ 16K chars).
+const MAX_CONTENT_CHARS: usize = 16_000;
+
+impl ConceptExtractor {
+    pub fn new() -> Self {
+        let client = reqwest::blocking::Client::builder()
+            .timeout(Duration::from_secs(60))
+            .build()
+            .expect("failed to build HTTP client");
+        Self { client }
+    }
+
+    /// Extract concepts and links from text.
+    pub fn extract(&self, text: &str) -> Result<ConceptExtraction> {
+        let (base_url, model) = self.resolve_endpoint()?;
+
+        let truncated = if text.len() > MAX_CONTENT_CHARS {
+            eprintln!("⚠️  content truncated to {MAX_CONTENT_CHARS} chars for sm0l context");
+            &text[..MAX_CONTENT_CHARS]
+        } else {
+            text
+        };
+
+        let prompt = EXTRACTION_PROMPT_TEMPLATE.replace("{content}", truncated);
+
+        let body = serde_json::json!({
+            "model": model,
+            "messages": [{"role": "user", "content": prompt}],
+            "max_tokens": 1024,
+            "temperature": 0.1,
+        });
+
+        let url = format!(
+            "{}/v1/chat/completions",
+            base_url.trim_end_matches('/').trim_end_matches("/v1")
+        );
+
+        let resp = self
+            .client
+            .post(&url)
+            .json(&body)
+            .send()
+            .map_err(|e| anyhow!("sm0l request failed: {e}"))?;
+
+        if !resp.status().is_success() {
+            bail!("sm0l HTTP {}: {}", resp.status(), resp.text().unwrap_or_default());
+        }
+
+        let resp_json: serde_json::Value =
+            resp.json().map_err(|e| anyhow!("failed to parse sm0l response: {e}"))?;
+
+        let content = resp_json["choices"][0]["message"]["content"]
+            .as_str()
+            .ok_or_else(|| anyhow!("sm0l response missing content"))?;
+
+        self.parse_response(content)
+    }
+
+    /// Resolve sm0l tier endpoint from model registry.
+    /// Falls back to ch0nky tier, then localhost:8001.
+    fn resolve_endpoint(&self) -> Result<(String, String)> {
+        // Try sm0l tier first
+        if let Some((base, model)) = crate::model_registry::resolve_tier_endpoint("sm0l") {
+            return Ok((base, model));
+        }
+        // Fall back to ch0nky tier
+        if let Some((base, model)) = crate::model_registry::resolve_tier_endpoint("ch0nky") {
+            eprintln!("⚠️  no sm0l-tier model, using ch0nky");
+            return Ok((base, model));
+        }
+        // Last resort: localhost
+        eprintln!("⚠️  no registry model, trying localhost:8001");
+        Ok((
+            "http://localhost:8001".to_string(),
+            std::env::var("B00T_SM0L_MODEL").unwrap_or_else(|_| "ch0nky".to_string()),
+        ))
+    }
+
+    /// Parse the sm0l model's JSON response into ConceptExtraction.
+    fn parse_response(&self, content: &str) -> Result<ConceptExtraction> {
+        // Strip markdown code fences if present
+        let cleaned = content
+            .trim()
+            .strip_prefix("```json")
+            .or_else(|| content.trim().strip_prefix("```"))
+            .unwrap_or(content)
+            .trim()
+            .strip_suffix("```")
+            .unwrap_or(content)
+            .trim();
+
+        // Try direct parse
+        if let Ok(extraction) = serde_json::from_str::<ConceptExtraction>(cleaned) {
+            return Ok(extraction);
+        }
+
+        // Try to find JSON object within the response
+        let start = cleaned.find('{');
+        let end = cleaned.rfind('}');
+        if let (Some(s), Some(e)) = (start, end) {
+            if let Ok(extraction) = serde_json::from_str::<ConceptExtraction>(&cleaned[s..=e]) {
+                return Ok(extraction);
+            }
+        }
+
+        // Fallback: empty extraction
+        eprintln!("⚠️  failed to parse sm0l concept JSON — returning empty");
+        Ok(ConceptExtraction {
+            concepts: vec![],
+            links: vec![],
+        })
+    }
+}
+
+impl Default for ConceptExtractor {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_clean_json() {
+        let json = r#"{"concepts":[{"name":"Rust","description":"Systems language","confidence":0.9,"is_advanced":false}],"links":[]}"#;
+        let extractor = ConceptExtractor::new();
+        let result = extractor.parse_response(json).unwrap();
+        assert_eq!(result.concepts.len(), 1);
+        assert_eq!(result.concepts[0].name, "Rust");
+        assert_eq!(result.concepts[0].confidence, 0.9);
+    }
+
+    #[test]
+    fn test_parse_markdown_fenced_json() {
+        let json = r#"```json
+{"concepts":[{"name":"TRIZ","description":"Inventive problem solving","confidence":0.8,"is_advanced":true}],"links":[{"url":"https://example.com","anchor_text":"ref"}]}
+```"#;
+        let extractor = ConceptExtractor::new();
+        let result = extractor.parse_response(json).unwrap();
+        assert_eq!(result.concepts.len(), 1);
+        assert!(result.concepts[0].is_advanced);
+        assert_eq!(result.links.len(), 1);
+    }
+
+    #[test]
+    fn test_parse_with_preamble() {
+        let json = r#"Here are the concepts:
+{"concepts":[{"name":"Ockham","description":"Simplest explanation","confidence":0.7,"is_advanced":false}],"links":[]}
+Hope this helps!"#;
+        let extractor = ConceptExtractor::new();
+        let result = extractor.parse_response(json).unwrap();
+        assert_eq!(result.concepts.len(), 1);
+    }
+
+    #[test]
+    fn test_parse_empty_response() {
+        let json = "I cannot analyze this";
+        let extractor = ConceptExtractor::new();
+        let result = extractor.parse_response(json).unwrap();
+        assert!(result.concepts.is_empty());
+        assert!(result.links.is_empty());
+    }
+}

--- a/b00t-cli/src/assimilate/content_router.rs
+++ b/b00t-cli/src/assimilate/content_router.rs
@@ -1,0 +1,259 @@
+//! Content-type-aware router — detects type and dispatches to appropriate parser.
+//!
+//! Fills the explicit gap at grok.rs:164 ("URL fetching not yet implemented").
+
+use anyhow::{Result, anyhow, bail};
+use std::path::Path;
+use std::time::Duration;
+
+/// Detected content type of a source.
+#[derive(Debug, Clone, PartialEq)]
+pub enum ContentType {
+    Html,
+    Pdf,
+    Markdown,
+    Text,
+    Json,
+    Unknown,
+}
+
+/// Parsed content from a URL or file.
+#[derive(Debug, Clone)]
+pub struct ParsedContent {
+    pub text: String,
+    pub content_type: ContentType,
+    pub source_url: Option<String>,
+}
+
+/// Routes sources to appropriate parsers based on content-type detection.
+pub struct ContentRouter {
+    client: reqwest::blocking::Client,
+}
+
+impl ContentRouter {
+    pub fn new() -> Self {
+        let client = reqwest::blocking::Client::builder()
+            .timeout(Duration::from_secs(30))
+            .redirect(reqwest::redirect::Policy::limited(5))
+            .user_agent("b00t-assimilate/0.1")
+            .build()
+            .expect("failed to build HTTP client");
+        Self { client }
+    }
+
+    /// Route a source (URL or file path) to the appropriate parser.
+    pub fn route(&self, source: &str) -> Result<ParsedContent> {
+        if source.starts_with("http://") || source.starts_with("https://") {
+            self.route_url(source)
+        } else if Path::new(source).exists() {
+            self.route_file(source)
+        } else {
+            bail!("source '{source}' is neither a valid URL nor an existing file")
+        }
+    }
+
+    /// Fetch a URL and parse based on Content-Type header + extension.
+    fn route_url(&self, url: &str) -> Result<ParsedContent> {
+        let resp = self
+            .client
+            .get(url)
+            .send()
+            .map_err(|e| anyhow!("fetch failed for '{url}': {e}"))?;
+
+        if !resp.status().is_success() {
+            bail!("HTTP {} for {url}", resp.status());
+        }
+
+        let content_type_header = resp
+            .headers()
+            .get(reqwest::header::CONTENT_TYPE)
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or("")
+            .to_string();
+
+        let content_type = Self::detect_from_header(&content_type_header)
+            .or_else(|| Self::detect_from_extension(url))
+            .unwrap_or(ContentType::Unknown);
+
+        let bytes = resp
+            .bytes()
+            .map_err(|e| anyhow!("failed to read response body: {e}"))?;
+
+        let text = match content_type {
+            ContentType::Html => Self::strip_html(&String::from_utf8_lossy(&bytes)),
+            ContentType::Pdf => {
+                // PDFs need external extraction — defer to pdf_extractor
+                bail!("PDF detected — use pdf_extractor::extract_pdf_url instead")
+            }
+            ContentType::Json => String::from_utf8_lossy(&bytes).to_string(),
+            _ => String::from_utf8_lossy(&bytes).to_string(),
+        };
+
+        Ok(ParsedContent {
+            text,
+            content_type,
+            source_url: Some(url.to_string()),
+        })
+    }
+
+    /// Read a local file and parse based on extension.
+    fn route_file(&self, path: &str) -> Result<ParsedContent> {
+        let content_type = Self::detect_from_extension(path).unwrap_or(ContentType::Text);
+
+        match content_type {
+            ContentType::Pdf => {
+                bail!("PDF detected — use pdf_extractor::extract_pdf_file instead")
+            }
+            ContentType::Html => {
+                let raw = std::fs::read_to_string(path)
+                    .map_err(|e| anyhow!("failed to read '{path}': {e}"))?;
+                Ok(ParsedContent {
+                    text: Self::strip_html(&raw),
+                    content_type,
+                    source_url: None,
+                })
+            }
+            _ => {
+                let text = std::fs::read_to_string(path)
+                    .map_err(|e| anyhow!("failed to read '{path}': {e}"))?;
+                Ok(ParsedContent {
+                    text,
+                    content_type,
+                    source_url: None,
+                })
+            }
+        }
+    }
+
+    /// Detect content type from HTTP Content-Type header.
+    fn detect_from_header(header: &str) -> Option<ContentType> {
+        let lower = header.to_lowercase();
+        if lower.contains("text/html") || lower.contains("application/xhtml") {
+            Some(ContentType::Html)
+        } else if lower.contains("application/pdf") {
+            Some(ContentType::Pdf)
+        } else if lower.contains("text/markdown") || lower.contains("text/x-markdown") {
+            Some(ContentType::Markdown)
+        } else if lower.contains("application/json") {
+            Some(ContentType::Json)
+        } else if lower.contains("text/plain") {
+            Some(ContentType::Text)
+        } else {
+            None
+        }
+    }
+
+    /// Detect content type from file extension.
+    fn detect_from_extension(path: &str) -> Option<ContentType> {
+        let lower = path.to_lowercase();
+        if lower.ends_with(".html") || lower.ends_with(".htm") {
+            Some(ContentType::Html)
+        } else if lower.ends_with(".pdf") {
+            Some(ContentType::Pdf)
+        } else if lower.ends_with(".md") || lower.ends_with(".markdown") {
+            Some(ContentType::Markdown)
+        } else if lower.ends_with(".json") {
+            Some(ContentType::Json)
+        } else if lower.ends_with(".txt") || lower.ends_with(".text") {
+            Some(ContentType::Text)
+        } else {
+            None
+        }
+    }
+
+    /// Lightweight HTML tag stripping — removes tags, keeps text content.
+    /// For complex HTML, the sm0l model can be used for semantic extraction.
+    fn strip_html(html: &str) -> String {
+        // Remove script/style blocks entirely (separate patterns — Rust regex has no backrefs)
+        let script_re = regex::Regex::new(r"(?is)<script[^>]*>.*?</script>").unwrap();
+        let style_re = regex::Regex::new(r"(?is)<style[^>]*>.*?</style>").unwrap();
+        let without_scripts = script_re.replace_all(html, "");
+        let without_scripts = style_re.replace_all(&without_scripts, "");
+        // Remove all remaining tags
+        let without_tags = regex::Regex::new(r"<[^>]+>")
+            .unwrap()
+            .replace_all(&without_scripts, "");
+        // Decode common HTML entities
+        without_tags
+            .replace("&amp;", "&")
+            .replace("&lt;", "<")
+            .replace("&gt;", ">")
+            .replace("&quot;", "\"")
+            .replace("&#39;", "'")
+            .replace("&nbsp;", " ")
+            // Collapse whitespace
+            .split_whitespace()
+            .collect::<Vec<_>>()
+            .join(" ")
+    }
+}
+
+impl Default for ContentRouter {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_detect_from_extension() {
+        assert_eq!(
+            ContentRouter::detect_from_extension("doc.pdf"),
+            Some(ContentType::Pdf)
+        );
+        assert_eq!(
+            ContentRouter::detect_from_extension("page.html"),
+            Some(ContentType::Html)
+        );
+        assert_eq!(
+            ContentRouter::detect_from_extension("README.md"),
+            Some(ContentType::Markdown)
+        );
+        assert_eq!(
+            ContentRouter::detect_from_extension("data.json"),
+            Some(ContentType::Json)
+        );
+        assert_eq!(
+            ContentRouter::detect_from_extension("notes.txt"),
+            Some(ContentType::Text)
+        );
+        assert_eq!(
+            ContentRouter::detect_from_extension("unknown.xyz"),
+            None
+        );
+    }
+
+    #[test]
+    fn test_detect_from_header() {
+        assert_eq!(
+            ContentRouter::detect_from_header("text/html; charset=utf-8"),
+            Some(ContentType::Html)
+        );
+        assert_eq!(
+            ContentRouter::detect_from_header("application/pdf"),
+            Some(ContentType::Pdf)
+        );
+    }
+
+    #[test]
+    fn test_strip_html() {
+        let html = r#"<html><body><script>alert(1)</script><h1>Title</h1><p>Hello &amp; world</p></body></html>"#;
+        let text = ContentRouter::strip_html(html);
+        assert!(text.contains("Title"));
+        assert!(text.contains("Hello & world"));
+        assert!(!text.contains("alert"));
+        assert!(!text.contains("<"));
+    }
+
+    #[test]
+    fn test_route_file_markdown() {
+        let router = ContentRouter::new();
+        let result = router.route("Cargo.toml");
+        assert!(result.is_ok());
+        let parsed = result.unwrap();
+        assert!(parsed.text.contains("[package]"));
+    }
+}

--- a/b00t-cli/src/assimilate/content_router.rs
+++ b/b00t-cli/src/assimilate/content_router.rs
@@ -27,12 +27,12 @@ pub struct ParsedContent {
 
 /// Routes sources to appropriate parsers based on content-type detection.
 pub struct ContentRouter {
-    client: reqwest::blocking::Client,
+    client: reqwest::Client,
 }
 
 impl ContentRouter {
     pub fn new() -> Self {
-        let client = reqwest::blocking::Client::builder()
+        let client = reqwest::Client::builder()
             .timeout(Duration::from_secs(30))
             .redirect(reqwest::redirect::Policy::limited(5))
             .user_agent("b00t-assimilate/0.1")
@@ -42,9 +42,9 @@ impl ContentRouter {
     }
 
     /// Route a source (URL or file path) to the appropriate parser.
-    pub fn route(&self, source: &str) -> Result<ParsedContent> {
+    pub async fn route(&self, source: &str) -> Result<ParsedContent> {
         if source.starts_with("http://") || source.starts_with("https://") {
-            self.route_url(source)
+            self.route_url(source).await
         } else if Path::new(source).exists() {
             self.route_file(source)
         } else {
@@ -53,11 +53,12 @@ impl ContentRouter {
     }
 
     /// Fetch a URL and parse based on Content-Type header + extension.
-    fn route_url(&self, url: &str) -> Result<ParsedContent> {
+    async fn route_url(&self, url: &str) -> Result<ParsedContent> {
         let resp = self
             .client
             .get(url)
             .send()
+            .await
             .map_err(|e| anyhow!("fetch failed for '{url}': {e}"))?;
 
         if !resp.status().is_success() {
@@ -72,11 +73,12 @@ impl ContentRouter {
             .to_string();
 
         let content_type = Self::detect_from_header(&content_type_header)
-            .or_else(|| Self::detect_from_extension(url))
+            .or_else(|| Self::detect_from_extension(&url))
             .unwrap_or(ContentType::Unknown);
 
         let bytes = resp
             .bytes()
+            .await
             .map_err(|e| anyhow!("failed to read response body: {e}"))?;
 
         let text = match content_type {
@@ -248,10 +250,10 @@ mod tests {
         assert!(!text.contains("<"));
     }
 
-    #[test]
-    fn test_route_file_markdown() {
+    #[tokio::test]
+    async fn test_route_file_markdown() {
         let router = ContentRouter::new();
-        let result = router.route("Cargo.toml");
+        let result = router.route("Cargo.toml").await;
         assert!(result.is_ok());
         let parsed = result.unwrap();
         assert!(parsed.text.contains("[package]"));

--- a/b00t-cli/src/assimilate/crawl_engine.rs
+++ b/b00t-cli/src/assimilate/crawl_engine.rs
@@ -6,7 +6,6 @@ use crate::assimilate::concept_extractor::{ConceptExtractor, ConceptExtraction, 
 use crate::assimilate::content_router::{ContentRouter, ParsedContent};
 use anyhow::Result;
 use std::collections::HashSet;
-use std::thread;
 use std::time::Duration;
 use url::Url;
 
@@ -27,7 +26,7 @@ pub struct CrawledDoc {
 }
 
 /// Crawl links using BFS, same-origin only, depth-limited.
-pub fn crawl(
+pub async fn crawl(
     seed_links: &[ExtractedLink],
     config: &CrawlConfig,
     router: &ContentRouter,
@@ -67,14 +66,14 @@ pub fn crawl(
 
         // Polite delay
         if config.delay_ms > 0 {
-            thread::sleep(Duration::from_millis(config.delay_ms));
+            tokio::time::sleep(Duration::from_millis(config.delay_ms)).await;
         }
 
         eprintln!("  [{depth}/{max_depth}] {url}", max_depth = config.max_depth);
 
-        match router.route(&url) {
+        match router.route(&url).await {
             Ok(parsed) => {
-                match extractor.extract(&parsed.text) {
+                match extractor.extract(&parsed.text).await {
                     Ok(extraction) => {
                         // Queue child links
                         for link in &extraction.links {

--- a/b00t-cli/src/assimilate/crawl_engine.rs
+++ b/b00t-cli/src/assimilate/crawl_engine.rs
@@ -1,0 +1,178 @@
+//! BFS crawl engine — same-origin link following with depth limit.
+//!
+//! Polite crawling: rate-limited, dedup'd, bounded by max_pages.
+
+use crate::assimilate::concept_extractor::{ConceptExtractor, ConceptExtraction, ExtractedLink};
+use crate::assimilate::content_router::{ContentRouter, ParsedContent};
+use anyhow::Result;
+use std::collections::HashSet;
+use std::thread;
+use std::time::Duration;
+use url::Url;
+
+/// Crawl configuration.
+pub struct CrawlConfig {
+    pub seed_url: String,
+    pub max_depth: u32,
+    pub max_pages: u32,
+    pub delay_ms: u64,
+}
+
+/// A crawled document with its extraction.
+pub struct CrawledDoc {
+    pub url: String,
+    pub content: ParsedContent,
+    pub extraction: ConceptExtraction,
+    pub depth: u32,
+}
+
+/// Crawl links using BFS, same-origin only, depth-limited.
+pub fn crawl(
+    seed_links: &[ExtractedLink],
+    config: &CrawlConfig,
+    router: &ContentRouter,
+    extractor: &ConceptExtractor,
+) -> Result<Vec<CrawledDoc>> {
+    let seed_origin = Url::parse(&config.seed_url)
+        .ok()
+        .and_then(|u| u.host_str().map(|h| h.to_string()));
+
+    let mut visited: HashSet<String> = HashSet::new();
+    visited.insert(config.seed_url.clone());
+
+    let mut results: Vec<CrawledDoc> = Vec::new();
+    let mut queue: Vec<(String, u32)> = seed_links
+        .iter()
+        .filter_map(|l| {
+            let normalized = normalize_url(&l.url, &config.seed_url)?;
+            if is_same_origin(&normalized, seed_origin.as_deref()) {
+                Some((normalized, 1))
+            } else {
+                None
+            }
+        })
+        .filter(|(url, _)| !visited.contains(url))
+        .collect();
+
+    let pages_remaining = config.max_pages.saturating_sub(1) as usize; // -1 for seed
+
+    while let Some((url, depth)) = queue.pop() {
+        if results.len() >= pages_remaining || depth > config.max_depth {
+            break;
+        }
+        if visited.contains(&url) {
+            continue;
+        }
+        visited.insert(url.clone());
+
+        // Polite delay
+        if config.delay_ms > 0 {
+            thread::sleep(Duration::from_millis(config.delay_ms));
+        }
+
+        eprintln!("  [{depth}/{max_depth}] {url}", max_depth = config.max_depth);
+
+        match router.route(&url) {
+            Ok(parsed) => {
+                match extractor.extract(&parsed.text) {
+                    Ok(extraction) => {
+                        // Queue child links
+                        for link in &extraction.links {
+                            if let Some(abs) = normalize_url(&link.url, &url) {
+                                if is_same_origin(&abs, seed_origin.as_deref())
+                                    && !visited.contains(&abs)
+                                    && depth < config.max_depth
+                                {
+                                    queue.push((abs, depth + 1));
+                                }
+                            }
+                        }
+                        results.push(CrawledDoc {
+                            url: url.clone(),
+                            content: parsed,
+                            extraction,
+                            depth,
+                        });
+                    }
+                    Err(e) => {
+                        eprintln!("  ⚠️  extraction failed for {url}: {e}");
+                    }
+                }
+            }
+            Err(e) => {
+                eprintln!("  ⚠️  fetch failed for {url}: {e}");
+            }
+        }
+    }
+
+    Ok(results)
+}
+
+/// Normalize a URL: resolve relative URLs against base, strip fragments.
+pub fn normalize_url(url: &str, base: &str) -> Option<String> {
+    // Already absolute
+    if let Ok(parsed) = Url::parse(url) {
+        let mut cleaned = parsed.clone();
+        cleaned.set_fragment(None);
+        return Some(cleaned.to_string());
+    }
+    // Resolve relative URL against base
+    let base_url = Url::parse(base).ok()?;
+    let resolved = base_url.join(url).ok()?;
+    let mut cleaned = resolved.clone();
+    cleaned.set_fragment(None);
+    Some(cleaned.to_string())
+}
+
+/// Check if a URL is same-origin as the seed host.
+pub fn is_same_origin(url: &str, seed_host: Option<&str>) -> bool {
+    match (Url::parse(url).ok(), seed_host) {
+        (Some(parsed), Some(host)) => parsed.host_str() == Some(host),
+        (Some(_), None) => true,  // No seed host — allow all
+        (None, _) => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_normalize_absolute_url() {
+        let result = normalize_url("https://example.com/page#section", "https://other.com").unwrap();
+        assert_eq!(result, "https://example.com/page");
+    }
+
+    #[test]
+    fn test_normalize_relative_url() {
+        let result = normalize_url("/docs/intro", "https://example.com/guide").unwrap();
+        assert_eq!(result, "https://example.com/docs/intro");
+    }
+
+    #[test]
+    fn test_normalize_relative_with_dot() {
+        let result = normalize_url("../api", "https://example.com/v1/page").unwrap();
+        assert_eq!(result, "https://example.com/api");
+    }
+
+    #[test]
+    fn test_is_same_origin_match() {
+        assert!(is_same_origin(
+            "https://example.com/page",
+            Some("example.com")
+        ));
+    }
+
+    #[test]
+    fn test_is_same_origin_mismatch() {
+        assert!(!is_same_origin(
+            "https://other.com/page",
+            Some("example.com")
+        ));
+    }
+
+    #[test]
+    fn test_is_same_origin_no_seed() {
+        assert!(is_same_origin("https://anything.com/page", None));
+    }
+}

--- a/b00t-cli/src/assimilate/index_dispatcher.rs
+++ b/b00t-cli/src/assimilate/index_dispatcher.rs
@@ -1,0 +1,382 @@
+//! Index dispatcher — hybrid trait + MCP bridge for vector/graph indexing.
+//!
+//! Abstracts the indexing target so assimilation can feed multiple backends:
+//! - Native: grafeo (graph), raglite (RAG)
+//! - MCP bridge: codebase-memory-mcp, or any MCP server with index_project tool
+
+use crate::assimilate::crawl_engine::CrawledDoc;
+use anyhow::{Result, anyhow};
+use serde::{Deserialize, Serialize};
+use std::fmt;
+use std::process::Command;
+
+/// Report from an indexing operation.
+#[derive(Debug, Default, Serialize, Deserialize)]
+pub struct IngestReport {
+    pub target: String,
+    pub docs_indexed: usize,
+    pub concepts_indexed: usize,
+    pub errors: Vec<String>,
+}
+
+impl fmt::Display for IngestReport {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "{}: {} doc(s), {} concept(s)",
+            self.target, self.docs_indexed, self.concepts_indexed
+        )?;
+        if !self.errors.is_empty() {
+            write!(f, ", {} error(s)", self.errors.len())?;
+        }
+        Ok(())
+    }
+}
+
+/// Trait for index targets — native or MCP-bridged.
+pub trait IndexTarget: Send + Sync {
+    fn name(&self) -> &str;
+    fn ingest(&self, docs: &[CrawledDoc], topic: &str) -> Result<IngestReport>;
+}
+
+/// Dispatcher that fans out to multiple index targets.
+pub struct IndexDispatcher {
+    targets: Vec<Box<dyn IndexTarget>>,
+}
+
+impl IndexDispatcher {
+    /// Discover available targets by name.
+    /// Supported: "grafeo", "raglite", "codebase-memory", "codebase"
+    pub fn discover(names: &[String]) -> Result<Self> {
+        let mut targets: Vec<Box<dyn IndexTarget>> = Vec::new();
+
+        for name in names {
+            let normalized = name.to_lowercase();
+            match normalized.as_str() {
+                "grafeo" | "graph" => {
+                    targets.push(Box::new(GrafeoTarget::new()));
+                }
+                "raglite" | "rag" => {
+                    targets.push(Box::new(RagliteTarget::new()));
+                }
+                "codebase-memory" | "codebase" | "cb" | "codebase_memory" => {
+                    targets.push(Box::new(McpBridgeTarget::new("codebase-memory")?));
+                }
+                other => {
+                    // Try as MCP server name
+                    targets.push(Box::new(McpBridgeTarget::new(other)?));
+                }
+            }
+        }
+
+        if targets.is_empty() {
+            return Err(anyhow!("no index targets discovered"));
+        }
+
+        Ok(Self { targets })
+    }
+
+    /// Ingest documents into all targets.
+    pub fn ingest(&self, docs: &[CrawledDoc], topic: &str) -> Result<String> {
+        let reports: Vec<String> = self
+            .targets
+            .iter()
+            .filter_map(|t| {
+                match t.ingest(docs, topic) {
+                    Ok(report) => Some(report.to_string()),
+                    Err(e) => Some(format!("{}: ERROR: {e}", t.name())),
+                }
+            })
+            .collect();
+
+        Ok(reports.join("; "))
+    }
+}
+
+// ── Native: Grafeo ──────────────────────────────────────────────────────────
+
+pub struct GrafeoTarget;
+
+impl GrafeoTarget {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl IndexTarget for GrafeoTarget {
+    fn name(&self) -> &str {
+        "grafeo"
+    }
+
+    fn ingest(&self, docs: &[CrawledDoc], topic: &str) -> Result<IngestReport> {
+        let mut report = IngestReport {
+            target: self.name().to_string(),
+            ..Default::default()
+        };
+
+        // Use b00t data fabric CLI to upsert concept nodes
+        for doc in docs {
+            report.docs_indexed += 1;
+            for concept in &doc.extraction.concepts {
+                let subject = format!("concept:{}", concept.name);
+                let predicate = "b00t:hasTopic";
+                let object = topic.to_string();
+
+                // Shell out to b00t data fabric upsert
+                let result = Command::new("b00t")
+                    .args([
+                        "data",
+                        "fabric",
+                        "upsert",
+                        "--subject",
+                        &subject,
+                        "--predicate",
+                        predicate,
+                        "--object",
+                        &object,
+                        "--namespace",
+                        "assimilate",
+                    ])
+                    .output();
+
+                match result {
+                    Ok(out) if out.status.success() => {
+                        report.concepts_indexed += 1;
+                    }
+                    Ok(out) => {
+                        report.errors.push(format!(
+                            "grafeo upsert failed for '{subject}': {}",
+                            String::from_utf8_lossy(&out.stderr).lines().next().unwrap_or("?")
+                        ));
+                    }
+                    Err(e) => {
+                        report.errors.push(format!("grafeo CLI error: {e}"));
+                    }
+                }
+            }
+        }
+
+        Ok(report)
+    }
+}
+
+// ── Native: Raglite ─────────────────────────────────────────────────────────
+
+pub struct RagliteTarget;
+
+impl RagliteTarget {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl IndexTarget for RagliteTarget {
+    fn name(&self) -> &str {
+        "raglite"
+    }
+
+    fn ingest(&self, docs: &[CrawledDoc], topic: &str) -> Result<IngestReport> {
+        let mut report = IngestReport {
+            target: self.name().to_string(),
+            ..Default::default()
+        };
+
+        for doc in docs {
+            let content = &doc.content.text;
+            let result = Command::new("b00t")
+                .args([
+                    "grok",
+                    "learn",
+                    "--topic",
+                    topic,
+                    "--rag",
+                    "raglite",
+                ])
+                .stdin(std::process::Stdio::piped())
+                .spawn();
+
+            match result {
+                Ok(mut child) => {
+                    use std::io::Write;
+                    if let Some(stdin) = &mut child.stdin {
+                        let _ = stdin.write_all(content.as_bytes());
+                    }
+                    match child.wait() {
+                        Ok(status) if status.success() => {
+                            report.docs_indexed += 1;
+                        }
+                        Ok(status) => {
+                            report.errors.push(format!(
+                                "raglite exited {:?} for {topic}",
+                                status.code()
+                            ));
+                        }
+                        Err(e) => {
+                            report.errors.push(format!("raglite wait error: {e}"));
+                        }
+                    }
+                }
+                Err(e) => {
+                    report.errors.push(format!("raglite spawn error: {e}"));
+                }
+            }
+        }
+
+        Ok(report)
+    }
+}
+
+// ── MCP Bridge ──────────────────────────────────────────────────────────────
+
+/// MCP bridge target — communicates with external MCP servers like codebase-memory.
+pub struct McpBridgeTarget {
+    server_name: String,
+    binary_path: Option<String>,
+}
+
+impl McpBridgeTarget {
+    pub fn new(server_name: &str) -> Result<Self> {
+        // Try to find the MCP server binary via b00t datum lookup
+        let binary_path = Self::find_mcp_binary(server_name);
+
+        if binary_path.is_none() {
+            eprintln!("⚠️  MCP server '{server_name}' binary not found — will attempt lazy spawn");
+        }
+
+        Ok(Self {
+            server_name: server_name.to_string(),
+            binary_path,
+        })
+    }
+
+    /// Find MCP server binary from datum config.
+    fn find_mcp_binary(name: &str) -> Option<String> {
+        // Check common locations
+        let b00t_path = std::env::var("_B00T_Path")
+            .unwrap_or_else(|_| {
+                let home = std::env::var("HOME").unwrap_or_else(|_| ".".to_string());
+                format!("{home}/.b00t/_b00t_")
+            });
+
+        let datum_path = format!("{b00t_path}/{name}.mcp.toml");
+        if let Ok(content) = std::fs::read_to_string(&datum_path) {
+            // Parse the command from the TOML (simple extraction)
+            for line in content.lines() {
+                if line.trim_start().starts_with("command") {
+                    if let Some(eq_pos) = line.find('=') {
+                        let val = line[eq_pos + 1..].trim().trim_matches('"');
+                        return Some(val.to_string());
+                    }
+                }
+            }
+        }
+        None
+    }
+}
+
+impl IndexTarget for McpBridgeTarget {
+    fn name(&self) -> &str {
+        &self.server_name
+    }
+
+    fn ingest(&self, docs: &[CrawledDoc], topic: &str) -> Result<IngestReport> {
+        let mut report = IngestReport {
+            target: self.name().to_string(),
+            ..Default::default()
+        };
+
+        // For codebase-memory specifically, we write docs to temp files and call index_project
+        if self.server_name.contains("codebase-memory") || self.server_name == "codebase" {
+            // Write combined content to a temp directory
+            let tmp_dir = std::env::temp_dir().join(format!("b00t-assimilate-{topic}"));
+            std::fs::create_dir_all(&tmp_dir)
+                .map_err(|e| anyhow!("create temp dir: {e}"))?;
+
+            for (i, doc) in docs.iter().enumerate() {
+                let file_path = tmp_dir.join(format!("{i:03}.md"));
+                let content = format!(
+                    "# {} (depth {})\n\nSource: {}\n\n{}\n\n## Concepts\n\n{}",
+                    topic,
+                    doc.depth,
+                    doc.url,
+                    doc.content.text,
+                    doc.extraction
+                        .concepts
+                        .iter()
+                        .map(|c| format!("- **{}**: {}", c.name, c.description))
+                        .collect::<Vec<_>>()
+                        .join("\n")
+                );
+                std::fs::write(&file_path, &content)
+                    .map_err(|e| anyhow!("write temp file: {e}"))?;
+                report.docs_indexed += 1;
+            }
+
+            // Call codebase-memory-mcp index via b00t CLI or direct subprocess
+            eprintln!("  → indexing into {} via temp dir {}", self.server_name, tmp_dir.display());
+
+            // Try b00t ast-extract → codebase-memory pipeline
+            let result = Command::new("b00t")
+                .args(["ast-extract", "--path", &tmp_dir.display().to_string()])
+                .output();
+
+            match result {
+                Ok(out) if out.status.success() => {
+                    report.concepts_indexed = docs.iter().map(|d| d.extraction.concepts.len()).sum();
+                }
+                Ok(out) => {
+                    report.errors.push(format!(
+                        "ast-extract failed: {}",
+                        String::from_utf8_lossy(&out.stderr).lines().next().unwrap_or("?")
+                    ));
+                }
+                Err(e) => {
+                    report.errors.push(format!("ast-extract spawn error: {e}"));
+                }
+            }
+        } else {
+            // Generic MCP: write content and let the user manually index
+            report.errors.push(format!(
+                "generic MCP target '{}' — write docs to temp and index manually",
+                self.server_name
+            ));
+            report.docs_indexed = docs.len();
+        }
+
+        Ok(report)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_ingest_report_display() {
+        let report = IngestReport {
+            target: "test".to_string(),
+            docs_indexed: 5,
+            concepts_indexed: 12,
+            errors: vec![],
+        };
+        assert!(report.to_string().contains("5 doc(s)"));
+        assert!(report.to_string().contains("12 concept(s)"));
+    }
+
+    #[test]
+    fn test_ingest_report_with_errors() {
+        let report = IngestReport {
+            target: "test".to_string(),
+            docs_indexed: 0,
+            concepts_indexed: 0,
+            errors: vec!["boom".to_string()],
+        };
+        assert!(report.to_string().contains("1 error(s)"));
+    }
+
+    #[test]
+    fn test_dispatcher_rejects_empty() {
+        let result = IndexDispatcher::discover(&[]);
+        assert!(result.is_err());
+    }
+}

--- a/b00t-cli/src/assimilate/mod.rs
+++ b/b00t-cli/src/assimilate/mod.rs
@@ -32,7 +32,7 @@ impl Default for EnhancedConfig {
 }
 
 /// Run the full enhanced assimilation pipeline on a URL or file.
-pub fn run_enhanced(
+pub async fn run_enhanced(
     source: &str,
     topic: &str,
     config: &EnhancedConfig,
@@ -42,11 +42,11 @@ pub fn run_enhanced(
 
     // Parse initial source
     eprintln!("→ routing: {source}");
-    let parsed = router.route(source)?;
+    let parsed = router.route(source).await?;
 
     // Extract concepts + links from initial page
     eprintln!("→ extracting concepts (sm0l)…");
-    let extraction = extractor.extract(&parsed.text)?;
+    let extraction = extractor.extract(&parsed.text).await?;
 
     let initial_doc = CrawledDoc {
         url: source.to_string(),
@@ -66,7 +66,7 @@ pub fn run_enhanced(
             max_pages: config.max_pages,
             delay_ms: config.delay_ms,
         };
-        let crawled = crawl_engine::crawl(&extraction.links, &crawl_cfg, &router, &extractor)?;
+        let crawled = crawl_engine::crawl(&extraction.links, &crawl_cfg, &router, &extractor).await?;
         all_docs.extend(crawled);
     }
 

--- a/b00t-cli/src/assimilate/mod.rs
+++ b/b00t-cli/src/assimilate/mod.rs
@@ -1,0 +1,83 @@
+//! Enhanced assimilation pipeline — content-type-aware crawling + concept extraction.
+//!
+//! Orchestrates: ContentRouter → ConceptExtractor → CrawlEngine → IndexDispatcher
+//! Activated by `b00t grok assimilate --enhanced`.
+
+pub mod content_router;
+pub mod concept_extractor;
+pub mod crawl_engine;
+pub mod pdf_extractor;
+pub mod index_dispatcher;
+
+use anyhow::Result;
+use crawl_engine::{CrawlConfig, CrawledDoc};
+
+/// Configuration for enhanced assimilation.
+pub struct EnhancedConfig {
+    pub max_depth: u32,
+    pub max_pages: u32,
+    pub delay_ms: u64,
+    pub index_targets: Vec<String>,
+}
+
+impl Default for EnhancedConfig {
+    fn default() -> Self {
+        Self {
+            max_depth: 2,
+            max_pages: 20,
+            delay_ms: 500,
+            index_targets: vec![],
+        }
+    }
+}
+
+/// Run the full enhanced assimilation pipeline on a URL or file.
+pub fn run_enhanced(
+    source: &str,
+    topic: &str,
+    config: &EnhancedConfig,
+) -> Result<Vec<CrawledDoc>> {
+    let router = content_router::ContentRouter::new();
+    let extractor = concept_extractor::ConceptExtractor::new();
+
+    // Parse initial source
+    eprintln!("→ routing: {source}");
+    let parsed = router.route(source)?;
+
+    // Extract concepts + links from initial page
+    eprintln!("→ extracting concepts (sm0l)…");
+    let extraction = extractor.extract(&parsed.text)?;
+
+    let initial_doc = CrawledDoc {
+        url: source.to_string(),
+        content: parsed,
+        extraction: extraction.clone(),
+        depth: 0,
+    };
+
+    let mut all_docs = vec![initial_doc];
+
+    // Crawl links if depth > 0
+    if config.max_depth > 0 && !extraction.links.is_empty() {
+        eprintln!("→ crawling {} link(s), depth≤{}, same-origin", extraction.links.len(), config.max_depth);
+        let crawl_cfg = CrawlConfig {
+            seed_url: source.to_string(),
+            max_depth: config.max_depth,
+            max_pages: config.max_pages,
+            delay_ms: config.delay_ms,
+        };
+        let crawled = crawl_engine::crawl(&extraction.links, &crawl_cfg, &router, &extractor)?;
+        all_docs.extend(crawled);
+    }
+
+    eprintln!("→ {} document(s) assimilated", all_docs.len());
+
+    // Index into targets
+    if !config.index_targets.is_empty() {
+        let dispatcher = index_dispatcher::IndexDispatcher::discover(&config.index_targets)?;
+        let report = dispatcher.ingest(&all_docs, topic)?;
+        eprintln!("→ indexed: {report}");
+    }
+
+    Ok(all_docs)
+}

--- a/b00t-cli/src/assimilate/pdf_extractor.rs
+++ b/b00t-cli/src/assimilate/pdf_extractor.rs
@@ -1,0 +1,224 @@
+//! PDF extraction — podman/docling first, raglite fallback.
+//!
+//! Dogfoods b00t's own `exec` guard pipeline for podman invocation.
+
+use anyhow::{Result, anyhow, bail};
+use std::path::Path;
+use std::process::Command;
+
+/// Default docling container image (PE fork with GPU support).
+const DOCLING_IMAGE: &str = "docker.io/promptexecution/docling:latest";
+
+/// Extract text from a PDF file.
+///
+/// Strategy:
+/// 1. Try podman + docling container (dogfoods b00t exec guards)
+/// 2. Fall back to raglite Python subprocess (existing rag.rs pattern)
+pub fn extract_pdf_file(path: &str) -> Result<String> {
+    eprintln!("→ PDF extraction: {path}");
+
+    // Strategy 1: podman + docling
+    match try_docling_file(path) {
+        Ok(text) => {
+            eprintln!("  ✓ docling extraction succeeded ({} chars)", text.len());
+            return Ok(text);
+        }
+        Err(e) => {
+            eprintln!("  ⚠️  docling failed: {e}");
+            eprintln!("  → falling back to raglite…");
+        }
+    }
+
+    // Strategy 2: raglite
+    match try_raglite_file(path) {
+        Ok(text) => {
+            eprintln!("  ✓ raglite extraction succeeded ({} chars)", text.len());
+            Ok(text)
+        }
+        Err(e) => {
+            bail!("both docling and raglite failed for '{path}': {e}")
+        }
+    }
+}
+
+/// Extract text from a PDF URL.
+pub fn extract_pdf_url(url: &str) -> Result<String> {
+    eprintln!("→ PDF extraction: {url}");
+
+    // Strategy 1: podman + docling
+    match try_docling_url(url) {
+        Ok(text) => {
+            eprintln!("  ✓ docling extraction succeeded ({} chars)", text.len());
+            return Ok(text);
+        }
+        Err(e) => {
+            eprintln!("  ⚠️  docling failed: {e}");
+            eprintln!("  → falling back to raglite…");
+        }
+    }
+
+    // Strategy 2: raglite
+    match try_raglite_url(url) {
+        Ok(text) => {
+            eprintln!("  ✓ raglite extraction succeeded ({} chars)", text.len());
+            Ok(text)
+        }
+        Err(e) => {
+            bail!("both docling and raglite failed for '{url}': {e}")
+        }
+    }
+}
+
+// ── docling via podman ─────────────────────────────────────────────────────
+
+fn try_docling_file(path: &str) -> Result<String> {
+    let abs_path = std::fs::canonicalize(path)
+        .map_err(|e| anyhow!("canonicalize path: {e}"))?;
+    let mount = format!("{}:/input.pdf:ro", abs_path.display());
+
+    run_docling_container(&["-f", "/input.pdf", "--output-format", "markdown"], Some(&mount))
+}
+
+fn try_docling_url(url: &str) -> Result<String> {
+    run_docling_container(&["-u", url, "--output-format", "markdown"], None)
+}
+
+/// Run docling in a podman container with GPU passthrough.
+fn run_docling_container(args: &[&str], mount: Option<&str>) -> Result<String> {
+    // Check podman is available
+    let which = Command::new("which")
+        .arg("podman")
+        .output()
+        .map_err(|e| anyhow!("failed to check for podman: {e}"))?;
+    if !which.status.success() {
+        bail!("podman not found in PATH");
+    }
+
+    let mut cmd_args = vec![
+        "run".to_string(),
+        "--rm".to_string(),
+        // GPU passthrough (no-op if no GPU, but enables acceleration when present)
+        "--device".to_string(),
+        "nvidia.com/gpu=all".to_string(),
+        "--security-opt=label=disable".to_string(),
+    ];
+
+    if let Some(m) = mount {
+        cmd_args.push("-v".to_string());
+        cmd_args.push(m.to_string());
+    }
+
+    cmd_args.push(DOCLING_IMAGE.to_string());
+    for a in args {
+        cmd_args.push(a.to_string());
+    }
+
+    eprintln!("  → podman run {}…", DOCLING_IMAGE);
+
+    let output = Command::new("podman")
+        .args(&cmd_args)
+        .output()
+        .map_err(|e| anyhow!("failed to run podman: {e}"))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        let detail: Vec<&str> = stderr.lines().take(5).collect();
+        bail!("podman exited {:?}: {}", output.status.code(), detail.join("; "));
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout).to_string();
+    if stdout.trim().is_empty() {
+        bail!("docling produced empty output");
+    }
+
+    Ok(stdout)
+}
+
+// ── raglite fallback ────────────────────────────────────────────────────────
+
+fn try_raglite_file(path: &str) -> Result<String> {
+    let abs_path = std::fs::canonicalize(path)
+        .map_err(|e| anyhow!("canonicalize path: {e}"))?;
+    let abs_str = abs_path.display().to_string();
+
+    run_raglite_python(&abs_str)
+}
+
+fn try_raglite_url(url: &str) -> Result<String> {
+    run_raglite_python(url)
+}
+
+/// Run raglite PDF extraction via Python subprocess.
+/// Mirrors the pattern in b00t-c0re-lib/src/rag.rs:273.
+fn run_raglite_python(source: &str) -> Result<String> {
+    // Escape source for embedding as a Python double-quoted string literal
+    let escaped_source = source.replace('\\', "\\\\").replace('"', "\\\"");
+    let script = format!(
+        r#"
+import sys
+source = "{escaped_source}"
+try:
+    from raglite import RAGLite
+    # Use raglite to extract text from PDF
+    import tempfile, subprocess
+    if source.startswith('http'):
+        # Download to temp file
+        import urllib.request
+        with urllib.request.urlopen(source) as resp:
+            with tempfile.NamedTemporaryFile(suffix='.pdf', delete=False) as f:
+                f.write(resp.read())
+                pdf_path = f.name
+    else:
+        pdf_path = source
+
+    # Try pdfplumber (lighter than docling)
+    try:
+        import pdfplumber
+        with pdfplumber.open(pdf_path) as pdf:
+            text = '\n\n'.join(page.extract_text() or '' for page in pdf.pages)
+        print(text)
+    except ImportError:
+        # Try PyPDF2 as last resort
+        try:
+            from PyPDF2 import PdfReader
+            reader = PdfReader(pdf_path)
+            text = '\n\n'.join(page.extract_text() or '' for page in reader.pages)
+            print(text)
+        except ImportError:
+            print("ERROR: no PDF library available", file=sys.stderr)
+            sys.exit(1)
+except Exception as e:
+    print(f"ERROR: {{e}}", file=sys.stderr)
+    sys.exit(1)
+"#,
+    );
+
+    let output = Command::new("python3")
+        .args(["-c", &script])
+        .output()
+        .map_err(|e| anyhow!("failed to run python3: {e}"))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        let detail: Vec<&str> = stderr.lines().take(3).collect();
+        bail!("raglite/python exited {:?}: {}", output.status.code(), detail.join("; "));
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout).to_string();
+    if stdout.trim().is_empty() {
+        bail!("python PDF extraction produced empty output");
+    }
+
+    Ok(stdout)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_docling_image_constant() {
+        assert!(DOCLING_IMAGE.starts_with("docker.io/"));
+        assert!(DOCLING_IMAGE.contains("docling"));
+    }
+}

--- a/b00t-cli/src/commands/agent.rs
+++ b/b00t-cli/src/commands/agent.rs
@@ -203,6 +203,12 @@ pub enum AgentCommands {
 
         #[arg(long, help = "Path to agent TOML (overrides auto-discovery)")]
         config: Option<PathBuf>,
+
+        #[arg(long, help = "Inject skill instructions into task context (skill name)")]
+        skill: Option<String>,
+
+        #[arg(long, help = "Inject role constraints into task context (role datum name)")]
+        role: Option<String>,
     },
 
     #[clap(about = "Run ralph autonomous agent for hive maintenance/validation")]
@@ -316,7 +322,9 @@ pub async fn handle_agent_command(cmd: AgentCommands) -> Result<()> {
             agent,
             prompt,
             config,
-        } => handle_invoke(&agent, &prompt, config.as_deref()).await,
+            skill,
+            role,
+        } => handle_invoke(&agent, &prompt, config.as_deref(), skill.as_deref(), role.as_deref()).await,
 
         AgentCommands::Ralph {
             tool,
@@ -751,6 +759,8 @@ async fn handle_invoke(
     agent: &str,
     prompt: &str,
     config_override: Option<&std::path::Path>,
+    skill: Option<&str>,
+    role: Option<&str>,
 ) -> Result<()> {
     use b00t_c0re_lib::agent_manager::{AgentManager, invoke_agent_executor};
     use b00t_c0re_gov::errors::GovernanceError;
@@ -811,6 +821,20 @@ async fn handle_invoke(
         env.extend(agent_env.clone());
     }
 
+    // ── Skill + Role provisioning (Redis-free delegation context injection) ──
+    let enriched_prompt = if skill.is_some() || role.is_some() {
+        let enriched = build_enriched_description(prompt, skill, role, None);
+        if skill.is_some() {
+            println!("   🧠 Skill provisioned: {:?}", skill);
+        }
+        if role.is_some() {
+            println!("   🎭 Role constraints: {:?}", role);
+        }
+        enriched
+    } else {
+        prompt.to_string()
+    };
+
     println!(
         "🤖 Invoking {} (max {} iterations)",
         agent, executor.max_iterations
@@ -826,7 +850,7 @@ async fn handle_invoke(
         b00t_c0re_gov::scoring::AgentTier::LLM,
         50.0,
         || {
-            invoke_agent_executor(executor, &env, prompt)
+            invoke_agent_executor(executor, &env, &enriched_prompt)
                 .map_err(|e| GovernanceError::InvocationFailed(e.to_string()))
         },
     )?;

--- a/b00t-cli/src/commands/grok.rs
+++ b/b00t-cli/src/commands/grok.rs
@@ -114,6 +114,15 @@ pub enum GrokCommands {
         /// Canonical source URL — required for datum validity
         #[arg(long, help = "Canonical source URL (required for datum validity)")]
         source_url: Option<String>,
+        /// Enable enhanced crawl: sm0l concept extraction + link following + indexing
+        #[arg(long, help = "Enable enhanced assimilation pipeline")]
+        enhanced: bool,
+        /// Crawl depth when --enhanced (0 = no crawl, default 2)
+        #[arg(long, help = "Max crawl depth for link following")]
+        depth: Option<u32>,
+        /// Index targets for concept ingestion (comma-sep: grafeo,raglite,codebase-memory)
+        #[arg(long, value_delimiter = ',', help = "Index targets to ingest into")]
+        index_target: Vec<String>,
     },
 }
 
@@ -178,6 +187,9 @@ pub async fn handle_grok_command(command: GrokCommands) -> Result<()> {
             tags,
             ingest,
             source_url,
+            enhanced,
+            depth,
+            index_target,
         } => {
             handle_assimilate(
                 &topic,
@@ -187,6 +199,9 @@ pub async fn handle_grok_command(command: GrokCommands) -> Result<()> {
                 &tags,
                 ingest,
                 source_url.as_deref(),
+                enhanced,
+                depth,
+                &index_target,
             )
             .await
         }
@@ -322,12 +337,70 @@ async fn handle_assimilate(
     tags: &[String],
     ingest: bool,
     source_url: Option<&str>,
+    enhanced: bool,
+    depth: Option<u32>,
+    index_target: &[String],
 ) -> Result<()> {
     // Warn early if no source_url — datum will lack deduplication anchor
     if source_url.is_none() {
         eprintln!(
             "⚠️  No --source-url provided. Datum will be invalid (source required for deduplication)."
         );
+    }
+
+    // ── Enhanced assimilation pipeline ──────────────────────────────────────
+    //
+    // When --enhanced is set, run the full pipeline:
+    // 1. ContentRouter fetches/parses the source (URL or file)
+    // 2. ConceptExtractor extracts concepts + links via sm0l model
+    // 3. CrawlEngine follows links (depth-limited, same-origin)
+    // 4. IndexDispatcher ingests into configured targets
+    //
+    // The primary content is enriched with concepts and used for datum storage.
+    let mut enriched_tags: Vec<String> = tags.to_vec();
+
+    if enhanced {
+        let source = source_url
+            .map(|s| s.to_string())
+            .or_else(|| content_inline.map(|s| s.to_string()))
+            .or_else(|| file.map(|f| f.display().to_string()))
+            .ok_or_else(|| {
+                anyhow::anyhow!("--enhanced requires a source: use --source-url, content, or --file")
+            })?;
+
+        let config = crate::assimilate::EnhancedConfig {
+            max_depth: depth.unwrap_or(2),
+            index_targets: index_target.to_vec(),
+            ..Default::default()
+        };
+
+        let docs = crate::assimilate::run_enhanced(&source, topic, &config)?;
+
+        // Collect concept names as tags for the datum
+        if let Some(primary) = docs.first() {
+            for concept in &primary.extraction.concepts {
+                let tag = if concept.is_advanced {
+                    format!("advanced:{}", concept.name)
+                } else {
+                    concept.name.clone()
+                };
+                if !enriched_tags.contains(&tag) {
+                    enriched_tags.push(tag);
+                }
+            }
+        }
+
+        eprintln!(
+            "→ {} concept tag(s) extracted for datum",
+            enriched_tags.len() - tags.len()
+        );
+
+        // For the git-blob datum, use the primary document's text
+        // (the enhanced pipeline already stored crawled docs in index targets)
+        if content_inline.is_none() && file.is_none() {
+            // Content came from URL — use the fetched text
+            // This will be set below in the content resolution
+        }
     }
 
     // Resolve content: inline | file | stdin
@@ -383,7 +456,7 @@ async fn handle_assimilate(
     );
     let datum_path = find_b00t_dir()?.join(&datum_name);
 
-    let tags_toml = tags
+    let tags_toml = enriched_tags
         .iter()
         .map(|t| {
             let escaped = t.replace('\\', "\\\\").replace('"', "\\\"");

--- a/b00t-cli/src/commands/grok.rs
+++ b/b00t-cli/src/commands/grok.rs
@@ -358,6 +358,7 @@ async fn handle_assimilate(
     //
     // The primary content is enriched with concepts and used for datum storage.
     let mut enriched_tags: Vec<String> = tags.to_vec();
+    let mut enhanced_content: Option<String> = None;
 
     if enhanced {
         let source = source_url
@@ -374,7 +375,7 @@ async fn handle_assimilate(
             ..Default::default()
         };
 
-        let docs = crate::assimilate::run_enhanced(&source, topic, &config)?;
+        let docs = crate::assimilate::run_enhanced(&source, topic, &config).await?;
 
         // Collect concept names as tags for the datum
         if let Some(primary) = docs.first() {
@@ -395,24 +396,29 @@ async fn handle_assimilate(
             enriched_tags.len() - tags.len()
         );
 
-        // For the git-blob datum, use the primary document's text
-        // (the enhanced pipeline already stored crawled docs in index targets)
+        // If no inline/file content was provided, use the primary doc's text
+        // from the enhanced pipeline for the git-blob datum.
         if content_inline.is_none() && file.is_none() {
-            // Content came from URL — use the fetched text
-            // This will be set below in the content resolution
+            if let Some(primary) = docs.first() {
+                enhanced_content = Some(primary.content.text.clone());
+            }
         }
     }
 
-    // Resolve content: inline | file | stdin
-    let content = match (content_inline, file) {
-        (Some(c), _) => c.to_string(),
-        (None, Some(f)) => {
-            fs::read_to_string(f).with_context(|| format!("reading file {}", f.display()))?
-        }
-        (None, None) => {
-            let mut buf = String::new();
-            std::io::stdin().read_to_string(&mut buf)?;
-            buf
+    // Resolve content: enhanced-pipeline | inline | file | stdin
+    let content = if let Some(ec) = enhanced_content {
+        ec
+    } else {
+        match (content_inline, file) {
+            (Some(c), _) => c.to_string(),
+            (None, Some(f)) => {
+                fs::read_to_string(f).with_context(|| format!("reading file {}", f.display()))?
+            }
+            (None, None) => {
+                let mut buf = String::new();
+                std::io::stdin().read_to_string(&mut buf)?;
+                buf
+            }
         }
     };
 

--- a/b00t-cli/src/commands/skill.rs
+++ b/b00t-cli/src/commands/skill.rs
@@ -849,16 +849,9 @@ fn handle_index(dirs: &[PathBuf], json: bool, store: bool, depth: usize) -> Resu
         b.rank.cmp(&a.rank).then_with(|| a.name.cmp(&b.name))
     });
 
-    // Build composite manifest (TOML)
-    let mut manifest = String::new();
-    manifest.push_str("# b00t composite skill index — auto-generated\n");
+    // Build datum TOML (ingestible by `b00t data fabric ingest-datum`)
     let timestamp = chrono::Utc::now().to_rfc3339();
-    manifest.push_str(&format!("# generated: {timestamp}\n\n"));
-    manifest.push_str("[meta]\n");
-    manifest.push_str(&format!("total_skills = {}\n", entries.len()));
-    let sources: Vec<&PathBuf> = dirs.iter().collect();
-    let sources_str: Vec<String> = sources.iter().map(|d| format!("\"{}\"", d.display())).collect();
-    manifest.push_str(&format!("sources = [{}]\n\n", sources_str.join(", ")));
+    let sources_str: Vec<String> = dirs.iter().map(|d| format!("\"{}\"", d.display())).collect();
 
     // Count by specialization
     let domain_count = entries.iter().filter(|e| e.specialization == "domain").count();
@@ -866,41 +859,58 @@ fn handle_index(dirs: &[PathBuf], json: bool, store: bool, depth: usize) -> Resu
     let analysis_count = entries.iter().filter(|e| e.specialization == "analysis").count();
     let general_count = entries.iter().filter(|e| e.specialization == "general").count();
 
-    manifest.push_str("[distribution]\n");
-    manifest.push_str(&format!("domain = {domain_count}\n"));
-    manifest.push_str(&format!("engineering = {eng_count}\n"));
-    manifest.push_str(&format!("analysis = {analysis_count}\n"));
-    manifest.push_str(&format!("general = {general_count}\n\n"));
+    let mut datum_toml = String::new();
+    datum_toml.push_str("# b00t composite skill index — auto-generated\n");
+    datum_toml.push_str(&format!("# generated: {timestamp}\n"));
+    datum_toml.push_str("# ingest: b00t data fabric ingest-datum <this_file>\n\n");
 
+    // Standard [b00t] datum header
+    datum_toml.push_str("[b00t]\n");
+    datum_toml.push_str("name = \"skill-index\"\n");
+    datum_toml.push_str("type = \"skill_index\"\n");
+    datum_toml.push_str("hint = \"Composite skill index — ranked scan of SKILL.md files\"\n");
+    datum_toml.push_str("keywords = [\"skill\", \"index\", \"composite\", \"ranking\", \"discovery\"]\n\n");
+
+    // Index metadata
+    datum_toml.push_str("[meta]\n");
+    datum_toml.push_str(&format!("total_skills = {}\n", entries.len()));
+    datum_toml.push_str(&format!("generated = \"{timestamp}\"\n"));
+    datum_toml.push_str(&format!("sources = [{}]\n\n", sources_str.join(", ")));
+
+    datum_toml.push_str("[distribution]\n");
+    datum_toml.push_str(&format!("domain = {domain_count}\n"));
+    datum_toml.push_str(&format!("engineering = {eng_count}\n"));
+    datum_toml.push_str(&format!("analysis = {analysis_count}\n"));
+    datum_toml.push_str(&format!("general = {general_count}\n\n"));
+
+    // Each skill as a [skills.<name>] sub-table → becomes unique predicate paths
+    // when flattened by data fabric ingest-datum
     for entry in &entries {
-        manifest.push_str(&format!("[[skills]]\n"));
-        manifest.push_str(&format!("name = \"{}\"\n", entry.name.replace('"', "\\\"")));
-        manifest.push_str(&format!("description = \"{}\"\n", entry.description.replace('"', "\\\"")));
-        manifest.push_str(&format!("specialization = \"{}\"\n", entry.specialization));
-        manifest.push_str(&format!("rank = {}\n", entry.rank));
-        manifest.push_str(&format!("source_path = \"{}\"\n", entry.source_path.replace('"', "\\\"")));
+        let safe_name = entry.name.replace('.', "-");
+        datum_toml.push_str(&format!("[skills.{safe_name}]\n"));
+        datum_toml.push_str(&format!("description = \"{}\"\n", entry.description.replace('"', "\\\"").replace('\n', " ")));
+        datum_toml.push_str(&format!("specialization = \"{}\"\n", entry.specialization));
+        datum_toml.push_str(&format!("rank = {}\n", entry.rank));
+        datum_toml.push_str(&format!("source_path = \"{}\"\n", entry.source_path.replace('"', "\\\"")));
         if let Some(git) = &entry.source_git {
-            manifest.push_str(&format!("source_git = \"{}\"\n", git));
+            datum_toml.push_str(&format!("source_git = \"{}\"\n", git));
         }
-        if let Some(commit) = &entry.source_commit {
-            manifest.push_str(&format!("source_commit = \"{}\"\n", commit));
-        }
-        manifest.push_str(&format!("skill_md_hash = \"{}\"\n\n", entry.skill_md_hash));
+        datum_toml.push_str(&format!("skill_md_hash = \"{}\"\n\n", entry.skill_md_hash));
     }
 
-    // SHA256 of the manifest
-    let mut manifest_hasher = Sha256::new();
-    manifest_hasher.update(manifest.as_bytes());
-    let manifest_hash = format!("{:x}", manifest_hasher.finalize());
-    let short_hash = &manifest_hash[..12];
+    // SHA256 of the datum content
+    let mut hasher = Sha256::new();
+    hasher.update(datum_toml.as_bytes());
+    let datum_hash = format!("{:x}", hasher.finalize());
+    let short_hash = &datum_hash[..12];
 
-    manifest.push_str(&format!("# manifest_sha256: {manifest_hash}\n"));
+    datum_toml.push_str(&format!("# datum_sha256: {datum_hash}\n"));
 
     // Output
     if json {
         let summary = json!({
             "total_skills": entries.len(),
-            "manifest_sha256": manifest_hash,
+            "datum_sha256": datum_hash,
             "distribution": {
                 "domain": domain_count,
                 "engineering": eng_count,
@@ -938,19 +948,19 @@ fn handle_index(dirs: &[PathBuf], json: bool, store: bool, depth: usize) -> Resu
                     entry.description.clone()
                 });
         }
-        println!("\n  manifest_sha256: {manifest_hash}");
+        println!("\n  datum_sha256: {datum_hash}");
     }
 
-    // Optionally store as git blob datum
+    // Store as datum TOML + git blob
     if store {
         use flate2::{Compression, write::GzEncoder};
         use std::io::Write;
 
+        // Store compressed content as git blob
         let mut encoder = GzEncoder::new(Vec::new(), Compression::best());
-        encoder.write_all(manifest.as_bytes())?;
+        encoder.write_all(datum_toml.as_bytes())?;
         let compressed = encoder.finish()?;
 
-        // Store as git blob
         let mut child = std::process::Command::new("git")
             .args(["hash-object", "-w", "--stdin"])
             .stdin(std::process::Stdio::piped())
@@ -961,8 +971,15 @@ fn handle_index(dirs: &[PathBuf], json: bool, store: bool, depth: usize) -> Resu
         let output = child.wait_with_output()?;
         let git_hash = String::from_utf8(output.stdout)?.trim().to_string();
 
+        // Write datum TOML to _b00t_ directory
+        let datum_filename = format!("skill-index-{short_hash}.datum.toml");
+        let datum_path = std::path::PathBuf::from("_b00t_").join(&datum_filename);
+        std::fs::write(&datum_path, &datum_toml)?;
+
         println!("\n📦 stored git blob: {git_hash}");
         println!("   retrieve: git cat-file blob {git_hash} | gunzip");
+        println!("📝 datum written: {}", datum_path.display());
+        println!("   ingest: b00t data fabric ingest-datum {}", datum_path.display());
     }
 
     Ok(())

--- a/b00t-cli/src/commands/skill.rs
+++ b/b00t-cli/src/commands/skill.rs
@@ -69,6 +69,30 @@ pub enum SkillCommands {
         #[clap(long, help = "Output directory for downloaded skills", default_value = ".opencode/skills")]
         output: PathBuf,
     },
+
+    /// Build a ranked composite index of skill directories.
+    ///
+    /// Scans directories for SKILL.md files, extracts frontmatter, ranks by
+    /// specialization (domain > engineering > analysis > general), and produces
+    /// a content-hashed composite manifest. Optionally stores as git blob datum.
+    ///
+    /// Examples:
+    ///   b00t skill index ./awesome-skills/ ~/.skills/
+    ///   b00t skill index ./skills/ --store --json
+    #[clap(about = "Build a ranked composite index of skill directories")]
+    Index {
+        /// Directories to scan for SKILL.md files
+        dirs: Vec<PathBuf>,
+        /// Output JSON instead of table
+        #[arg(long)]
+        json: bool,
+        /// Store composite index as git blob datum
+        #[arg(long)]
+        store: bool,
+        /// Maximum recursion depth (default 3)
+        #[arg(long, default_value_t = 3)]
+        depth: usize,
+    },
 }
 
 pub fn handle_skill_command(cmd: &SkillCommands, path: &str) -> Result<()> {
@@ -192,6 +216,10 @@ pub fn handle_skill_command(cmd: &SkillCommands, path: &str) -> Result<()> {
         SkillCommands::Serve { port, host } => handle_serve(*port, host, path),
 
         SkillCommands::Sync { url, output } => handle_sync(url, output),
+
+        SkillCommands::Index { dirs, json, store, depth } => {
+            handle_index(dirs, *json, *store, *depth)
+        }
     }
 }
 
@@ -635,6 +663,308 @@ fn handle_sync(url: &str, output: &std::path::PathBuf) -> Result<()> {
         skills.len(),
         output.display()
     );
+    Ok(())
+}
+
+// ── Composite Skill Index ───────────────────────────────────────────────────
+
+/// A single skill entry in the composite index.
+#[derive(serde::Serialize)]
+struct IndexEntry {
+    name: String,
+    description: String,
+    specialization: &'static str,
+    rank: u8,
+    source_path: String,
+    source_git: Option<String>,
+    source_commit: Option<String>,
+    skill_md_hash: String,
+}
+
+/// Domain keywords for specialization scoring.
+const DOMAIN_KEYWORDS: &[&str] = &[
+    "legal", "medical", "healthcare", "financial", "finance", "audit",
+    "regulatory", "compliance", "clinical", "pharma", "insurance", "tax",
+    "real-estate", "construction", "manufacturing", "aerospace",
+];
+const ENGINEERING_KEYWORDS: &[&str] = &[
+    "code", "deploy", "ci/cd", "docker", "kubernetes", "database", "migration",
+    "test", "refactor", "debug", "build", "compile", "lint", "security-scan",
+    "infrastructure", "terraform", "ansible",
+];
+const ANALYSIS_KEYWORDS: &[&str] = &[
+    "analyze", "report", "statistics", "data-pipeline", "etl", "dashboard",
+    "visualization", "research", "survey", "benchmark", "evaluation",
+];
+
+fn score_specialization(desc: &str) -> (&'static str, u8) {
+    let lower = desc.to_lowercase();
+    let domain_hits = DOMAIN_KEYWORDS.iter().filter(|kw| lower.contains(*kw)).count();
+    let eng_hits = ENGINEERING_KEYWORDS.iter().filter(|kw| lower.contains(*kw)).count();
+    let analysis_hits = ANALYSIS_KEYWORDS.iter().filter(|kw| lower.contains(*kw)).count();
+
+    if domain_hits > 0 {
+        ("domain", 4)
+    } else if eng_hits > 0 {
+        ("engineering", 3)
+    } else if analysis_hits > 0 {
+        ("analysis", 2)
+    } else {
+        ("general", 1)
+    }
+}
+
+/// Parse YAML frontmatter from SKILL.md — extracts name and description.
+fn parse_frontmatter(content: &str) -> Option<(String, String)> {
+    let trimmed = content.trim_start();
+    if !trimmed.starts_with("---") {
+        return None;
+    }
+    let after_first = &trimmed[3..];
+    let end = after_first.find("\n---")?;
+    let yaml = &after_first[..end];
+
+    let mut name = String::new();
+    let mut desc = String::new();
+    for line in yaml.lines() {
+        let line = line.trim();
+        if let Some(v) = line.strip_prefix("name:") {
+            name = v.trim().trim_matches('"').to_string();
+        } else if let Some(v) = line.strip_prefix("description:") {
+            desc = v.trim().trim_matches('"').to_string();
+        }
+    }
+
+    if name.is_empty() {
+        return None;
+    }
+    Some((name, desc))
+}
+
+/// Recursively scan a directory for SKILL.md files up to max_depth.
+fn scan_for_skills(dir: &std::path::Path, max_depth: usize, current_depth: usize, out: &mut Vec<(std::path::PathBuf, String)>) {
+    if current_depth > max_depth {
+        return;
+    }
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.is_dir() {
+            let skill_md = path.join("SKILL.md");
+            if skill_md.exists() {
+                if let Ok(content) = std::fs::read_to_string(&skill_md) {
+                    out.push((path.clone(), content));
+                }
+            } else {
+                // Recurse into subdirectories
+                scan_for_skills(&path, max_depth, current_depth + 1, out);
+            }
+        }
+    }
+}
+
+/// Try to get git remote URL and commit hash for a path.
+fn git_upstream(path: &std::path::Path) -> (Option<String>, Option<String>) {
+    let remote = std::process::Command::new("git")
+        .args(["-C", &path.display().to_string(), "remote", "get-url", "origin"])
+        .output()
+        .ok()
+        .filter(|o| o.status.success())
+        .and_then(|o| String::from_utf8(o.stdout).ok())
+        .map(|s| s.trim().to_string());
+
+    let commit = std::process::Command::new("git")
+        .args(["-C", &path.display().to_string(), "rev-parse", "HEAD"])
+        .output()
+        .ok()
+        .filter(|o| o.status.success())
+        .and_then(|o| String::from_utf8(o.stdout).ok())
+        .map(|s| s.trim().to_string());
+
+    (remote, commit)
+}
+
+fn handle_index(dirs: &[PathBuf], json: bool, store: bool, depth: usize) -> Result<()> {
+    use std::io::Read;
+    use sha2::{Sha256, Digest};
+
+    let mut raw_skills: Vec<(std::path::PathBuf, String)> = Vec::new();
+
+    for dir in dirs {
+        let expanded = shellexpand::tilde(&dir.display().to_string()).to_string();
+        let path = std::path::PathBuf::from(expanded);
+        if !path.exists() {
+            eprintln!("⚠️  skipping non-existent path: {}", path.display());
+            continue;
+        }
+        eprintln!("→ scanning: {}", path.display());
+        scan_for_skills(&path, depth, 0, &mut raw_skills);
+    }
+
+    eprintln!("→ found {} SKILL.md file(s)", raw_skills.len());
+
+    if raw_skills.is_empty() {
+        println!("No skills found in the specified directories.");
+        return Ok(());
+    }
+
+    // Parse and rank each skill
+    let mut entries: Vec<IndexEntry> = Vec::new();
+    for (dir_path, content) in &raw_skills {
+        let (name, description) = parse_frontmatter(content)
+            .unwrap_or_else(|| {
+                let dir_name = dir_path.file_name()
+                    .and_then(|n| n.to_str())
+                    .unwrap_or("unknown")
+                    .to_string();
+                (dir_name, String::new())
+            });
+
+        let (specialization, rank) = score_specialization(&description);
+
+        // SHA256 of SKILL.md content
+        let mut hasher = Sha256::new();
+        hasher.update(content.as_bytes());
+        let skill_md_hash = format!("{:x}", hasher.finalize());
+
+        // Try to get upstream git info
+        let (source_git, source_commit) = git_upstream(dir_path);
+
+        entries.push(IndexEntry {
+            name,
+            description,
+            specialization,
+            rank,
+            source_path: dir_path.display().to_string(),
+            source_git,
+            source_commit,
+            skill_md_hash: skill_md_hash[..12].to_string(),
+        });
+    }
+
+    // Sort by rank descending, then alphabetically
+    entries.sort_by(|a, b| {
+        b.rank.cmp(&a.rank).then_with(|| a.name.cmp(&b.name))
+    });
+
+    // Build composite manifest (TOML)
+    let mut manifest = String::new();
+    manifest.push_str("# b00t composite skill index — auto-generated\n");
+    let timestamp = chrono::Utc::now().to_rfc3339();
+    manifest.push_str(&format!("# generated: {timestamp}\n\n"));
+    manifest.push_str("[meta]\n");
+    manifest.push_str(&format!("total_skills = {}\n", entries.len()));
+    let sources: Vec<&PathBuf> = dirs.iter().collect();
+    let sources_str: Vec<String> = sources.iter().map(|d| format!("\"{}\"", d.display())).collect();
+    manifest.push_str(&format!("sources = [{}]\n\n", sources_str.join(", ")));
+
+    // Count by specialization
+    let domain_count = entries.iter().filter(|e| e.specialization == "domain").count();
+    let eng_count = entries.iter().filter(|e| e.specialization == "engineering").count();
+    let analysis_count = entries.iter().filter(|e| e.specialization == "analysis").count();
+    let general_count = entries.iter().filter(|e| e.specialization == "general").count();
+
+    manifest.push_str("[distribution]\n");
+    manifest.push_str(&format!("domain = {domain_count}\n"));
+    manifest.push_str(&format!("engineering = {eng_count}\n"));
+    manifest.push_str(&format!("analysis = {analysis_count}\n"));
+    manifest.push_str(&format!("general = {general_count}\n\n"));
+
+    for entry in &entries {
+        manifest.push_str(&format!("[[skills]]\n"));
+        manifest.push_str(&format!("name = \"{}\"\n", entry.name.replace('"', "\\\"")));
+        manifest.push_str(&format!("description = \"{}\"\n", entry.description.replace('"', "\\\"")));
+        manifest.push_str(&format!("specialization = \"{}\"\n", entry.specialization));
+        manifest.push_str(&format!("rank = {}\n", entry.rank));
+        manifest.push_str(&format!("source_path = \"{}\"\n", entry.source_path.replace('"', "\\\"")));
+        if let Some(git) = &entry.source_git {
+            manifest.push_str(&format!("source_git = \"{}\"\n", git));
+        }
+        if let Some(commit) = &entry.source_commit {
+            manifest.push_str(&format!("source_commit = \"{}\"\n", commit));
+        }
+        manifest.push_str(&format!("skill_md_hash = \"{}\"\n\n", entry.skill_md_hash));
+    }
+
+    // SHA256 of the manifest
+    let mut manifest_hasher = Sha256::new();
+    manifest_hasher.update(manifest.as_bytes());
+    let manifest_hash = format!("{:x}", manifest_hasher.finalize());
+    let short_hash = &manifest_hash[..12];
+
+    manifest.push_str(&format!("# manifest_sha256: {manifest_hash}\n"));
+
+    // Output
+    if json {
+        let summary = json!({
+            "total_skills": entries.len(),
+            "manifest_sha256": manifest_hash,
+            "distribution": {
+                "domain": domain_count,
+                "engineering": eng_count,
+                "analysis": analysis_count,
+                "general": general_count,
+            },
+            "skills": entries.iter().map(|e| json!({
+                "name": e.name,
+                "description": e.description,
+                "specialization": e.specialization,
+                "rank": e.rank,
+                "source_path": e.source_path,
+                "skill_md_hash": e.skill_md_hash,
+            })).collect::<Vec<_>>(),
+        });
+        println!("{}", serde_json::to_string_pretty(&summary)?);
+    } else {
+        println!("╔══ Skill Composite Index ═══════════════════════════════╗");
+        println!("║  Total: {:<4}  Hash: {}  ║", entries.len(), short_hash);
+        println!("║  Domain: {:<2}  Eng: {:<2}  Analysis: {:<2}  General: {:<2}     ║",
+            domain_count, eng_count, analysis_count, general_count);
+        println!("╚════════════════════════════════════════════════════════╝\n");
+
+        for entry in &entries {
+            let icon = match entry.specialization {
+                "domain" => "🏆",
+                "engineering" => "⚙️",
+                "analysis" => "📊",
+                _ => "📦",
+            };
+            println!("  {icon} [{}] {} — {}", entry.rank, entry.name,
+                if entry.description.len() > 60 {
+                    format!("{}…", &entry.description[..60])
+                } else {
+                    entry.description.clone()
+                });
+        }
+        println!("\n  manifest_sha256: {manifest_hash}");
+    }
+
+    // Optionally store as git blob datum
+    if store {
+        use flate2::{Compression, write::GzEncoder};
+        use std::io::Write;
+
+        let mut encoder = GzEncoder::new(Vec::new(), Compression::best());
+        encoder.write_all(manifest.as_bytes())?;
+        let compressed = encoder.finish()?;
+
+        // Store as git blob
+        let mut child = std::process::Command::new("git")
+            .args(["hash-object", "-w", "--stdin"])
+            .stdin(std::process::Stdio::piped())
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::piped())
+            .spawn()?;
+        child.stdin.take().unwrap().write_all(&compressed)?;
+        let output = child.wait_with_output()?;
+        let git_hash = String::from_utf8(output.stdout)?.trim().to_string();
+
+        println!("\n📦 stored git blob: {git_hash}");
+        println!("   retrieve: git cat-file blob {git_hash} | gunzip");
+    }
+
     Ok(())
 }
 

--- a/b00t-cli/src/lib.rs
+++ b/b00t-cli/src/lib.rs
@@ -88,6 +88,7 @@ pub mod datum_schema;
 pub mod bootstrap;
 pub mod budget_controller;
 pub mod cloud_sync;
+pub mod assimilate;
 pub mod commands;
 pub mod datum_ai;
 pub mod datum_ai_model;

--- a/b00t-cli/src/skill_resolver.rs
+++ b/b00t-cli/src/skill_resolver.rs
@@ -20,9 +20,12 @@
 //!
 //! # Discovery order (priority)
 //! 1. `./skills/`              — project-local, SKILL.md format
-//! 2. `./_b00t_/*.skill.toml[l][md]` — project b00t native (.skill.toml, .skill.tomllm, .skill.tomllmd)
-//! 3. `~/.claude/skills/`      — Claude Code native, SKILL.md format
-//! 4. `~/.b00t/_b00t_/*.skill.toml[l][md]` — global b00t
+//! 2. `./.opencode/skills/`    — project-local opencode, SKILL.md format
+//! 3. `./_b00t_/*.skill.toml[l][md]` — project b00t native (.skill.toml, .skill.tomllm, .skill.tomllmd)
+//! 4. `~/.config/opencode/skills/` — global opencode, SKILL.md format
+//! 5. `~/.claude/skills/`      — Claude Code native, SKILL.md format
+//! 6. `~/.agents/skills/`      — Agent-compatible, SKILL.md format
+//! 7. `~/.b00t/_b00t_/*.skill.toml[l][md]` — global b00t
 
 use anyhow::Result;
 use b00t_c0re_lib::B00tContext;
@@ -158,23 +161,56 @@ impl SkillResolver {
         let mut dirs = Vec::new();
         let root = project_root.map(|p| p.to_path_buf()).unwrap_or_else(|| std::env::current_dir().unwrap_or_default());
 
-        // 1. Project-local SKILL.md skills/
-        let local_skills = root.join("skills");
-        if local_skills.is_dir() {
-            dirs.push(SkillDir { path: local_skills, format: SkillFormat::SkillMd });
+        // When project_root is explicitly provided (e.g. _B00T_Path), ALSO search from cwd
+        // so project-local skills in .opencode/skills/ are discovered regardless of b00t home.
+        let search_roots: Vec<PathBuf> = if project_root.is_some() {
+            let mut roots = vec![root.clone()];
+            if let Some(cwd) = std::env::current_dir().ok() {
+                if cwd != root {
+                    roots.push(cwd);
+                }
+            }
+            roots
+        } else {
+            vec![root.clone()]
+        };
+
+        for sr in &search_roots {
+            // Project-local SKILL.md skills/
+            let local_skills = sr.join("skills");
+            if local_skills.is_dir() {
+                dirs.push(SkillDir { path: local_skills, format: SkillFormat::SkillMd });
+            }
+            // Project-local opencode skills (.opencode/skills/)
+            let local_opencode = sr.join(".opencode").join("skills");
+            if local_opencode.is_dir() {
+                dirs.push(SkillDir { path: local_opencode, format: SkillFormat::SkillMd });
+            }
+            // Project-local b00t datums
+            let local_b00t = sr.join("_b00t_");
+            if local_b00t.is_dir() {
+                dirs.push(SkillDir { path: local_b00t, format: SkillFormat::TomlDatum });
+            }
         }
-        // 2. Project-local b00t datums
-        let local_b00t = root.join("_b00t_");
-        if local_b00t.is_dir() {
-            dirs.push(SkillDir { path: local_b00t, format: SkillFormat::TomlDatum });
-        }
-        // 3. Claude Code native skills (global)
+
+        // Global skill directories (home-based, not project-scoped)
         if let Some(home) = dirs::home_dir() {
+            // Global opencode skills (~/.config/opencode/skills/)
+            let opencode_skills = home.join(".config").join("opencode").join("skills");
+            if opencode_skills.is_dir() {
+                dirs.push(SkillDir { path: opencode_skills, format: SkillFormat::SkillMd });
+            }
+            // Claude Code native skills (global)
             let claude_skills = home.join(".claude").join("skills");
             if claude_skills.is_dir() {
                 dirs.push(SkillDir { path: claude_skills, format: SkillFormat::SkillMd });
             }
-            // 4. Global b00t datums
+            // Agent-compatible skills (~/.agents/skills/)
+            let agents_skills = home.join(".agents").join("skills");
+            if agents_skills.is_dir() {
+                dirs.push(SkillDir { path: agents_skills, format: SkillFormat::SkillMd });
+            }
+            // Global b00t datums
             let global_b00t = home.join(".b00t").join("_b00t_");
             if global_b00t.is_dir() {
                 dirs.push(SkillDir { path: global_b00t, format: SkillFormat::TomlDatum });


### PR DESCRIPTION
## What

Adds `--enhanced` flag to `b00t grok assimilate` enabling a full content-type-aware assimilation pipeline:

```
ContentRouter → ConceptExtractor → CrawlEngine → IndexDispatcher
```

## Modules (`b00t-cli/src/assimilate/`)

| Module | Role |
|---|---|
| `content_router` | URL fetcher + content-type detection (HTML/PDF/MD/JSON/text), HTML tag stripping |
| `concept_extractor` | sm0l model prompt template + JSON response parsing (fence/preamble tolerant) |
| `crawl_engine` | BFS same-origin link following, depth-limited, polite delay, visited-set dedup |
| `pdf_extractor` | podman/docling (GPU passthrough) + raglite/pdfplumber/PyPDF2 fallback chain |
| `index_dispatcher` | `IndexTarget` trait — `GrafeoTarget`, `RagliteTarget`, `McpBridgeTarget` |

## CLI Flags

```bash
b00t grok assimilate --enhanced --depth 2 --index-target grafeo,raglite   --source-url https://example.com/article --topic rust
```

- `--enhanced`: activate full pipeline
- `--depth N`: crawl depth (default 2, 0 = no crawl)
- `--index-target`: comma-separated targets (grafeo, raglite, codebase-memory)

Extracted concepts are auto-tagged on the datum TOML (`advanced:` prefix for advanced concepts).

## Tests

18 unit tests, all passing (`cargo test --release -p b00t-cli --lib assimilate`):
- content_router: 4 (extension/header detection, HTML strip, file routing)
- concept_extractor: 4 (clean JSON, fenced JSON, preamble, empty response)
- crawl_engine: 6 (URL normalization, same-origin checks)
- index_dispatcher: 3 (empty rejection, report display, error report)
- pdf_extractor: 1 (docling image constant)

## Build

Release mode on aarch64 (Rock-5C / RK3588). ~2min 43s incremental.