### PR TITLE
feat: add .agents/skills/ — agentskills-compatible SKILL.md files

### DIFF
--- a/.agents/skills/b00t-bless/SKILL.md
+++ b/.agents/skills/b00t-bless/SKILL.md
@@ -1,0 +1,27 @@
+---
+name: b00t-bless
+description: Load a b00t blessing — a prerequisite graph of skills, tools, and authorizations for a specific role. Use when starting a specialized agent session, checking what tools a role needs, or compiling a sandboxed agent manifest. Activates on "load blessing", "what does role X need", "compile agent", "blessing manifest".
+license: MIT
+---
+
+Load blessings for role-based agent authorization:
+
+```bash
+b00t whoami                          # orient: load AGENTS.md + current role
+b00t whoami --role=<role>            # load role supplement (≤120 lines)
+b00t blessing --manifest --role=<R>  # walk depends_on graph → tool auth manifest
+b00t compile-agent --role=X --random-transferable=3  # compiled sandbox AGENTS.md
+```
+
+Fresh agent startup protocol (MUST follow in order):
+1. `b00t whoami` — orient + load session context
+2. `b00t blessing --manifest` — walk prerequisite graph
+3. `b00t learn <skill>` for each unlocked skill — load soul pages
+4. Execute task — tools are authorized after learning
+
+Role supplement files: `AGENTS/<role>.md` — concise (≤120 lines), tail-map required.
+
+Available roles: executive, worker, tester, reviewer, researcher, architect.
+
+No learning = no authorization. The blessing system enforces separation of concern:
+agents only get tools their role requires, preventing privilege escalation.

--- a/.agents/skills/b00t-learn/SKILL.md
+++ b/.agents/skills/b00t-learn/SKILL.md
@@ -1,0 +1,29 @@
+---
+name: b00t-learn
+description: Load a b00t datum soul page for a topic (tool, skill, library, concept). Use when asked to learn about a specific technology, check what b00t knows about a topic, or load tribal knowledge before implementing. Activates on "b00t learn X", "load soul for X", or "what does b00t know about X".
+license: MIT
+---
+
+Load a datum soul page to get b00t's compiled knowledge for a topic:
+
+```bash
+b00t learn <topic>              # load soul: description, hints, usage examples
+b00t learn <topic> --concise    # compact view for context-constrained agents
+b00t learn <topic> --raw        # raw TOML datum for introspection
+```
+
+When a soul is missing, b00t queues research automatically:
+```bash
+b00t learn rust                 # found: returns compiled soul page
+b00t learn unknown-lib          # miss: queues research-soul task
+```
+
+The soul pipeline:
+1. `b00t learn` — loads existing datum or returns miss
+2. Stage 1 review: keyword-overlap discriminator (flags graph-adjacent noise)
+3. Stage 2 review: grok vector endorsement (semantic similarity check)
+4. Both reject → `review-soul: <topic>` task queued for pi/opencode review
+5. `just research-soul topic=<X>` — ingest raw sources → grok assimilate → datum update
+
+Always `b00t learn` a topic before implementing it — the soul contains non-obvious
+constraints, tribal knowledge (🤓 comments), and usage patterns that prevent mistakes.

--- a/.agents/skills/b00t-ooda/SKILL.md
+++ b/.agents/skills/b00t-ooda/SKILL.md
@@ -1,0 +1,32 @@
+---
+name: b00t-ooda
+description: Run an autonomous OODA (Observe-Orient-Decide-Act) loop via ralph to execute task queues with a chosen AI executor. Use when asked to run autonomously, start an agent loop, execute pending tasks without supervision, or run OODA cycles. Activates on "run ooda", "autonomous loop", "start ralph", "execute tasks with pi/opencode/claude".
+license: MIT
+---
+
+Launch a ralph OODA loop to execute tasks autonomously:
+
+```bash
+b00t ooda run                           # claude executor, 5 iterations
+b00t ooda run --agent=pi --max-iter=10  # local ch0nky via pi-coding-agent
+b00t ooda run --agent=opencode          # opencode executor
+b00t ooda run --task=42                 # target specific task ID
+b00t ooda run --dry-run                 # preview command without executing
+b00t ooda status                        # task queue summary
+b00t ooda phase                         # current OodaPhase from last run
+```
+
+Executor tiers:
+- `claude` — frontier (claude-sonnet); best reasoning, highest cost
+- `opencode` — ch0nky (qwen36-local when inference running); code-focused
+- `pi` — ch0nky (llama-cpp); local, non-interactive, fastest for simple tasks
+- `amp` — Amplitude agent; parallel tool use
+- `codex` — OpenAI Codex; sandboxed execution
+
+OODA task dispatch (title prefix → recipe):
+- `review-soul: <T>` → `just review-soul topic=<T>`
+- `research-soul: <T>` → `just research-soul topic=<T>`
+- user story text → standard story implementation cycle
+
+The loop terminates when the executor emits `<promise>COMPLETE</promise>`
+or all pending tasks are done.

--- a/.agents/skills/b00t-task/SKILL.md
+++ b/.agents/skills/b00t-task/SKILL.md
@@ -1,0 +1,29 @@
+---
+name: b00t-task
+description: Manage the b00t task queue — add, list, pick next, and mark tasks done. Use when asked to track work, add a bug/feature/research task, check what's next, or report task completion. Activates on "add task", "next task", "mark done", "task queue", "what should I work on".
+license: MIT
+---
+
+b00t task management (native, replaces taskmaster-ai):
+
+```bash
+b00t task list                  # show all tasks with status
+b00t task next                  # next pending task (priority ordered)
+b00t task add "<title>"         # add task (title prefixes matter)
+b00t task done <id>             # mark task complete
+```
+
+Title prefix conventions — determines how OODA executors handle the task:
+- `bug: <desc>` — bug fix; executor writes test first, then fix
+- `feat: <desc>` — new feature; TDD cycle
+- `research-soul: <topic>` — triggers `just research-soul topic=<topic>`
+- `review-soul: <topic>` — triggers `just review-soul topic=<topic>` (pi review)
+- `gh#<N>: <desc>` — GitHub issue reference
+
+Always branch before starting a task:
+```bash
+git checkout -b task/<id>-<slug> main
+b00t task done <id>   # when tests pass and commit is clean
+```
+
+Tasks live in `.b00t/tasks.json` — committed to repo for hive-wide visibility.


### PR DESCRIPTION
Closes #420

Adds 4 SKILL.md files under `.agents/skills/` in agentskills format:

| Skill | Activates on |
|-------|-------------|
| `b00t-learn` | "b00t learn X", "load soul", "what does b00t know about" |
| `b00t-task` | "add task", "next task", "mark done", "task queue" |
| `b00t-ooda` | "run ooda", "autonomous loop", "start ralph", "execute tasks" |
| `b00t-bless` | "load blessing", "compile agent", "blessing manifest" |

Compatible with Claude Code, VS Code Copilot, and any agentskills client.
Uses progressive disclosure — description activates, body loads on demand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)