### PR TITLE
feat: kreuzberg Stage 1 — datum + MCP wrapper + end-to-end validation

### DIFF
--- a/_b00t_/kreuzberg-test.py
+++ b/_b00t_/kreuzberg-test.py
@@ -37,7 +37,8 @@ async def main() -> None:
         try:
             from kreuzberg import extract_file
             result = await extract_file(sample)
-            text = result.text[:500] if result.text else "(no text)"
+            content = getattr(result, 'content', None) or getattr(result, 'text', None) or "(no content)"
+            text = content[:500]
             print(text)
             print("\n✅ kreuzberg extraction test passed")
         except Exception as e:

--- a/_b00t_/kreuzberg.cli.toml
+++ b/_b00t_/kreuzberg.cli.toml
@@ -3,31 +3,34 @@ name = "kreuzberg"
 type = "cli"
 desires = "latest"
 install = '''
-# Kreuzenberg document intelligence library
-# 🥾 Prefer uvx for auto-install; uv pip as fallback
-if command -v uvx >/dev/null 2>&1; then
-    echo "✨ Installing kreuzberg via uvx (auto-managed)"
-    uvx kreuzberg-mcp --help >/dev/null 2>&1 && echo "✅ kreuzberg ready via uvx" && exit 0
-fi
-
-if command -v uv >/dev/null 2>&1; then
-    echo "📦 Installing kreuzberg via uv pip"
-    uv pip install --system "kreuzberg[all]"
-elif command -v pip3 >/dev/null 2>&1; then
-    echo "📦 Installing kreuzberg via pip3"
-    pip3 install "kreuzberg[all]"
+# Kreuzberg document intelligence library
+# 🥾 Prefer pip install --user so the MCP datum can use `python3` directly
+if command -v pip3 >/dev/null 2>&1; then
+    echo "📦 Installing kreuzberg via pip3 --user"
+    pip3 install --user kreuzberg
+    echo "✅ kreuzberg installed"
+elif command -v pip >/dev/null 2>&1; then
+    echo "📦 Installing kreuzberg via pip --user"
+    pip install --user kreuzberg
+    echo "✅ kreuzberg installed"
+elif command -v uv >/dev/null 2>&1; then
+    echo "📦 Installing kreuzberg via uv tool install"
+    uv tool install kreuzberg
+    echo "✅ kreuzberg installed"
 else
-    echo "⚠️  Neither uv nor pip3 found. Install uv first: curl -LsSf https://astral.sh/uv/install.sh | sh"
+    echo "⚠️  No pip or uv found. Install pip first."
     exit 1
 fi
 '''
 
 update = '''
 # Update kreuzberg
-if command -v uv >/dev/null 2>&1; then
-    uv pip install --system --upgrade "kreuzberg[all]"
-elif command -v pip3 >/dev/null 2>&1; then
-    pip3 install --upgrade "kreuzberg[all]"
+if command -v pip3 >/dev/null 2>&1; then
+    pip3 install --user --upgrade kreuzberg
+elif command -v pip >/dev/null 2>&1; then
+    pip install --user --upgrade kreuzberg
+elif command -v uv >/dev/null 2>&1; then
+    uv tool upgrade kreuzberg
 fi
 '''
 

--- a/_b00t_/kreuzberg.mcp.toml
+++ b/_b00t_/kreuzberg.mcp.toml
@@ -9,29 +9,38 @@ hook_detect = "gates"
 topic = "kreuzberg-mcp"
 auto_digest = true
 
-# 🥾: PRIMARY — uvx kreuzberg-mcp (auto-install via uv)
+# 🥾: PRIMARY — wrapper script (kreuzberg must be installed via pip install --user)
 [[b00t.mcp.stdio]]
 priority = 0
-command = "uvx"
-requires = ["python"]
+command = "python3"
+requires = ["python", "kreuzberg"]
 transport = "stdio"
-args = ["kreuzberg-mcp"]
+args = ["/home/brianh/.dotfiles/_b00t_/scripts/kreuzberg-mcp-wrapper.py"]
 
-# 🥾: FALLBACK — python -m kreuzberg.mcp (if installed via pip/uv)
+# 🥾: FALLBACK — direct python path
 [[b00t.mcp.stdio]]
 priority = 10
 command = "python3"
 requires = ["python", "kreuzberg"]
 transport = "stdio"
-args = ["-m", "kreuzberg.mcp"]
+args = ["_b00t_/scripts/kreuzberg-mcp-wrapper.py"]
+
+# 🥾: UPSTREAM — uvx kreuzberg-mcp (when upstream MCP server ships)
+[[b00t.mcp.stdio]]
+priority = 20
+command = "uvx"
+requires = ["python"]
+transport = "stdio"
+args = ["kreuzberg-mcp"]
+unstable = true
 
 [[b00t.gate]]
-rhai = "command_exists(\"uvx\") || command_exists(\"python3\")"
-hint = "uvx or python3 required for kreuzberg MCP server"
+rhai = "command_exists(\"uv\") || command_exists(\"python3\")"
+hint = "uv or python3 required for kreuzberg MCP server"
 
 [[b00t.gate]]
-rhai = "command_exists(\"uvx\")"
-hint = "uvx (uv tool runner) required for auto-install path"
+rhai = "command_exists(\"uv\")"
+hint = "uv required for tool-managed kreuzberg"
 
 [[b00t.usage]]
 description = "Run kreuzberg MCP server via uvx (auto-install)"

--- a/_b00t_/scripts/kreuzberg-mcp-wrapper.py
+++ b/_b00t_/scripts/kreuzberg-mcp-wrapper.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python3
+"""kreuzberg MCP wrapper — exposes document extraction via MCP tools.
+
+Usage:
+  uv run _b00t_/scripts/kreuzberg-mcp-wrapper.py
+
+Or via the MCP datum:
+  python3 _b00t_/scripts/kreuzberg-mcp-wrapper.py
+"""
+import asyncio
+import json
+import sys
+from pathlib import Path
+
+HAS_KREUZBERG = False
+try:
+    import kreuzberg
+    from kreuzberg import extract_file, extract_bytes
+    HAS_KREUZBERG = True
+except ImportError:
+    pass
+
+
+TOOLS = []
+if HAS_KREUZBERG:
+    TOOLS = [
+        {
+            "name": "kreuzberg_extract_file",
+            "description": "Extract text content from a document file (PDF, DOCX, images, etc.)",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "path": {"type": "string", "description": "Path to the document file"},
+                },
+                "required": ["path"],
+            },
+        },
+        {
+            "name": "kreuzberg_extract_bytes",
+            "description": "Extract text content from raw document bytes (base64-encoded)",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "data": {"type": "string", "description": "Base64-encoded document bytes"},
+                    "mime_type": {"type": "string", "description": "MIME type (e.g. application/pdf)"},
+                },
+                "required": ["data", "mime_type"],
+            },
+        },
+        {
+            "name": "kreuzberg_list_formats",
+            "description": "List supported document formats",
+            "inputSchema": {"type": "object", "properties": {}},
+        },
+    ]
+
+
+async def handle_extract_file(args: dict) -> dict:
+    path = args["path"]
+    try:
+        result = await extract_file(path)
+        content = result.content or ""
+        return {
+            "content": [
+                {"type": "text", "text": content},
+                {"type": "text", "text": json.dumps({
+                    "mime_type": result.mime_type,
+                    "pages": getattr(result, "get_page_count", lambda: None)(),
+                    "char_count": len(content),
+                })},
+            ]
+        }
+    except Exception as e:
+        return {"content": [{"type": "text", "text": f"Error: {e}"}], "isError": True}
+
+
+async def handle_extract_bytes(args: dict) -> dict:
+    import base64
+    data = base64.b64decode(args["data"])
+    mime_type = args["mime_type"]
+    try:
+        result = await extract_bytes(data, mime_type=mime_type)
+        content = result.content or ""
+        return {"content": [{"type": "text", "text": content}]}
+    except Exception as e:
+        return {"content": [{"type": "text", "text": f"Error: {e}"}], "isError": True}
+
+
+async def handle_list_formats() -> dict:
+    return {
+        "content": [
+            {"type": "text", "text": json.dumps({
+                "supported_formats": [
+                    "text/plain", "application/pdf", "image/png", "image/jpeg",
+                    "image/tiff", "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+                    "text/html", "text/markdown",
+                ],
+                "engine": "kreuzberg",
+            }, indent=2)},
+        ]
+    }
+
+
+async def handle_request(request: dict) -> dict | None:
+    method = request.get("method", "")
+    req_id = request.get("id")
+
+    if method == "initialize":
+        return {
+            "jsonrpc": "2.0", "id": req_id,
+            "result": {
+                "protocolVersion": "2025-03-26",
+                "capabilities": {"tools": {}},
+                "serverInfo": {"name": "kreuzberg-mcp", "version": "0.1.0"},
+            },
+        }
+    elif method == "tools/list":
+        return {"jsonrpc": "2.0", "id": req_id, "result": {"tools": TOOLS}}
+    elif method == "tools/call":
+        params = request.get("params", {})
+        name = params.get("name", "")
+        args = params.get("arguments", {})
+        if not HAS_KREUZBERG:
+            result = {
+                "content": [{"type": "text", "text": "kreuzberg not installed. Run: uv tool install kreuzberg"}],
+                "isError": True,
+            }
+        elif name == "kreuzberg_extract_file":
+            result = await handle_extract_file(args)
+        elif name == "kreuzberg_extract_bytes":
+            result = await handle_extract_bytes(args)
+        elif name == "kreuzberg_list_formats":
+            result = await handle_list_formats()
+        else:
+            result = {"content": [{"type": "text", "text": f"Unknown tool: {name}"}], "isError": True}
+        return {"jsonrpc": "2.0", "id": req_id, "result": result}
+    elif method == "notifications/initialized":
+        return None
+    else:
+        return {"jsonrpc": "2.0", "id": req_id, "error": {"code": -32601, "message": f"Unknown method: {method}"}}
+
+
+async def main() -> None:
+    while True:
+        line = await asyncio.get_event_loop().run_in_executor(None, sys.stdin.readline)
+        if not line:
+            break
+        line = line.strip()
+        if not line:
+            continue
+        request = json.loads(line)
+        response = await handle_request(request)
+        if response is not None:
+            sys.stdout.write(json.dumps(response) + "\n")
+            sys.stdout.flush()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/justfile
+++ b/justfile
@@ -2109,8 +2109,8 @@ kreuzberg-install:
         curl -LsSf https://astral.sh/uv/install.sh | sh
         export PATH="$HOME/.local/bin:$PATH"
     fi
-    echo "📦 Installing kreuzberg[all] via uv pip..."
-    uv pip install --system "kreuzberg[all]"
+    echo "📦 Installing kreuzberg via pip install --user..."
+    pip3 install --user kreuzberg
     echo ""
     echo "🔍 Verifying installation..."
     python3 -c "import kreuzberg; print('kreuzberg OK')"

--- a/vendor/.b00t/tasks.json
+++ b/vendor/.b00t/tasks.json
@@ -4,7 +4,9 @@
       "id": 1,
       "title": "Implement kreuzberg integration (Stage 1 of #341) — MCP datum for document intelligence",
       "description": "Issue #398 (latent space) identified that kreuzberg integration (issue #341) is at 0% implementation. Stage 1: Create _b00t_/kreuzberg.mcp.toml datum, register kreuzberg MCP server, validate text extraction from PDFs. Blocks paper parsing end-to-end in b00t ecosystem.",
-      "status": "pending",
+      "status": "completed",
+      "completed_at": "2026-06-20T00:00:00Z",
+      "result": "kreuzberg MCP datum exists, MCP wrapper built (3 tools: extract_file, extract_bytes, list_formats), end-to-end validated with kreuzberg v4.9.9. Upstream MCP server path (uvx kreuzberg-mcp) noted for future when upstream ships it.",
       "priority": 3,
       "tags": [
         "paper-parsing",


### PR DESCRIPTION
Stage 1 of #341 — kreuzberg document intelligence integration

- MCP datum: fixed to point to working wrapper
- MCP wrapper: 3 tools (extract_file, extract_bytes, list_formats)
- Test script: fixed API (result.text -> result.content)
- CLI datum: fixed install path (pip install --user)
- justfile: fixed kreuzberg-install target

Validated: initialize, tools/list, tools/call all working with kreuzberg v4.9.9. Unblocks issue #398 (paper parsing).