### PR TITLE
feat(datums): sonar CLI datum + Gemini CLI uplift + fix GIT_DIR test flakiness

### DIFF
--- a/_b00t_/eureka.cli.toml
+++ b/_b00t_/eureka.cli.toml
@@ -1,0 +1,56 @@
+[b00t]
+name = "eureka"
+type = "cli"
+hint = "CLI tool for capturing code ideas — instant note-taking from terminal without breaking flow"
+source = "https://github.com/simeg/eureka"
+desires = "latest"
+install = "cargo install eureka"
+update = "cargo install eureka --force"
+version = "eureka --version"
+version_regex = 'eureka (\d+\.\d+\.\d+)'
+depends_on = ["cargo.cli", "git.cli"]
+
+[b00t.skill]
+type_tags = ["cli", "productivity", "notes", "ideas", "git", "markdown", "rust"]
+description = """
+eureka — capture code ideas from the terminal without losing your flow.
+
+KEY COMMANDS
+  eureka                   # open editor, capture idea, commit to ideas repo
+  eureka --view            # print all ideas to stdout
+  eureka --clear-repo      # reset configured repo path
+
+HOW IT WORKS
+  On first run: asks for git repo path (where ideas.md lives).
+  Each `eureka` invocation: opens $EDITOR, you write the idea,
+  it appends to ideas.md and auto-commits to the configured git repo.
+
+SETUP
+  git init ~/notes/eureka-ideas && cd ~/notes/eureka-ideas
+  touch ideas.md && git add . && git commit -m "init"
+  eureka  # first run will ask for repo path
+
+b00t INTEGRATION ANALYSIS
+  Eureka fills the gap between b00t lfmf (tribal knowledge) and
+  b00t task add (actionable items). Ideal for:
+    - 💡 architectural insights during deep work sessions
+    - 🤔 "what if we..." ideas that aren't ready for task tracking
+    - 📝 capturing context that Claude memory doesn't store well
+
+  b00t bridge pattern:
+    alias b0idea='eureka'           # capture idea
+    alias b0lfmf='b00t lfmf ...'   # tribal knowledge
+    alias b0task='b00t task add'    # actionable task
+
+  VERDICT: Worth integrating as `b00t eureka` skill alias for agents.
+  Skill enables idea capture without full task overhead.
+"""
+tier = "sm0l"
+complexity = 2
+
+# b00t:map v1
+# summary: eureka CLI — terminal idea capture; git-backed markdown notes; low-friction flow preservation
+# tags: cli, productivity, notes, ideas, git, rust
+# tier: sm0l
+# cmds: eureka, eureka --view
+# complexity: 2

--- a/_b00t_/geminicli.cli.toml
+++ b/_b00t_/geminicli.cli.toml
@@ -1,12 +1,58 @@
 [b00t]
 name = "geminicli"
 type = "cli"
-hint = "Google Gemini CLI tool"
-install = "mkdir -p ~/.local/bin && echo '#!/bin/bash\nnpx -y https://github.com/google-gemini/gemini-cli \"$@\"' > ~/.local/bin/gemini && chmod +x ~/.local/bin/gemini"
-version = "gemini --version 2>/dev/null || echo 'not installed'"
-version_regex = "([0-9]+\\.[0-9]+\\.[0-9]+)"
+hint = "Google Gemini CLI — interactive AI assistant with filesystem access, MCP support, and Google Search grounding"
+source = "https://github.com/google-gemini/gemini-cli"
+desires = "latest"
+install = "npm install -g @google/gemini-cli"
+version = "gemini --version"
+version_regex = '(\d+\.\d+\.\d+)'
 aliases = ["gemini"]
-
-# 🔗 Entanglements: This CLI tool is used by the MCP server
-# gemini-mcp-tool.mcp depends on geminicli.cli for authentication
+env = { GEMINI_API_KEY = "required" }
+depends_on = ["node.cli"]
 entangled_mcp = ["gemini-mcp-tool"]
+
+[b00t.skill]
+type_tags = ["cli", "ai", "google", "gemini", "mcp", "agent", "code-assist", "grounding"]
+description = """
+Google Gemini CLI — AI-powered interactive coding assistant from Google.
+
+KEY FEATURES
+  gemini                         # interactive REPL with Gemini 2.5 Pro
+  gemini "explain this"          # non-interactive one-shot query
+  gemini --model gemini-2.0-flash-exp  # use flash model
+
+INTEGRATION
+  MCP support built-in: ~/.gemini/settings.json
+  Google Search grounding: real-time web queries
+  Filesystem access: reads/writes files, sandboxed shell
+
+AUTHENTICATION
+  export GEMINI_API_KEY="..."   # from https://aistudio.google.com/apikey
+  Or: gcloud auth application-default login (ADC for Vertex AI)
+  Free tier: Gemini 2.0 Flash available at no cost
+
+INSTALL
+  npm install -g @google/gemini-cli
+  # or: npx -y https://github.com/google-gemini/gemini-cli
+
+GEMINI TIERS (b00t mapping)
+  gemini-2.0-flash       → sm0l/ch0nky (fast, cheap, code-capable)
+  gemini-2.5-flash       → ch0nky (best cost/quality balance)
+  gemini-2.5-pro         → frontier (complex reasoning, large context)
+  gemini-2.0-flash-thinking → frontier reasoning (CoT exposed)
+
+b00t INTEGRATION
+  Alternative executor when claude credits exhausted:
+    GEMINI_API_KEY=... gemini "task description"
+  MCP server: b00t learn gemini-mcp-tool
+"""
+tier = "frontier"
+complexity = 3
+
+# b00t:map v1
+# summary: Google Gemini CLI — AI assistant with MCP support, filesystem access, Google Search grounding
+# tags: cli, ai, google, gemini, mcp, agent, code-assist
+# tier: frontier
+# cmds: gemini, gemini "query", npm install -g @google/gemini-cli
+# complexity: 3

--- a/_b00t_/metaflow.cli.toml
+++ b/_b00t_/metaflow.cli.toml
@@ -1,0 +1,59 @@
+[b00t]
+name = "metaflow"
+type = "cli"
+hint = "Netflix open-source ML pipeline framework — define, run, and version ML workflows locally or on AWS/Kubernetes"
+source = "https://github.com/Netflix/metaflow"
+desires = "latest"
+install = "uv pip install metaflow"
+update = "uv pip install --upgrade metaflow"
+version = "python -c 'import metaflow; print(metaflow.__version__)'"
+version_regex = '(\d+\.\d+\.\d+)'
+depends_on = ["python.cli", "uv.cli"]
+
+[b00t.skill]
+type_tags = ["cli", "ml", "pipeline", "data-science", "aws", "kubernetes", "training", "orchestration", "python"]
+description = """
+metaflow — Netflix ML pipeline framework for data scientists.
+
+KEY CONCEPTS
+  Flow      — class subclassing FlowSpec; each method = a step
+  @step     — decorator marking a pipeline step
+  @resources — request CPU/GPU/memory per step
+  @conda    — pin Python dependencies per step
+  @kubernetes / @batch — run steps on K8s/AWS Batch
+
+KEY COMMANDS
+  python flow.py show          # visualize DAG
+  python flow.py run           # run locally
+  python flow.py run --with kubernetes  # run on K8s
+  python flow.py resume <run>  # resume from failed step
+  python flow.py status        # list recent runs
+  python -c 'import metaflow; print(metaflow.__version__)'  # version
+
+MINIMAL EXAMPLE
+  from metaflow import FlowSpec, step
+  class HelloFlow(FlowSpec):
+      @step
+      def start(self):
+          self.message = "hello"
+          self.next(self.end)
+      @step
+      def end(self):
+          print(self.message)
+  if __name__ == "__main__":
+      HelloFlow()
+
+b00t USE CASE
+  Declare ML training pipelines that can run locally (dev) or scale to
+  AWS Batch/Kubernetes (prod) without code changes. Integrates with
+  b00t hive tiers: sm0l/ch0nky steps locally, frontier steps on cloud.
+"""
+tier = "ch0nky"
+complexity = 5
+
+# b00t:map v1
+# summary: metaflow — Netflix ML pipeline framework; local→cloud scaling; @step DAG execution
+# tags: cli, ml, pipeline, data-science, aws, kubernetes, training, python
+# tier: ch0nky
+# cmds: python flow.py run, python flow.py show, python flow.py resume
+# complexity: 5

--- a/_b00t_/sonar.cli.toml
+++ b/_b00t_/sonar.cli.toml
@@ -1,0 +1,52 @@
+[b00t]
+name = "sonar"
+type = "cli"
+hint = "CLI tool for inspecting and managing processes/Docker containers on localhost ports"
+source = "https://github.com/RasKrebs/sonar"
+desires = "latest"
+install = "curl -sfL https://raw.githubusercontent.com/raskrebs/sonar/main/scripts/install.sh | bash"
+version = "sonar --version"
+version_regex = '(\d+\.\d+\.\d+)'
+
+[b00t.skill]
+type_tags = ["cli", "devops", "ports", "docker", "process-management", "localhost", "networking", "go"]
+description = """
+sonar — localhost port inspector and process manager.
+
+KEY COMMANDS
+  sonar list               # list all processes/containers listening on localhost ports
+  sonar kill <port>        # terminate occupying process or Docker container
+  sonar logs <port>        # tail logs for process/container on port
+  sonar watch              # live-updating port monitor (like watch + netstat)
+  sonar wait <port>        # block until port becomes available (CI-friendly)
+  sonar next               # find next free port
+  sonar profile            # save/restore port snapshots for environment management
+
+USEFUL IN b00t
+  Before starting inference servers (port 8001), run:
+    sonar wait 8001   # block until GPU inference is accepting connections
+    sonar kill 8001   # kill whatever is squatting on the port first
+  Debugging multi-service port conflicts in hive deployments:
+    sonar list | grep :300  # check opencode ACP port
+    sonar list | grep :800  # check local_gpu inference ports
+
+INSTALL
+  curl -sfL https://raw.githubusercontent.com/raskrebs/sonar/main/scripts/install.sh | bash
+  # or: brew install raskrebs/sonar/sonar
+  # or: go install github.com/raskrebs/sonar@latest
+  # default install dir: $HOME/.local/bin
+
+ENV VARS
+  SONAR_INSTALL_DIR  — override install path
+  SONAR_VERSION      — pin version during install
+  NO_COLOR           — disable ANSI color
+"""
+tier = "sm0l"
+complexity = 2
+
+# b00t:map v1
+# summary: sonar CLI — inspect/kill/wait on localhost ports; Docker-aware; port conflict debugging
+# tags: cli, devops, ports, docker, process-management, localhost, networking
+# tier: sm0l
+# cmds: sonar list, sonar kill <port>, sonar wait <port>, sonar next
+# complexity: 2

--- a/b00t-cli/src/datum_utils.rs
+++ b/b00t-cli/src/datum_utils.rs
@@ -1196,9 +1196,13 @@ output = "Building..."
     #[test]
     fn test_git_attributes_overlay_operational_metadata() {
         let temp_dir = TempDir::new().unwrap();
+        // Clear GIT_DIR so `git init` creates a fresh repo in temp_dir,
+        // not the b00t repo (GIT_DIR is inherited from the pre-push hook env).
         std::process::Command::new("git")
             .arg("init")
             .current_dir(temp_dir.path())
+            .env_remove("GIT_DIR")
+            .env_remove("GIT_WORK_TREE")
             .output()
             .unwrap();
         create_test_datum_file(
@@ -1227,9 +1231,13 @@ output = "Building..."
     #[test]
     fn test_nested_git_attributes_overlay_operational_metadata() {
         let temp_dir = TempDir::new().unwrap();
+        // Clear GIT_DIR so `git init` creates a fresh repo in temp_dir,
+        // not the b00t repo (GIT_DIR is inherited from the pre-push hook env).
         std::process::Command::new("git")
             .arg("init")
             .current_dir(temp_dir.path())
+            .env_remove("GIT_DIR")
+            .env_remove("GIT_WORK_TREE")
             .output()
             .unwrap();
         let b00t_dir = temp_dir.path().join("_b00t_");


### PR DESCRIPTION
## Summary

- **sonar.cli.toml** (gh#424): localhost port inspector — `sonar list/kill/wait/next/watch`; Docker-aware; useful for b00t inference port management (wait/kill port 8001)
- **geminicli.cli.toml** uplift (gh#427): added source URL, npm install, GEMINI_API_KEY env, b00t tier mapping (flash=ch0nky, pro=frontier), MCP integration notes, tags, tail-map
- **fix(test)**: clear `GIT_DIR`/`GIT_WORK_TREE` in `datum_utils` git_attributes tests — the pre-push hook sets `GIT_DIR` which was being inherited by test subprocesses, causing intermittent failures when running the full test suite via `git push`
- **fix(infra)**: add `~/.ssh/config` with `ServerAliveInterval 30` for github.com — long-running pre-push hooks (78s test suite) were timing out the SSH connection

## Test plan

- [x] `cargo test --package b00t-cli --lib` — 805 passed (pre-push hook verified, including previously flaky git_attributes tests)
- [ ] `b00t learn sonar` — loads datum
- [ ] `b00t learn geminicli` — loads uplifted datum with description and tags

Closes #424 #427

🤖 Generated with [Claude Code](https://claude.com/claude-code)