### PR TITLE
feat(skills): register b00t skills — tags, discovery, compile fix, just skills recipe (gh#420)

### DIFF
--- a/b00t-cli/src/blessing/irontology.rs
+++ b/b00t-cli/src/blessing/irontology.rs
@@ -4,6 +4,8 @@
 
 use crate::blessing::BlessingGraph;
 use std::collections::{BTreeMap, HashSet};
+#[cfg(test)]
+use crate::blessing::BlessingNode;
 
 /// Validation result with detailed diagnostics
 #[derive(Debug, Clone, PartialEq)]

--- a/b00t-cli/src/blessing/prompts.rs
+++ b/b00t-cli/src/blessing/prompts.rs
@@ -3,6 +3,8 @@
 
 use crate::blessing::BlessingGraph;
 use crate::inventory::Inventory;
+#[cfg(test)]
+use crate::blessing::BlessingNode;
 
 /// Prompt generation context: role + current system state
 #[derive(Debug, Clone)]

--- a/justfile
+++ b/justfile
@@ -1509,6 +1509,18 @@ autolearn-loop:
     echo "[loop] max cycles reached"
 
 
+# skills: list all registered b00t skills (SKILL.md + *.skill.toml datums)
+# 🤓 b00t-cli --path discovers skills/ relative to the path arg, not $PWD default
+skills query="":
+    #!/usr/bin/env bash
+    B00T_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || echo "$HOME/.b00t")
+    if [ -z "{{query}}" ]; then
+      b00t-cli --path "$B00T_ROOT" skill list
+    else
+      b00t-cli --path "$B00T_ROOT" skill search "{{query}}"
+    fi
+
+
 # ── ralph with diversity ──────────────────────────────────────────────────────
 # ralph-spawn: instantiate a ralph agent with a random personality + transferable skills.
 # Karpathy deepwiki OKR pattern: RESEARCH is a separate cycle from EXECUTION.

--- a/skills/aws-cli/SKILL.md
+++ b/skills/aws-cli/SKILL.md
@@ -3,6 +3,9 @@ name: aws-cli
 description: |
   CLI-first AWS orchestration skill for Lambda, ECS/Fargate, and S3 workflows rooted in `.☁️` runbooks.
 version: 0.1.0
+tags: [aws, cli, lambda, ecs, fargate, s3, cloud, devops]
+applies_to: [AWS deployment, Lambda functions, ECS/Fargate, S3 storage, cloud orchestration]
+output_types: [.sh, .json, .yaml]
 allowed-tools: Read, Write, Edit, Grep, Glob, Bash, codebase_investigator, web_fetch, write_todos
 ---
 

--- a/skills/b00t-interface-library/SKILL.md
+++ b/skills/b00t-interface-library/SKILL.md
@@ -9,6 +9,9 @@ description: >
   (karpathy/autoresearch): agent reads program.md, iterates on the library,
   experiments autonomously.
 version: 1.0.0
+tags: [rust, b00t, library, lifecycle, mcp, daemon, sidecar, autoresearch]
+applies_to: [Rust library design, lifecycle management, MCP server development, process governance]
+output_types: [.rs, .toml]
 allowed-tools: Read, Write, Edit, Grep, Glob, Bash, Task
 ---
 

--- a/skills/datum-system/SKILL.md
+++ b/skills/datum-system/SKILL.md
@@ -6,6 +6,9 @@ description: |
   WHICH environment variables are required (not the values). Enables DRY approach
   by centralizing configuration in Rust, exposed to Python via PyO3.
 version: 1.0.0
+tags: [b00t, datum, toml, config, rust, pyo3, ai-model]
+applies_to: [creating datums, configuring AI providers, managing tool versions, b00t setup]
+output_types: [.toml, .tomllm, .tomllmd]
 allowed-tools: Read, Write, Edit, Grep, Glob, Bash
 ---
 

--- a/skills/direnv-pattern/SKILL.md
+++ b/skills/direnv-pattern/SKILL.md
@@ -5,6 +5,9 @@ description: |
   where datums specify WHICH environment variables are required and .env contains
   the actual secret VALUES. Ensures automatic environment loading per-project.
 version: 1.0.0
+tags: [b00t, direnv, env, config, secrets, python, dotenv]
+applies_to: [environment setup, secret management, project configuration, direnv]
+output_types: [.env, .envrc, .env.example]
 allowed-tools: Read, Write, Edit, Bash
 ---
 

--- a/skills/dry-philosophy/SKILL.md
+++ b/skills/dry-philosophy/SKILL.md
@@ -5,6 +5,9 @@ description: |
   principles. Use existing libraries, leverage Rust via PyO3 instead of duplicating
   logic in Python, and contribute to upstream projects rather than fork privately.
 version: 1.0.0
+tags: [b00t, dry, philosophy, rust, python, pyo3, code-quality]
+applies_to: [code review, architecture, library selection, avoiding duplication]
+output_types: [.rs, .py, .md]
 allowed-tools: Read, Grep, Glob, Bash, WebSearch
 ---
 

--- a/skills/executive-role/SKILL.md
+++ b/skills/executive-role/SKILL.md
@@ -4,6 +4,9 @@ description: |
   Defines the shared role, responsibilities, and operating principles for an Executive agent in the b00t hive.
   This skill uses Rhai scripting to provide model-specific directives.
 version: 1.1.0
+tags: [b00t, agent, role, executive, hive, rhai, orchestration]
+applies_to: [executive agent setup, hive orchestration, agent delegation, crew management]
+output_types: [.md, .tomllmd]
 allowed-tools: Read, Write, Edit, Grep, Glob, Bash, codebase_investigator, web_fetch, write_todos
 ---
 

--- a/skills/firecrawl/SKILL.md
+++ b/skills/firecrawl/SKILL.md
@@ -5,6 +5,9 @@ description: |
   crawl websites, search the web, and extract structured data. Supports cloud API and
   self-hosted deployments including CRW (Rust alternative).
 version: 1.0.0
+tags: [mcp, web, scraping, firecrawl, crawl, markdown, data-extraction]
+applies_to: [web scraping, URL to markdown, website crawling, structured data extraction, AI research]
+output_types: [.md, .json]
 allowed-tools: Read, Write, Edit, Grep, Glob, Bash, mcp_firecrawl_*
 ---
 


### PR DESCRIPTION
## Summary
- Closes gh#420 — register b00t skills

**skills/*/SKILL.md (7 files)**: add `tags`, `applies_to`, `output_types` frontmatter so `b00t skill search <query>` and `just skills query=<q>` return meaningful results. Covers: datum-system, direnv-pattern, dry-philosophy, aws-cli, executive-role, firecrawl, b00t-interface-library

**justfile**: `just skills [query=""]` convenience recipe wrapping `b00t-cli --path $B00T_ROOT skill list/search`
> 🤓 Default `--path ~/.b00t/_b00t_` does NOT discover `skills/` directory — requires explicit `--path` to repo root. The recipe uses `git rev-parse --show-toplevel` to resolve this automatically.

**b00t-cli compile fix**: `BlessingNode` used only in `#[cfg(test)]` test blocks in `irontology.rs` + `prompts.rs` — the import was missing, causing 13 compiler errors on main. Fixed by adding `#[cfg(test)] use crate::blessing::BlessingNode;`

## Reviewer verdict (compiled reviewer agent)
```
REVIEW: PASS — Verdict: APPROVE
Files: 11 changed
Issues: 1 [WARN] advisory (import placement — idiomatic, no correctness issue)
Tests: 795 passing
```

## Test plan
- [x] `cargo test --package b00t-cli --lib` → 795 passed; 0 failed (pre-push hook verified)
- [x] `just skills` → 7 skills listed with tags
- [x] `just skills query=rust` → returns skills tagged with rust
- [ ] `b00t skill activate datum-system` — load skill instructions

🤖 Generated with [Claude Code](https://claude.com/claude-code)