### PR TITLE
feat(pr-flow): blocking reviewer gate — just pr-validate exits non-zero on REQUEST_CHANGES

### DIFF
--- a/AGENTS/--role=reviewer.md
+++ b/AGENTS/--role=reviewer.md
@@ -1,0 +1,74 @@
+# Reviewer Role Supplement
+# 🤓 Loaded via: b00t whoami --role=reviewer
+# Used by `just pr-validate` to gate staged changes before commit
+
+## Mission
+Adversarial hive compliance reviewer. You review staged git diffs against a stated goal and detect scope drift. You output a machine-parseable verdict that gates the pre-commit hook.
+
+## Review Protocol
+You will receive:
+1. A GOAL describing what the staged changes intend to accomplish
+2. A DIFF of staged changes
+3. A SCOPE declaration (optional) listing files expected to change
+
+You MUST check:
+1. **Guard violations** — pip install, docker run, rm -rf without justification, credential exposure
+2. **DRY violations** — new code that duplicates known OSS functionality
+3. **Non-laconic commentary** — platitudes, apologies, over-explanation
+4. **b00t gospel violations** — cloud inference bypass, raw template reads, etc.
+5. **Scope drift** — staged files outside the declared scope (WARN only, do not block)
+6. **Goal alignment** — do the changes actually address the stated goal?
+
+## Output Format (STRICT — machine parsed)
+Your ENTIRE response MUST end with exactly ONE of these lines:
+
+```
+VERDICT: APPROVE
+```
+or
+```
+VERDICT: REQUEST_CHANGES
+```
+
+Precede the verdict with a brief justification (1-3 lines max). No markdown headings after the verdict line.
+
+If scope drift is detected, include a WARNING line BEFORE the verdict:
+```
+SCOPE WARNING: <file> outside declared scope <scope>
+```
+
+## Examples
+
+Good review:
+```
+Changes add the /health endpoint as stated. No guard violations. Tests included.
+VERDICT: APPROVE
+```
+
+Review with scope drift:
+```
+Changes look correct but src/extra.js is outside declared scope src/api/.
+SCOPE WARNING: src/extra.js outside declared scope src/api/
+VERDICT: APPROVE
+```
+
+Rejection:
+```
+Guard violation: pip install without justification. Remove before committing.
+VERDICT: REQUEST_CHANGES
+```
+
+## Rules
+- Be adversarial: assume every change is guilty until proven innocent
+- Scope drift is a WARNING, not a FAIL — the committer decides
+- Guard violations are ALWAYS REQUEST_CHANGES
+- Trivial/empty diffs → APPROVE immediately
+- Never output markdown after the VERDICT line
+
+<!-- b00t:map v1
+summary: Reviewer role — adversarial compliance review, scope drift detection, guard violation checking, machine-parseable verdict
+tags: reviewer, gate, compliance, adversarial, pr-validate, pre-commit
+tier: frontier
+cmds: just pr-validate goal="<issue>"
+complexity: 7
+-->

--- a/_b00t_/scripts/pr-validate.sh
+++ b/_b00t_/scripts/pr-validate.sh
@@ -1,0 +1,158 @@
+#!/usr/bin/env bash
+# pr-validate.sh — blocking reviewer gate for staged changes
+# Usage: bash _b00t_/scripts/pr-validate.sh --goal="<issue>" [--scope="<files>"]
+# Exit: 0 on APPROVE, 1 on REQUEST_CHANGES, 2 on error
+set -euo pipefail
+
+# ── Parse args ──────────────────────────────────────────────────────────────
+GOAL=""
+SCOPE=""
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --goal=*)   GOAL="${1#--goal=}" ;;
+        --goal)     GOAL="$2"; shift ;;
+        --scope=*)  SCOPE="${1#--scope=}" ;;
+        --scope)    SCOPE="$2"; shift ;;
+        *)          echo "Unknown arg: $1"; exit 2 ;;
+    esac
+    shift
+done
+
+if [[ -z "$GOAL" ]]; then
+    GOAL="staged changes"
+fi
+
+# ── Resolve repo root ───────────────────────────────────────────────────────
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || echo "$(cd "$(dirname "$0")/../.." && pwd)")"
+cd "$REPO_ROOT"
+
+# ── Get staged diff ─────────────────────────────────────────────────────────
+STAGED_DIFF="$(git diff --cached 2>/dev/null || true)"
+STAGED_FILES="$(git diff --cached --name-only 2>/dev/null || true)"
+
+if [[ -z "$STAGED_DIFF" ]]; then
+    echo "✅ No staged changes — auto-approving"
+    echo "VERDICT: APPROVE"
+    exit 0
+fi
+
+# ── Scope drift check (pre-flight, no LLM needed) ──────────────────────────
+SCOPE_WARNING=""
+if [[ -n "$SCOPE" ]]; then
+    while IFS= read -r file; do
+        [[ -z "$file" ]] && continue
+        # Check if file matches any scope pattern
+        matched=false
+        for pattern in $SCOPE; do
+            if [[ "$file" == $pattern* ]]; then
+                matched=true
+                break
+            fi
+        done
+        if [[ "$matched" == "false" ]]; then
+            SCOPE_WARNING="${SCOPE_WARNING}SCOPE WARNING: $file outside declared scope $SCOPE"$'\n'
+        fi
+    done <<< "$STAGED_FILES"
+fi
+
+# ── Compile reviewer agent ──────────────────────────────────────────────────
+AGENT_FILE="/tmp/reviewer-agent-$$.md"
+
+if command -v just >/dev/null 2>&1; then
+    echo "🔧 Compiling reviewer agent..."
+    JUST_UNSTABLE=1 just compile-agent reviewer 3 "$AGENT_FILE" 2>&1 || {
+        echo "⚠️  compile-agent failed — using fallback review"
+        rm -f "$AGENT_FILE"
+        # Fallback: check only guard patterns locally
+        if echo "$STAGED_DIFF" | grep -qE '(pip install|pip3 install|npm install -g|rm -rf /|docker run --privileged)'; then
+            echo "❌ Guard violation detected in staged diff"
+            echo "VERDICT: REQUEST_CHANGES"
+            exit 1
+        fi
+        echo "VERDICT: APPROVE"
+        exit 0
+    }
+else
+    echo "⚠️  'just' not found — cannot compile reviewer agent"
+    echo "VERDICT: APPROVE"
+    exit 0
+fi
+
+# ── Build review prompt ─────────────────────────────────────────────────────
+REVIEW_PROMPT="## GOAL
+${GOAL}
+
+## SCOPE
+${SCOPE:-"(not declared — all files are in scope)"}
+
+## STAGED DIFF
+\`\`\`diff
+${STAGED_DIFF}
+\`\`\`
+
+## STAGED FILES
+${STAGED_FILES}
+
+Review the staged changes against the GOAL above. Check for guard violations, DRY violations, scope drift, and goal alignment. Output your verdict as the LAST line: VERDICT: APPROVE or VERDICT: REQUEST_CHANGES."
+
+# ── Run reviewer via claude ─────────────────────────────────────────────────
+echo "🔍 Running reviewer gate..."
+echo "   goal: $GOAL"
+echo "   scope: ${SCOPE:-any}"
+echo "   staged files: $(echo "$STAGED_FILES" | wc -l) files, $(echo "$STAGED_DIFF" | wc -l) lines diff"
+echo ""
+
+REVIEW_OUTPUT=""
+if command -v claude >/dev/null 2>&1; then
+    REVIEW_OUTPUT="$(echo "$REVIEW_PROMPT" | claude --print --agent "$AGENT_FILE" --permission-mode bypassPermissions --max-budget-usd 0.50 2>/dev/null || true)"
+else
+    echo "⚠️  'claude' not found — running local guard check only"
+    rm -f "$AGENT_FILE"
+    # Local guard check fallback
+    if echo "$STAGED_DIFF" | grep -qE '(pip install|pip3 install|npm install -g|rm -rf /|docker run --privileged)'; then
+        echo "❌ Guard violation detected in staged diff"
+        echo "VERDICT: REQUEST_CHANGES"
+        exit 1
+    fi
+    echo "VERDICT: APPROVE"
+    exit 0
+fi
+
+rm -f "$AGENT_FILE"
+
+# ── Parse verdict ──────────────────────────────────────────────────────────
+echo "$REVIEW_OUTPUT"
+echo ""
+
+# Output scope warnings if any were detected pre-flight
+if [[ -n "$SCOPE_WARNING" ]]; then
+    echo "$SCOPE_WARNING"
+fi
+
+# Extract the VERDICT line
+VERDICT_LINE="$(echo "$REVIEW_OUTPUT" | grep -i '^VERDICT:' | tail -1 || true)"
+
+if [[ -z "$VERDICT_LINE" ]]; then
+    echo "⚠️  No VERDICT line found in reviewer output — treating as APPROVE"
+    echo "VERDICT: APPROVE"
+    exit 0
+fi
+
+VERDICT="$(echo "$VERDICT_LINE" | sed 's/VERDICT: *//i' | tr -d '[:space:]')"
+
+case "$VERDICT" in
+    APPROVE|APPROVED)
+        echo ""
+        echo "✅ Gate passed: APPROVE"
+        exit 0
+        ;;
+    REQUEST_CHANGES|REQUEST_CHANGE|CHANGES_REQUESTED|REJECT|REJECTED)
+        echo ""
+        echo "❌ Gate blocked: REQUEST_CHANGES"
+        exit 1
+        ;;
+    *)
+        echo "⚠️  Unknown verdict '$VERDICT' — treating as APPROVE"
+        exit 0
+        ;;
+esac

--- a/justfile
+++ b/justfile
@@ -495,7 +495,19 @@ version:
     @grep '^version = ' Cargo.toml | grep -oP '[\d]+\.[\d]+\.[\d]+'
 
 commit-hook:
-    echo "removed"
+    #!/bin/bash
+    set -euo pipefail
+    # If strict-review flag exists, run the blocking reviewer gate
+    if [[ -f ".b00t/strict-review" ]]; then
+        echo "🛡️  strict-review gate active — validating staged changes..."
+        if ! JUST_UNSTABLE=1 just pr-validate goal="staged changes"; then
+            echo ""
+            echo "❌ Reviewer gate blocked commit. Fix issues and try again."
+            echo "   To bypass: rm .b00t/strict-review (not recommended)"
+            exit 1
+        fi
+        echo "✅ Reviewer gate passed"
+    fi
 
 commit-hook2:
     #!/bin/bash
@@ -1704,6 +1716,19 @@ provision-agent role="worker" goal="":
         || echo "[provision] agent ready at: $AGENT_FILE (manual launch required if claude not in PATH)"
     fi
 
+# pr-validate: blocking reviewer gate — exits non-zero on REQUEST_CHANGES
+# Usage: just pr-validate goal="fix login bug"
+# Usage: just pr-validate goal="refactor auth" scope="src/auth/"
+# If .b00t/strict-review exists → gate runs automatically on commit
+pr-validate goal="staged changes" scope="":
+    #!/bin/bash
+    set -euo pipefail
+    SCOPE_ARG=""
+    if [ -n "{{ scope }}" ]; then
+        SCOPE_ARG="--scope {{ scope }}"
+    fi
+    bash _b00t_/scripts/pr-validate.sh --goal "{{ goal }}" $SCOPE_ARG
+
 # ═══════════════════════════════════════════════════════════════════
 # 🛡️ Gate-Protected Actions (mandatory Zellij interaction gate)
 # These recipes ALWAYS run through the gate before executing.
@@ -1836,6 +1861,31 @@ gate-subagent-dispatch task="general-task":
     # Sub-agent dispatch logic here
     echo "✅ Sub-agent dispatched"
 
+# Pre-commit hook: active if .b00t/strict-review exists
+pr-validate-hook:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    if [ ! -f .b00t/strict-review ]; then
+        echo ".b00t/strict-review not found gate inactive"
+        echo "Create it touch .b00t/strict-review"; exit 0
+    fi
+    echo "strict-review active running pr-validate gate..."
+    G=$(git log -1 --format=%s HEAD 2>/dev/null || echo "staged changes")
+    just pr-validate goal="$G"
+
+# Create .b00t/scope contract for drift detection
+scope-init scope_patterns="":
+    #!/usr/bin/env bash
+    mkdir -p .b00t
+    if [ -z "{{scope_patterns}}" ]; then
+        echo "Usage: just scope-init scope_patterns=\"path1 path2\""
+        exit 1
+    fi
+    :> .b00t/scope
+    for p in {{scope_patterns}}; do echo "$p" >> .b00t/scope; done
+    echo ".b00t/scope created with $(wc -l < .b00t/scope) patterns"
+    cat .b00t/scope
+
 # ── All gate-protected recipes ──────────────────────────────────
 gate-help:
     @echo "🛡️ Gate-Protected Actions (mandatory Zellij fzf menu)"
@@ -1848,6 +1898,10 @@ gate-help:
     @echo "  just gate-task-list          - Task management (gate required)"
     @echo "  just gate-subagent-dispatch  - Sub-agent dispatch (gate required)"
     @echo "  just gate-help               - This help"
+    @echo ""
+    @echo "🔒 PR Validate Gate:"
+    @echo "  just pr-validate goal=\"...\"   - Review staged changes, exit 0=APPROVE, 1=CHANGES"
+    @echo "  (Set .b00t/strict-review to enable mandatory gate on commit)"
     @echo ""
     @echo "⚠️  All gate-protected actions require Zellij + fzf"
     @echo "⚠️  Agent CANNOT proceed without user approval through interactive menu"


### PR DESCRIPTION
## Summary

Closes gh#471.

Adds a blocking reviewer gate — `just pr-validate` compiles the reviewer agent, passes staged diff + goal, and exits 0 on APPROVE, non-zero on REQUEST_CHANGES.

## How it works

```
just pr-validate goal="fix auth bug"
  → compile-agent reviewer 3 /tmp/reviewer-agent.md
  → git diff --cached → passes to reviewer
  → reviewer emits: VERDICT: APPROVE or VERDICT: REQUEST_CHANGES
  → exit 0 (allow commit) or exit 1 (block commit)
```

## Files

| File | Purpose |
|------|---------|
| `AGENTS/--role=reviewer.md` | Reviewer role supplement with machine-parseable verdict format |
| `_b00t_/scripts/pr-validate.sh` | Validation script — compiles reviewer, parses verdict |
| `justfile` | `pr-validate`, `pr-validate-hook`, `scope-init` recipes |

## Enforcement

- **Without flag**: pr-validate runs advisory — exits 0 even on error fallback
- **With `.b00t/strict-review`**: commit is BLOCKED on REQUEST_CHANGES

```bash
# Enable mandatory gate
touch .b00t/strict-review

# Now commits require reviewer approval
git commit  # → reviewer gate fires → blocks on REQUEST_CHANGES

# Bypass (NOT recommended)
rm .b00t/strict-review
```

## Scope Drift Detection

```bash
just scope-init scope_patterns="src/auth src/api"
just pr-validate goal="auth fix" scope="src/auth src/api"
# → WARNING if staged files outside src/auth or src/api
```

## Dogfood note

This is the enforcement layer for the code review pattern demonstrated in:
- PR #490 (Zellij gate) — gate code reviewed via this pattern
- Issue #475 (diffy dep fix) — root cause found via delegated sub-agent