### PR TITLE
feat: write guard gate with proposed-datums staging area (#470)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -301,6 +301,7 @@ yarn-error.log*
 yarn.lock
 # Session/temporary caches
 cache/
+.tmp/
 .serena/
 session-guards.json
 # Runtime state files

--- a/_b00t_/gates/write-guard.gate.toml
+++ b/_b00t_/gates/write-guard.gate.toml
@@ -1,0 +1,31 @@
+# 🥾 Write Guard Gate — Sandbox Gate for _b00t_/ Writes
+# Intercepts unauthorized writes to _b00t_/ and redirects to staging area.
+# Only sessions with datum-authoring blessing may write directly.
+#
+# Architecture:
+#   agent write to _b00t_/*.toml → gate.check("write-guard") →
+#     Blessed (datum-authoring) → allow (exit 0)
+#     Not blessed                → redirect to .tmp/proposed-datums/ + create review task
+
+[b00t]
+name = "write-guard"
+type = "gate"
+hint = "Intercepts writes to _b00t_/ — redirects to staging if no datum-authoring blessing"
+
+[gate]
+mode = "mandatory"
+trigger = "on-write"
+condition = "_b00t_-path"
+target_patterns = ["_b00t_/*.toml", "_b00t_/*.datum.toml", "_b00t_/*.skill.toml"]
+
+[gate.redirect]
+staging_dir = ".tmp/proposed-datums/"
+create_task = true
+task_label = "review: proposed datum"
+
+# b00t:map v1
+# summary: Write guard — redirects unauthorized _b00t_/ writes to staging + creates review task
+# tags: governance, gate, write-guard, datum, staging
+# tier: ch0nky
+# cmds: b00t gate check write-guard, just propose-datum
+# complexity: 7

--- a/_b00t_/scripts/write-guard.sh
+++ b/_b00t_/scripts/write-guard.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# write-guard.sh — Write guard hook for _b00t_/ sandbox gate
+# Intercepts writes to _b00t_/*.toml. Redirects unauthorized writes to staging.
+#
+# Usage: bash _b00t_/scripts/write-guard.sh <target_file>
+# Exit: 0 = allowed (blessed), 1 = redirected to staging (not blessed)
+#
+# Blessing check: reads KVCache key "zellij.gate.blessings" for "datum-authoring"
+set -euo pipefail
+
+# ── Parse args ──────────────────────────────────────────────────────────────
+TARGET_FILE="${1:-}"
+if [[ -z "$TARGET_FILE" ]]; then
+    echo "write-guard: ERROR - no target file specified" >&2
+    echo "Usage: bash _b00t_/scripts/write-guard.sh <target_file>" >&2
+    exit 2
+fi
+
+# ── Resolve paths ───────────────────────────────────────────────────────────
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || echo "$(cd "$(dirname "$0")/../.." && pwd)")"
+cd "$REPO_ROOT"
+
+TARGET_BASENAME="$(basename "$TARGET_FILE")"
+STAGING_DIR=".tmp/proposed-datums"
+KV_FILE="${B00T_KV_FILE:-$HOME/.b00t/kv-store.json}"
+
+# ── Check blessings via KVCache ─────────────────────────────────────────────
+BLESSED=false
+if command -v python3 >/dev/null 2>&1 && [[ -f "$KV_FILE" ]]; then
+    BLESSINGS_JSON="$(python3 -c "
+import json, sys
+try:
+    with open('$KV_FILE') as f:
+        data = json.load(f)
+    blessings = data.get('zellij.gate.blessings', '')
+    print(blessings)
+except:
+    sys.exit(1)
+" 2>/dev/null || echo "")"
+
+    if [[ "$BLESSINGS_JSON" == *"datum-authoring"* ]]; then
+        BLESSED=true
+    fi
+fi
+
+# ── Allow if blessed ────────────────────────────────────────────────────────
+if [[ "$BLESSED" == "true" ]]; then
+    echo "write-guard: ✅ datum-authoring blessing confirmed — write allowed to $TARGET_FILE"
+    exit 0
+fi
+
+# ── Redirect to staging ─────────────────────────────────────────────────────
+mkdir -p "$STAGING_DIR"
+
+STAGING_PATH="$STAGING_DIR/$TARGET_BASENAME"
+cp "$TARGET_FILE" "$STAGING_PATH" 2>/dev/null || {
+    echo "write-guard: WARNING - could not copy '$TARGET_FILE' to staging (file may not exist yet)" >&2
+    # Create a placeholder to indicate the attempted write
+    echo "# Proposed datum: $TARGET_BASENAME (staged by write-guard)" > "$STAGING_PATH"
+    echo "# Original target: $TARGET_FILE" >> "$STAGING_PATH"
+    echo "# Status: pending review" >> "$STAGING_PATH"
+}
+
+# ── Create review task ──────────────────────────────────────────────────────
+if command -v b00t >/dev/null 2>&1; then
+    b00t task add "review: proposed datum $TARGET_BASENAME" 2>/dev/null || true
+fi
+
+# ── Report to caller ────────────────────────────────────────────────────────
+echo ""
+echo "╔══════════════════════════════════════════════════════════════╗"
+echo "║  🛡️  WRITE GUARD: datum-authoring blessing required         ║"
+echo "╠══════════════════════════════════════════════════════════════╣"
+echo "║  Write to _b00t_/ blocked: $TARGET_BASENAME"
+echo "║  Redirected to staging: $STAGING_PATH"
+echo "║                                                              ║"
+echo "║  ▸ Request blessing from operator                            ║"
+echo "║  ▸ Or use: just propose-datum $TARGET_FILE                 ║"
+echo "║  ▸ Review pending: just review-proposed                      ║"
+echo "╚══════════════════════════════════════════════════════════════╝"
+echo ""
+
+exit 1

--- a/justfile
+++ b/justfile
@@ -1678,6 +1678,52 @@ compile-agent role="worker" n_skills="3" out="/tmp/compiled-agent.md":
     echo "   role: {{role}}"
     echo "   skills: ${ASSIGNED[*]}"
 
+# ── Write Guard / Proposed Datums Staging ──────────────────────────────────────
+
+# propose-datum: operator shortcut to stage a datum for review
+# Usage: just propose-datum <path-to-datum>
+# Copies the file to .tmp/proposed-datums/ and creates a review task
+propose-datum file:
+    #!/bin/bash
+    set -euo pipefail
+    FILE="{{file}}"
+    if [[ -z "$FILE" ]]; then
+        echo "Usage: just propose-datum <path-to-datum>" >&2
+        echo "Example: just propose-datum _b00t_/my-skill.skill.toml" >&2
+        exit 1
+    fi
+    if [[ ! -f "$FILE" ]]; then
+        echo "Error: file not found: $FILE" >&2
+        exit 1
+    fi
+    mkdir -p .tmp/proposed-datums
+    BASENAME="$(basename "$FILE")"
+    cp "$FILE" .tmp/proposed-datums/"$BASENAME"
+    if command -v b00t >/dev/null 2>&1; then
+        b00t task add "review: proposed datum $FILE" 2>/dev/null || true
+    fi
+    echo "📋 Proposed datum staged for review: .tmp/proposed-datums/$BASENAME"
+    echo "   Review pending: just review-proposed"
+
+# review-proposed: list pending proposed datums and their review tasks
+review-proposed:
+    #!/bin/bash
+    set -euo pipefail
+    echo "📋 Proposed datums:"
+    echo ""
+    if [[ -d .tmp/proposed-datums ]] && ls .tmp/proposed-datums/*.toml >/dev/null 2>&1; then
+        ls -la .tmp/proposed-datums/*.toml 2>/dev/null
+    else
+        echo "  (no proposed datums)"
+    fi
+    echo ""
+    echo "📋 Review tasks:"
+    if command -v b00t >/dev/null 2>&1; then
+        b00t task list 2>/dev/null | grep "review: proposed" || echo "  (no review tasks)"
+    else
+        echo "  (b00t CLI not available)"
+    fi
+
 # ── end ralph / compile-agent ──────────────────────────────────────────────────
 
 # provision-agent: operator convenience — compile + launch agent for a role+goal in one command.


### PR DESCRIPTION
## Summary
Implements issue #470: \_b00t\_/ write guard — sandbox gate with proposed-datums staging area.

## Changes
- **`_b00t_/gates/write-guard.gate.toml`** — Mandatory on-write gate that intercepts writes to `_b00t_/*.toml` files. Redirects unauthorized writes to staging area.
- **`_b00t_/scripts/write-guard.sh`** — Hook script that checks `datum-authoring` blessing via KVCache (`zellij.gate.blessings`). If blessed: allows write (exit 0). If not: redirects to `.tmp/proposed-datums/`, creates review task, exits 1.
- **`just propose-datum`** — Operator shortcut to stage a datum file for review.
- **`just review-proposed`** — Lists pending proposed datums and their review tasks.
- **`.gitignore`** — Added `.tmp/` for staging directory.

## Test Results
- ✅ Without blessing: write guard intercepts and redirects to staging (exit 1)
- ✅ With `datum-authoring` blessing: direct write allowed (exit 0)
- ✅ `just propose-datum _b00t_/test-datum.toml` — staged correctly
- ✅ `just review-proposed` — lists pending proposals and tasks

Closes #470