### PR TITLE
fix(readme): correct Claude Code plugin install commands (gh#422)

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,18 +52,23 @@ b00t advice rust "PyO3"            # retrieve lessons for a tool+pattern
 
 ## 🤖 MCP Integration
 
-### Claude Code Marketplace (recommended)
+### Claude Code Plugin
 
 ```bash
-# In Claude Code, add the b00t marketplace plugin
-/plugin marketplace add elasticdotventures/_b00t_
-/plugin install b00t@b00t-plugins
-/plugin install skill-document-understanding@b00t-plugins
+# Load b00t plugin from local checkout (Claude Code --plugin-dir)
+claude --plugin-dir /path/to/_b00t_/.claude-plugin
+
+# Or install the b00t MCP server directly and let it surface skills
+b00t mcp install b00t-mcp claudecode   # registers b00t-mcp in Claude Code
 ```
 
 Provides `/b00t` skill, context-aware tool dispatch, and all available b00t skills.
-Bundles publish deterministic MCP recipes at `.claude-plugin/recipes/{skills,roles}/*.json`
-(for example: `skill-document-understanding` provides `docling-mcp` + `fetch-url-as-markdown`).
+Plugin manifest: `.claude-plugin/plugin.json` — deterministic MCP recipes at
+`.claude-plugin/recipes/{skills,mcp-servers}/*.json`
+(e.g. `skills/document-understanding.json` bundles `docling-mcp` + fetch tools).
+
+> 🤓 `/plugin marketplace add` does not exist in Claude Code CLI.
+> Use `claude --plugin-dir` for local plugin loading, or `b00t mcp install` for MCP-only.
 
 ### Direct MCP Server
 

--- a/b00t-cli/Cargo.toml
+++ b/b00t-cli/Cargo.toml
@@ -32,7 +32,6 @@ chrono = { workspace = true, features = ["serde"] }
 diffy = { workspace = true }
 tempfile = "3.13.0"
 thiserror = "2"
-diffy = { workspace = true }
 
 # b00t-cli specific dependencies
 rhai = { workspace = true }


### PR DESCRIPTION
## Summary
- Closes gh#422
- Replaces fabricated `/plugin marketplace add elasticdotventures/_b00t_` (non-existent command) with real installation methods:
  - `claude --plugin-dir .claude-plugin` — loads from local `.claude-plugin/` directory (which exists: `plugin.json`, `marketplace.json`, `recipes/`)
  - `b00t mcp install b00t-mcp claudecode` — correct MCP datum name verified via `b00t mcp list`
- Adds `🤓` note clarifying the non-existence of `/plugin marketplace add` to prevent future drift
- Also fixes recurring duplicate `diffy` dep in `b00t-cli/Cargo.toml`

## Reviewer verdict (compiled reviewer agent)
```
REVIEW: PASS — Verdict: APPROVE
Issues: 2 [WARN] (addressed: MCP datum name corrected to b00t-mcp)
```

## Test plan
- [x] `cargo test --package b00t-cli --lib` → 777 passed; 0 failed
- [ ] `claude --plugin-dir .claude-plugin` — loads plugin locally
- [ ] `b00t mcp install b00t-mcp claudecode` — installs MCP server

🤖 Generated with [Claude Code](https://claude.com/claude-code)