### PR TITLE
feat(system): system node config, local GPU agent routing, research recipe

### DIFF
--- a/_b00t_/b00t-hooks.skill.toml
+++ b/_b00t_/b00t-hooks.skill.toml
@@ -1,0 +1,49 @@
+[b00t]
+name = "b00t-hooks"
+type = "skill"
+hint = "b00t hooks implementation status — Claude Code hooks (PostToolUse/PreToolUse/SessionStart) and git hooks (pre-commit/pre-push)"
+description = """
+b00t HOOKS IMPLEMENTATION (as of 2026-06)
+
+CLAUDE CODE HOOKS (~/.claude/hooks/)
+  rustfmt-post-edit    [PostToolUse Edit|Write *.rs] — auto-run rustfmt after Rust edits
+  cbm-code-discovery-gate [PreToolUse Grep|Glob|Read] — nudge toward codebase-memory-mcp
+  cbm-session-reminder [SessionStart startup|resume|clear|compact] — code discovery reminder
+
+REGISTERED IN settings.json
+  PreToolUse:   cbm-code-discovery-gate ✅
+  SessionStart: cbm-session-reminder ✅
+  PostToolUse:  rustfmt-post-edit ✅ (added via just install-rustfmt-hook)
+
+GIT HOOKS (.git/hooks/)
+  pre-commit   — runs `just commit-hook` (cargo fmt + version bump via commit-hook2)
+  pre-push     — gates push on `cargo test --package b00t-cli --lib`
+                 install: just install-pre-push-hook
+
+HOOK SOURCES (_b00t_/hooks/)
+  rustfmt-post-edit  — shell script, reads JSON stdin for tool_name + file_path
+  pre-push           — shell script, blocks if tests fail; skips fork remotes
+
+GAPS IDENTIFIED (#421)
+  - commit-hook body was `echo "removed"` (stub) — commit-hook2 has real logic
+  - pre-push hook existed only as .sample — now implemented and installable
+  - PostToolUse rustfmt hook was NOT in settings.json despite being installed
+
+INSTALL RECIPES
+  just install-rustfmt-hook     # copy + print settings.json patch
+  just install-pre-push-hook    # copy to .git/hooks/ + chmod
+  just test-hook                # run rustfmt integration tests
+  just build-hooks              # build Node.js hook bundles for opencode
+"""
+
+[b00t.skill]
+type_tags = ["hooks", "git", "claude-code", "workflow", "automation"]
+complexity = 4
+tier = "sm0l"
+
+# b00t:map v1
+# summary: b00t hooks — Claude Code PostToolUse/PreToolUse/SessionStart + git pre-commit/pre-push
+# tags: hooks, git, claude-code, rustfmt, workflow
+# tier: sm0l
+# cmds: just install-rustfmt-hook, just install-pre-push-hook, just test-hook
+# complexity: 4

--- a/_b00t_/hooks/pre-push
+++ b/_b00t_/hooks/pre-push
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# pre-push hook for b00t repo — runs tests before allowing push to remote.
+# Install: cp _b00t_/hooks/pre-push .git/hooks/pre-push && chmod +x .git/hooks/pre-push
+# Or: just install-pre-push-hook
+set -euo pipefail
+
+REMOTE="$1"
+URL="$2"
+
+# Skip push to personal forks (not main upstream)
+if [[ "$URL" == *"fork"* ]]; then
+  echo "[pre-push] fork remote — skipping test gate"
+  exit 0
+fi
+
+# Gate: never force-push to main
+while read LOCAL_REF LOCAL_SHA REMOTE_REF REMOTE_SHA; do
+  if [[ "$REMOTE_REF" == "refs/heads/main" && "$LOCAL_SHA" == "0000000000000000000000000000000000000000" ]]; then
+    echo "🚫 pre-push: force-delete of main is BLOCKED" >&2
+    exit 1
+  fi
+done
+
+# Run Rust tests for b00t-cli (fast — lib tests only, no integration)
+echo "[pre-push] running cargo test --package b00t-cli --lib ..."
+if ! cargo test --package b00t-cli --lib --quiet 2>&1; then
+  echo "🚫 pre-push: tests failed — push blocked" >&2
+  exit 1
+fi
+
+echo "✅ pre-push: tests pass"

--- a/_b00t_/learn/lfmf-tool-format.md
+++ b/_b00t_/learn/lfmf-tool-format.md
@@ -1,0 +1,2 @@
+---
+lfmf-tool-format: lesson arg must be topic:body format max 25 tokens per field; tool arg max 25 tokens

--- a/_b00t_/learn/mcp-context.md
+++ b/_b00t_/learn/mcp-context.md
@@ -1,0 +1,2 @@
+---
+mcp-context: deferred-tool pattern already in b00t-mcp; mcp2cli adds no value here

--- a/_b00t_/rust-trait-object-layout.skill.toml
+++ b/_b00t_/rust-trait-object-layout.skill.toml
@@ -1,0 +1,63 @@
+[b00t]
+name = "rust-trait-object-layout"
+type = "skill"
+hint = "Rust trait object layout, DST coercions, vtable fat-pointer internals, and the generic field unsized coercion surprise"
+source = "https://neugierig.org/software/blog/2025/03/trait-object-layout.html"
+description = """
+Rust trait object layout — key facts:
+
+LAYOUT BASICS
+  dyn Trait           = dynamically sized type (DST); layout IS the underlying value
+  &dyn Trait          = fat pointer: (ptr_to_value, ptr_to_vtable)
+  Box<dyn Trait>      = owned fat pointer; vtable via CoerceUnsized magic impl
+  vtable              = static table of method pointers for one concrete type+trait pair
+
+CRITICAL DIFFERENCE FROM C++
+  C++: vtable ptr embedded IN the struct (every object pays the cost)
+  Rust: vtable NEVER in the struct; it lives in the fat reference/Box
+
+STANDARD COERCIONS
+  &File → &dyn Read               // compile silently converts
+  Box<File> → Box<dyn Read>       // via CoerceUnsized on Box
+
+SURPRISING COERCION (generic last-field DST)
+  // std::io::BufReader has R NOT as the last field → does NOT support this coercion.
+  // Works only with structs where the generic is the LAST field:
+  struct Adapter<R: ?Sized> { buf: Vec<u8>, inner: R }
+  let a = Adapter { buf: vec![], inner: my_file };
+  let r: &Adapter<dyn Read> = &a;   // LEGAL — inner is the last field
+  // r is fat ptr: (ptr_to_Adapter, Read vtable for File)
+  // Rule: legal only if the coerced generic appears as the LAST field
+  // Constraint: only ONE vtable per fat pointer → cannot coerce two trait params
+
+  &SomeType<dyn A, dyn B>   // NOT legal — would need two vtables
+  &Adapter<dyn Read>        // legal — single last-field coercion
+
+GOTCHA — Box/Rc do NOT support inline generic coercion:
+  let b: Box<File> = Box::new(f);
+  let r: &Box<dyn Read> = &b;   // ILLEGAL — Box doesn't impl CoerceUnsized for refs
+  let r: Box<dyn Read>  = b;    // LEGAL   — ownership transfer (CoerceUnsized on Box itself)
+
+WHY THIS MATTERS IN b00t
+  DatumStore trait uses Box<dyn DatumStore> extensively.
+  When wrapping adapters (e.g. CachingStore<HashMapStore>), the last-field coercion
+  means &CachingStore<dyn DatumStore> is legal — useful for zero-cost adapter stacks.
+  Chalk Interner pattern (b00t learn chalk-interner) relies on this layout guarantee.
+
+SPEC REFERENCE
+  Reference Manual §"Type coercions → Unsized coercions" (no stable anchor URL)
+  Blog source: https://neugierig.org/software/blog/2025/03/trait-object-layout.html
+"""
+
+[b00t.skill]
+type_tags = ["rust", "advanced", "trait-object", "dst", "vtable", "coercion", "transferable"]
+complexity = 7
+tier = "ch0nky"
+unlocks = ["rust-advanced", "datum-macro"]
+
+# b00t:map v1
+# summary: Rust trait object layout — DST fat pointers, vtable placement, generic last-field coercion
+# tags: rust, trait-object, dst, vtable, coercion, advanced, transferable
+# tier: ch0nky
+# cmds: b00t learn rust-trait-object-layout
+# complexity: 7

--- a/_b00t_/system.node.toml
+++ b/_b00t_/system.node.toml
@@ -1,0 +1,88 @@
+# b00t System Node Config — global KV for operator harness selection and agent routing
+# 🤓 This file is the single source of truth for which agent harness to use by default.
+#    Operators read: recommended_agent, claude.status, local_gpu.*
+#    b00t hive checks this on startup to route tasks to the available tier.
+#
+# Edit to change recommended agent when credits/availability changes.
+# CLI: b00t-cli ontology sparql --subject system.node --predicate all
+
+[b00t]
+name = "system.node"
+type = "config"
+hint = "Global system node KV — recommended agent, harness status, local GPU config"
+
+# ── Recommended agent (operator override) ────────────────────────────────────
+# Set this to whichever harness has available credits/energy right now.
+# Options: "opencode", "claude", "pi", "local_gpu"
+# 🤓 local_gpu (port 8001) is always available — unlimited energy on RTX 3090
+recommended_agent = "local_gpu"
+
+# ── Harness status registry ───────────────────────────────────────────────────
+[b00t.agents.claude]
+status = "offline"
+reason = "usage credits exhausted"
+credits_refresh = "2026-06-20"
+model = "claude-sonnet-4-6"
+tier = "frontier"
+# 🤓 When online: executive + architect tasks only (expensive). Prefer local_gpu for ch0nky work.
+
+[b00t.agents.opencode]
+status = "available"
+model = "qwen36-local"
+tier = "ch0nky"
+ipc_port = 3000
+notes = "may also use deepseek credits if DEEPSEEK_API_KEY is set"
+# Swap in: systemctl --user start b00t@opencode-agent.service
+
+[b00t.agents.pi]
+status = "available"
+model = "ch0nky"
+tier = "ch0nky"
+notes = "pi CLI wrapper around local_gpu; good for streaming tasks"
+
+[b00t.agents.local_gpu]
+status = "available"
+endpoint = "http://localhost:8001/v1"
+models = ["ch0nky", "gemma4", "qwen36"]
+active_model = "ch0nky"
+tier = "ch0nky"
+energy = "unlimited"
+notes = "RTX 3090 24GB; direct OpenAI-compat API; always-on recommended default"
+
+# ── Deepseek fallback (cloud credits, may be available) ──────────────────────
+[b00t.agents.deepseek]
+status = "check_env"
+# Available if DEEPSEEK_API_KEY is set; opencode routes to it automatically
+env_key = "DEEPSEEK_API_KEY"
+tier = "frontier"
+notes = "opencode can proxy through deepseek when key is present"
+
+# ── Local GPU details ─────────────────────────────────────────────────────────
+[b00t.local_gpu]
+host = "localhost"
+port = 8001
+base_url = "http://localhost:8001/v1"
+# 🤓 Served by vLLM with OpenAI-compatible API; --served-model-name ch0nky
+default_model = "ch0nky"
+available_models = ["ch0nky"]
+# Activate profile: systemctl --user start b00t@inference-gemma4
+# or: b00t hive activate inference-qwen36-27b
+inference_profiles = ["inference-gemma4", "inference-qwen36-27b", "inference-qwen36-27b-llamacpp"]
+
+# ── Ephemeral research task defaults ──────────────────────────────────────────
+[b00t.research]
+# Config for `just research topic=<T>` — operator shortcut for goal-driven research
+default_agent = "local_gpu"
+default_tier = "ch0nky"
+# pi executor: uses local_gpu endpoint directly, streams output
+executor = "pi"
+artifact_dir = ".tmp/research"
+# Artifacts are ephemeral — cleared by `just research-clean`
+auto_queue_review = true
+
+# b00t:map v1
+# summary: Global system node KV — recommended agent (local_gpu), harness status, local GPU at :8001
+# tags: system, node, config, recommended_agent, local_gpu, claude, opencode, offline
+# tier: sm0l
+# cmds: cat _b00t_/system.node.toml
+# complexity: 2

--- a/b00t-cli/Cargo.toml
+++ b/b00t-cli/Cargo.toml
@@ -32,7 +32,6 @@ chrono = { workspace = true, features = ["serde"] }
 diffy = { workspace = true }
 tempfile = "3.13.0"
 thiserror = "2"
-diffy = { workspace = true }
 
 # b00t-cli specific dependencies
 rhai = { workspace = true }

--- a/justfile
+++ b/justfile
@@ -1509,6 +1509,58 @@ autolearn-loop:
     echo "[loop] max cycles reached"
 
 
+# research: Operator shortcut — ephemeral goal-driven research task via local GPU.
+# Creates a .tmp/research/<topic>.md artifact, routes through recommended_agent (default: local_gpu).
+# Simple interface: just research topic="rust trait objects"
+# 🤓 recommended_agent = local_gpu → pi CLI → http://localhost:8001/v1 (always-on, unlimited energy)
+#    Set RESEARCH_AGENT=opencode to route via opencode ACP instead.
+#    Artifacts are ephemeral — clean with: just research-clean
+research topic="":
+    #!/usr/bin/env bash
+    set -euo pipefail
+    TOPIC="{{topic}}"
+    if [ -z "$TOPIC" ]; then echo "usage: just research topic='<topic description>'"; exit 1; fi
+    AGENT="${RESEARCH_AGENT:-local_gpu}"
+    ARTIFACT_DIR="${PWD}/.tmp/research"
+    mkdir -p "$ARTIFACT_DIR"
+    SLUG=$(echo "$TOPIC" | tr '[:upper:] ' '[:lower:]-' | tr -cd '[:alnum:]-' | head -c 60)
+    ARTIFACT="$ARTIFACT_DIR/${SLUG}.md"
+    echo "[research] topic: $TOPIC"
+    echo "[research] agent: $AGENT → artifact: $ARTIFACT"
+    PROMPT="You are a research assistant. Produce a concise technical research note (300-600 words) on the following topic. Include: key concepts, practical applications, gotchas, and references. Output in markdown.\n\nTopic: $TOPIC"
+    if [ "$AGENT" = "opencode" ]; then
+      opencode run --model qwen36-local/ch0nky "$PROMPT" > "$ARTIFACT" 2>&1
+    else
+      # local_gpu: pi CLI → OpenAI-compat :8001
+      pi --provider openai --base-url http://localhost:8001/v1 --model ch0nky \
+        --system "You are a research assistant producing concise technical notes." \
+        "$TOPIC — produce a 300-600 word research note covering: key concepts, practical applications, gotchas, and references. Output in markdown." \
+        > "$ARTIFACT" 2>&1 \
+        || printf '%s\n' "# Research: $TOPIC" "" "Error: pi failed. Ensure local GPU is active:" \
+             "  systemctl --user start b00t@inference-gemma4" \
+             "  or: b00t hive activate inference-gemma4" > "$ARTIFACT"
+    fi
+    echo "[research] artifact: $ARTIFACT ($(wc -c < "$ARTIFACT")c)"
+    cat "$ARTIFACT"
+
+# research-clean: remove ephemeral research artifacts
+research-clean:
+    #!/usr/bin/env bash
+    rm -rf "${PWD}/.tmp/research" && echo "✅ Cleaned .tmp/research/"
+
+
+# install-pre-push-hook: install pre-push git hook that gates pushes on passing tests.
+# 🤓 pre-push is NOT installed by default — only blocks pushes to non-fork remotes.
+install-pre-push-hook:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    B00T_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || echo "$HOME/.b00t")
+    SRC="$B00T_ROOT/_b00t_/hooks/pre-push"
+    DST="$B00T_ROOT/.git/hooks/pre-push"
+    cp "$SRC" "$DST" && chmod +x "$DST"
+    echo "✅ Installed $DST"
+    echo "   Gate: cargo test --package b00t-cli --lib before push to non-fork remotes"
+
 # ── ralph with diversity ──────────────────────────────────────────────────────
 # ralph-spawn: instantiate a ralph agent with a random personality + transferable skills.
 # Karpathy deepwiki OKR pattern: RESEARCH is a separate cycle from EXECUTION.


### PR DESCRIPTION
## Summary
- `_b00t_/system.node.toml`: global KV config — `recommended_agent = "local_gpu"` (default), claude marked `offline` with `credits_refresh = "2026-06-20"`, harness registry for opencode/pi/local_gpu/deepseek
- `justfile`: `just research topic=<T>` — simple operator shortcut for ephemeral goal-driven research via local GPU (port 8001); `just research-clean` to purge artifacts
- `_b00t_/rust-trait-object-layout.skill.toml`: closes gh#403 — DST/vtable/fat-pointer/coercion skill datum
- `_b00t_/b00t-hooks.skill.toml`: closes gh#421 — hook inventory (PostToolUse rustfmt, PreToolUse cbm-gate, SessionStart cbm-reminder, pre-commit, pre-push)
- `_b00t_/hooks/pre-push`: git pre-push hook gating on `cargo test --lib` for non-fork remotes
- `b00t-cli/Cargo.toml`: remove duplicate `diffy` dependency (compile fix)

## Test plan
- [x] `cargo test --package b00t-cli --lib` → 777 passed; 0 failed
- [ ] `just research topic="rust trait objects"` with local GPU active on :8001
- [ ] Verify `system.node.toml` loads via `b00t-cli ontology sparql --subject system.node --predicate all`

🤖 Generated with [Claude Code](https://claude.com/claude-code)