### PR TITLE
chore: vendor irontology-mcp PDF/arXiv intake + compile fix + .tmp gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -288,6 +288,7 @@ telemetry.jsonl
 events.jsonl
 test_*.json
 tmp/
+.tmp/
 togaf-cli/
 togaf-dsl/
 var/

--- a/b00t-cli/src/blessing/irontology.rs
+++ b/b00t-cli/src/blessing/irontology.rs
@@ -4,6 +4,8 @@
 
 use crate::blessing::BlessingGraph;
 use std::collections::{BTreeMap, HashSet};
+#[cfg(test)]
+use crate::blessing::BlessingNode;
 
 /// Validation result with detailed diagnostics
 #[derive(Debug, Clone, PartialEq)]

--- a/b00t-cli/src/blessing/prompts.rs
+++ b/b00t-cli/src/blessing/prompts.rs
@@ -3,6 +3,8 @@
 
 use crate::blessing::BlessingGraph;
 use crate::inventory::Inventory;
+#[cfg(test)]
+use crate::blessing::BlessingNode;
 
 /// Prompt generation context: role + current system state
 #[derive(Debug, Clone)]


### PR DESCRIPTION
## Summary

- **vendor/irontology-mcp**: bump to `b48d8b1` (`feat/pdf-arxiv-intake`) — PDF extraction + arXiv/HuggingFace intake connectors
- **b00t-cli blessing compile fix**: `BlessingNode` is only used inside `#[cfg(test)]` blocks in `irontology.rs` and `prompts.rs` — the unconditional import caused 13 `E0422` errors on main. Added `#[cfg(test)] use crate::blessing::BlessingNode;` to both files.
- **.gitignore**: add `.tmp/` (ephemeral research artifacts from `just research` recipe; `tmp/` was already covered but `.tmp/` was not)

## Test plan

- [x] `cargo test --package b00t-cli --lib` → 795 passed; 0 failed (pre-push hook verified)
- [x] `git status` clean after commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)