### PR TITLE
fix(skill-resolver): use git root for skill discovery — fixes b00t skill list (gh#474)

### DIFF
--- a/b00t-cli/src/blessing/irontology.rs
+++ b/b00t-cli/src/blessing/irontology.rs
@@ -4,6 +4,8 @@
 
 use crate::blessing::BlessingGraph;
 use std::collections::{BTreeMap, HashSet};
+#[cfg(test)]
+use crate::blessing::BlessingNode;
 
 /// Validation result with detailed diagnostics
 #[derive(Debug, Clone, PartialEq)]

--- a/b00t-cli/src/blessing/prompts.rs
+++ b/b00t-cli/src/blessing/prompts.rs
@@ -3,6 +3,8 @@
 
 use crate::blessing::BlessingGraph;
 use crate::inventory::Inventory;
+#[cfg(test)]
+use crate::blessing::BlessingNode;
 
 /// Prompt generation context: role + current system state
 #[derive(Debug, Clone)]

--- a/b00t-cli/src/commands/skill.rs
+++ b/b00t-cli/src/commands/skill.rs
@@ -225,6 +225,17 @@ pub fn handle_skill_command(cmd: &SkillCommands, path: &str) -> Result<()> {
 
 /// Build a `SkillResolver` relative to the provided CLI `path` argument.
 fn build_resolver(path: &str) -> SkillResolver {
+    // Prefer git project root so `b00t skill list` works from any subdirectory,
+    // not just when cwd happens to be the repo root.
+    if let Ok(out) = std::process::Command::new("git")
+        .args(["rev-parse", "--show-toplevel"])
+        .output()
+    {
+        if out.status.success() {
+            let git_root = String::from_utf8_lossy(&out.stdout).trim().to_string();
+            return SkillResolver::for_path(std::path::Path::new(&git_root));
+        }
+    }
     match get_expanded_path(path) {
         Ok(expanded) => SkillResolver::for_path(&expanded),
         Err(_) => {


### PR DESCRIPTION
## Summary

Closes gh#474.

`b00t skill list` (no flags) returned **"No skills found"** because the default `--path ~/.b00t/_b00t_` was passed to `build_resolver()`, which only searched `_b00t_/skills/` — a path that doesn't exist. The cwd-secondary-search logic in `build_dirs` only helped when cwd happened to be the exact project root.

## Fix

`build_resolver()` now calls `git rev-parse --show-toplevel` first and uses the git project root for `SkillResolver::for_path()`. Works from any subdirectory. Falls back to `_B00T_Path` expansion when not in a git repository.

Also carries the `BlessingNode` `#[cfg(test)]` compile fix until PR #469 (task/31) merges.

## Test plan

- [x] `b00t-cli skill list` from project root → 7 skills listed  
- [x] `cargo test --package b00t-cli --lib` → 795 passed; 0 failed (pre-push hook verified)
- [ ] `b00t-cli skill list` from `b00t-cli/` subdirectory → finds project skills

🤖 Generated with [Claude Code](https://claude.com/claude-code)