### PR TITLE
fix: add glama.json MCP registry listing + fix README plugin syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,18 +52,21 @@ b00t advice rust "PyO3"            # retrieve lessons for a tool+pattern
 
 ## 🤖 MCP Integration
 
-### Claude Code Marketplace (recommended)
+### Claude Code Plugin (recommended)
 
 ```bash
-# In Claude Code, add the b00t marketplace plugin
-/plugin marketplace add elasticdotventures/_b00t_
-/plugin install b00t@b00t-plugins
-/plugin install skill-document-understanding@b00t-plugins
+# Load b00t plugin for this session
+claude --plugin-dir ~/.b00t/.claude-plugin/plugins/b00t
+
+# Or add permanently to your Claude Code settings:
+# "pluginDirectories": ["~/.b00t/.claude-plugin/plugins/b00t"]
 ```
 
 Provides `/b00t` skill, context-aware tool dispatch, and all available b00t skills.
 Bundles publish deterministic MCP recipes at `.claude-plugin/recipes/{skills,roles}/*.json`
 (for example: `skill-document-understanding` provides `docling-mcp` + `fetch-url-as-markdown`).
+
+**MCP Registry**: b00t-mcp is listed on [Glama](https://glama.ai/mcp/servers) — search "b00t".
 
 ### Direct MCP Server
 

--- a/glama.json
+++ b/glama.json
@@ -1,0 +1,17 @@
+{
+  "name": "b00t-mcp",
+  "displayName": "b00t",
+  "description": "b00t hive agent framework — datum system, blessing-based skill authorization, OODA loop, and autonomous agent orchestration for Rust/Python polyglot projects",
+  "license": "MIT",
+  "homepage": "https://github.com/elasticdotventures/_b00t_",
+  "repository": "https://github.com/elasticdotventures/_b00t_",
+  "icon": "https://raw.githubusercontent.com/elasticdotventures/_b00t_/main/_b00t_/assets/b00t-icon.png",
+  "keywords": ["agent", "rust", "datum", "mcp", "hive", "ooda", "autonomous"],
+  "category": "Development Tools",
+  "server": {
+    "type": "stdio",
+    "command": "b00t-mcp",
+    "args": ["--stdio"],
+    "env": {}
+  }
+}


### PR DESCRIPTION
Closes #422

- Adds  — MCP registry entry for b00t-mcp (Glama, Smithery, etc.)
- Fixes README: `/plugin marketplace add` was invented syntax; replaced with real `claude --plugin-dir` and settings reference
- Adds Glama search link to README

🤖 Generated with [Claude Code](https://claude.com/claude-code)