### PR TITLE
fix(warnings): suppress rustc unused/dead-code warnings across 6 files

### DIFF
--- a/b00t-azure-cp/src/main.rs
+++ b/b00t-azure-cp/src/main.rs
@@ -403,6 +403,7 @@ struct AzureCpServer {
     credential: Arc<dyn TokenCredential>,
     /// Shared HTTP client with connect/request timeouts for Cost Management queries.
     http_client: reqwest::Client,
+    #[allow(dead_code)]
     tool_router: ToolRouter<AzureCpServer>,
 }
 

--- a/b00t-c0re-lib/tests/grok_raglight_e2e_test.rs
+++ b/b00t-c0re-lib/tests/grok_raglight_e2e_test.rs
@@ -15,6 +15,8 @@
 //! # Run unit-only (always safe):
 //!   cargo test --package b00t-c0re-lib --test grok_raglight_e2e_test
 
+#![allow(dead_code)]
+
 use anyhow::Result;
 use b00t_c0re_lib::{DocumentSource, LoaderType, RagLightConfig, RagLightManager};
 use serde::Deserialize;

--- a/b00t-embed/tests/demo_layer_lifecycle.rs
+++ b/b00t-embed/tests/demo_layer_lifecycle.rs
@@ -279,7 +279,7 @@ async fn demo_layer_lifecycle() {
 
         // Build a linear layer using the VarMap as the weight store.
         let linear = {
-            let mut vm = model_varmap.lock().unwrap();
+            let vm = model_varmap.lock().unwrap();
             let vb = candle_nn::VarBuilder::from_varmap(&vm, DType::F32, &Device::Cpu);
             candle_nn::linear(in_dim, out_dim, vb.pp("demo_layer")).unwrap()
             // vm unlocked here implicitly (no explicit drop needed with MutexGuard)
@@ -397,7 +397,7 @@ async fn demo_layer_lifecycle() {
     {
         let test_varmap = Arc::new(Mutex::new(VarMap::new()));
         let linear = {
-            let mut vm = test_varmap.lock().unwrap();
+            let vm = test_varmap.lock().unwrap();
             let vb = candle_nn::VarBuilder::from_varmap(&vm, DType::F32, &Device::Cpu);
             candle_nn::linear(2, 1, vb.pp("proj")).unwrap()
         };

--- a/b00t-embed/tests/test_qwen3_composable.rs
+++ b/b00t-embed/tests/test_qwen3_composable.rs
@@ -3,9 +3,7 @@
 //
 // Run: cargo test --test test_qwen3_composable -p b00t-embed -- --nocapture
 
-use std::collections::HashMap;
-
-use candle_core::{DType, Device, Tensor};
+use candle_core::{DType, Device};
 use candle_nn::{VarBuilder, VarMap};
 use hf_hub::api::sync::ApiBuilder;
 use hf_hub::Repo;
@@ -42,7 +40,7 @@ fn test_tensor_name_alignment() {
 
     // Build VarMap and create VarBuilder to simulate model construction
     let varmap = VarMap::new();
-    let vb = VarBuilder::from_varmap(&varmap, DType::F32, &Device::Cpu);
+    let _vb = VarBuilder::from_varmap(&varmap, DType::F32, &Device::Cpu);
 
     // Load Qwen3 model config to know shapes
     let config_path = repo.get("config.json").expect("config.json download");

--- a/b00t-lib-chat/src/discovery.rs
+++ b/b00t-lib-chat/src/discovery.rs
@@ -368,7 +368,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_stale_pruning() {
-        let mut registry = SocketRegistry::new();
+        let registry = SocketRegistry::new();
 
         // Insert an agent with old timestamp
         let old_endpoint = AgentEndpoint {

--- a/b00t-lib-chat/tests/multi_agent_integration.rs
+++ b/b00t-lib-chat/tests/multi_agent_integration.rs
@@ -4,8 +4,7 @@
 //! multiple transports (Unix sockets, NATS, MQTT, Redis).
 
 use b00t_chat::{
-    ChatClient, ChatMessage, ChatMetrics, Destination, MessageRouter, SocketRegistry,
-    SocketRegistryBuilder,
+    ChatMessage, ChatMetrics, Destination, MessageRouter, SocketRegistryBuilder,
 };
 use std::sync::Arc;
 use std::time::Duration;
@@ -15,11 +14,6 @@ use tokio::time::{sleep, timeout};
 /// Timeout duration for operations (prevents tests hanging indefinitely).
 const TEST_TIMEOUT: Duration = Duration::from_secs(10);
 
-/// Deadlock detection interval (check for progress every N seconds).
-const DEADLOCK_CHECK_INTERVAL: Duration = Duration::from_secs(2);
-
-/// Maximum number of deadlock checks before failing.
-const MAX_DEADLOCK_CHECKS: usize = 3;
 
 #[tokio::test]
 async fn test_basic_agent_discovery() {


### PR DESCRIPTION
## Summary

- Remove unused imports (`HashMap`, `Tensor`, `ChatClient`, `SocketRegistry`) in test files
- Remove needless `mut` bindings on two `VarMap` lock guards (`demo_layer_lifecycle.rs`) and one `SocketRegistry` (`discovery.rs`)
- Remove two dead constants (`DEADLOCK_CHECK_INTERVAL`, `MAX_DEADLOCK_CHECKS`) from `multi_agent_integration.rs` test
- Add `#[allow(dead_code)]` on `AzureCpServer.tool_router` — proc-macro field, compiler false positive
- Add `#![allow(dead_code)]` at file level in `grok_raglight_e2e_test.rs` for serde-only fixture structs

Vendor `DEFAULT_VIDEO_*` warning is feature-gated upstream code — not touched.

## Test plan

- [x] `cargo check -p b00t-embed -p b00t-chat -p b00t-azure-cp -p b00t-c0re-lib` — clean
- [x] pre-push hook: `cargo test --package b00t-cli --lib` — 840 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)