### PR TITLE
feat: apply Karpathy 4-principle way-of-working to g0spell + skill datum

### DIFF
--- a/.b00t.g0spell.md
+++ b/.b00t.g0spell.md
@@ -270,3 +270,52 @@ immutable instructions written in stone (or the digital equivalent which is git 
 
 
 
+
+---
+
+## Karpathy Way of Working — Four Principles
+
+Derived from [Andrej Karpathy's observations](https://x.com/karpathy/status/2015883857489522876) on LLM coding pitfalls. Applied to b00t hive agents:
+
+### 1. Think Before Coding
+
+**Don't assume. Surface confusion. Present tradeoffs.**
+
+- State assumptions explicitly before writing code
+- When ambiguity exists, present 2-3 interpretations — don't pick silently
+- Push back when a simpler path exists; say so before proceeding
+- Stop when confused — name what's unclear, ask the operator
+- `b00t learn <topic>` before implementing — the soul contains non-obvious constraints
+
+### 2. Simplicity First (DRY + NRtW)
+
+**Minimum code that solves the problem. Nothing speculative.**
+
+- No features beyond what was asked (no "flexibility" that wasn't requested)
+- No abstractions for single-use code; three similar lines beats a premature abstraction
+- No error handling for impossible scenarios — trust framework guarantees
+- The Simon Willison test: if 200 lines could be 50, rewrite it
+- `b00t lfmf <topic> "<lesson>"` when complexity was avoidable
+
+### 3. Surgical Changes
+
+**Touch only what you must. Clean up only your own mess.**
+
+- Don't improve adjacent code, comments, or formatting
+- Match existing style, even if you'd do it differently
+- Mention unrelated dead code — never delete it without being asked
+- Every changed line must trace directly to the operator's request
+- Never remove `# 🤓` comments without 3× TRIZ justification
+
+### 4. Goal-Driven Execution (TDD-first)
+
+**Define success criteria. Loop until verified.**
+
+- Write the failing test first — task isn't done until tests pass
+- NEVER claim solved without running the test suite
+- `just autolearn` for knowledge loading before implementation
+- `b00t ooda run` for autonomous goal-loop execution
+- Report `<promise>COMPLETE</promise>` only when verifiably done
+
+---
+*Karpathy pattern memoized via `b00t lfmf karpathy "think-first simplicity surgical tdd-loop"`*

--- a/_b00t_/karpathy-autoresearch.skill.toml
+++ b/_b00t_/karpathy-autoresearch.skill.toml
@@ -1,0 +1,28 @@
+[b00t]
+name = "karpathy-autoresearch"
+type = "skill"
+hint = "Andrej Karpathy's way of working: think-first, simplicity-first, surgical changes, goal-driven TDD loop"
+description = """
+Four principles for LLM coding agents from Karpathy's observations:
+1. Think Before Coding — state assumptions, surface ambiguity, push back when warranted
+2. Simplicity First — minimum code, no speculative abstractions, DRY+NRtW
+3. Surgical Changes — touch only what you must, trace every line to the request
+4. Goal-Driven TDD — failing test first, loop until verified, never claim solved without testing
+
+Applied in b00t: soul-first (b00t learn before implement), lfmf for lessons,
+autolearn loop for goal-driven knowledge loading, OODA for autonomous execution.
+"""
+source = "https://x.com/karpathy/status/2015883857489522876"
+reference = "https://github.com/forrestchang/andrej-karpathy-skills"
+
+[b00t.skill]
+type_tags = ["karpathy", "way-of-working", "methodology", "tdd", "simplicity", "transferable"]
+complexity = 3
+tier = "frontier"
+
+# b00t:map v1
+# summary: Karpathy 4-principle way-of-working — think-first, simplicity, surgical, TDD-loop
+# tags: karpathy, methodology, tdd, simplicity, way-of-working, transferable
+# tier: frontier
+# cmds: b00t learn karpathy-autoresearch
+# complexity: 3


### PR DESCRIPTION
Closes #393

- Appends Karpathy principles section to `.b00t.g0spell.md` with b00t-specific adaptations
- Adds `karpathy-autoresearch.skill.toml` datum so `b00t learn karpathy-autoresearch` works
- Tagged `transferable` — available as random transferable skill in `compile-agent`

Principles integrated:
1. **Think Before Coding** → `b00t learn` before implement; surface ambiguity
2. **Simplicity First** → DRY+NRtW; no speculative abstractions
3. **Surgical Changes** → no orthogonal edits; trace every line to request
4. **Goal-Driven TDD** → failing test first; OODA loop for verification

🤖 Generated with [Claude Code](https://claude.com/claude-code)