### PR TITLE
refactor(acl): unify key serialization between CLI and proxy

### DIFF
--- a/b00t-c0re-lib/src/acl_keys.rs
+++ b/b00t-c0re-lib/src/acl_keys.rs
@@ -1,0 +1,53 @@
+// 🤓 Shared ACL types for b00t API key management
+//    Used by both b00t-cli (server.rs) and b00t-mcp (server_llm.rs)
+//    to guarantee identical JSON serialization format.
+
+use serde::{Deserialize, Serialize};
+
+/// Ontology-scoped action: what operation a permission grants.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "lowercase")]
+pub enum Action {
+    Read,
+    Write,
+    Execute,
+}
+
+/// A single permission entry: access to an ontology class with an action.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct ClassPermission {
+    pub class: String,
+    pub action: Action,
+}
+
+impl ClassPermission {
+    /// Parse "b00t:EmbeddingModel:execute" → ClassPermission { class, action }
+    /// Uses `rsplitn(2, ':')` so the class can contain colons (e.g. "b00t:ChatModel").
+    pub fn parse(s: &str) -> Option<Self> {
+        let parts: Vec<&str> = s.rsplitn(2, ':').collect();
+        if parts.len() != 2 {
+            return None;
+        }
+        let action = match parts[0] {
+            "read" => Action::Read,
+            "write" => Action::Write,
+            "execute" => Action::Execute,
+            _ => return None,
+        };
+        Some(ClassPermission {
+            class: parts[1].to_string(),
+            action,
+        })
+    }
+}
+
+/// A registered API key entry stored in server-keys.json.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct KeyEntry {
+    pub consumer: String,
+    /// RFC 3339 timestamp of key creation (via chrono serde feature).
+    pub created_at: chrono::DateTime<chrono::Utc>,
+    /// Access permissions — empty means deny-all (v0.9+ behavior).
+    #[serde(default)]
+    pub access: Vec<ClassPermission>,
+}

--- a/b00t-c0re-lib/src/lib.rs
+++ b/b00t-c0re-lib/src/lib.rs
@@ -27,6 +27,7 @@ pub mod version {
 }
 
 pub mod aaiii;
+pub mod acl_keys;
 pub mod agent_coordination;
 pub mod agent_manager;
 pub mod agent_subtype;
@@ -69,6 +70,7 @@ pub mod template;
 pub mod utils;
 
 // Re-export commonly used types
+pub use acl_keys::{Action, ClassPermission, KeyEntry};
 pub use agent_subtype::AgentSubtype;
 pub use agent_manager::{
     AgentConfig, AgentHandle, AgentManager, ExecutorConfig, invoke_agent_executor,

--- a/b00t-cli/src/commands/server.rs
+++ b/b00t-cli/src/commands/server.rs
@@ -1,5 +1,6 @@
 // 🤓 b00t server — OpenAI-compatible router + API key authority
 //    Runs b00t-mcp in HTTP+LLM mode; manages keys via shared JSON file and OS keyring.
+use b00t_c0re_lib::{Action, ClassPermission, KeyEntry};
 use clap::Subcommand;
 use serde_json::Value;
 
@@ -100,15 +101,22 @@ pub fn handle_server_command(cmd: &ServerCommands) -> anyhow::Result<()> {
                     let keys = data["keys"]
                         .as_object_mut()
                         .ok_or_else(|| anyhow::anyhow!("invalid keys file"))?;
-                    let access_json: Vec<Value> = access.iter().map(|a| {
+                    // Build typed permission entries matching server_llm.rs format
+                    let access_entries: Vec<ClassPermission> = access.iter().map(|a| {
                         let (class, action) = a.rsplit_once(':').unwrap_or((a, "execute"));
-                        serde_json::json!({"class": class, "action": action})
+                        let action_enum = match action {
+                            "read" => Action::Read,
+                            "write" => Action::Write,
+                            _ => Action::Execute,
+                        };
+                        ClassPermission { class: class.to_string(), action: action_enum }
                     }).collect();
-                    keys.insert(key.clone(), serde_json::json!({
-                        "consumer": consumer,
-                        "created_at": chrono::Utc::now().to_rfc3339(),
-                        "access": access_json,
-                    }));
+                    let entry = KeyEntry {
+                        consumer: consumer.clone(),
+                        created_at: chrono::Utc::now(),
+                        access: access_entries,
+                    };
+                    keys.insert(key.clone(), serde_json::to_value(&entry)?);
                     if let Some(parent) = keys_path.parent() {
                         std::fs::create_dir_all(parent)?;
                     }

--- a/b00t-mcp/src/server_llm.rs
+++ b/b00t-mcp/src/server_llm.rs
@@ -16,6 +16,7 @@ use axum::{
     routing::{get, post},
 };
 use axum::http::header;
+pub use b00t_c0re_lib::{Action, ClassPermission, KeyEntry};
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 use std::collections::HashMap;
@@ -175,41 +176,7 @@ fn resolve_upstream(soul: &SoulConfig) -> (String, String) {
 }
 
 // ── ACL types (ontology-scoped) ────────────────────────────────────────────
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "lowercase")]
-pub enum Action { Read, Write, Execute }
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct ClassPermission {
-    pub class: String,
-    pub action: Action,
-}
-
-impl ClassPermission {
-    /// Parse "b00t:EmbeddingModel:execute" → ClassPermission { class, action }
-    pub fn parse(s: &str) -> Option<Self> {
-        let parts: Vec<&str> = s.rsplitn(2, ':').collect();
-        if parts.len() != 2 { return None; }
-        let action = match parts[0] {
-            "read" => Action::Read,
-            "write" => Action::Write,
-            "execute" => Action::Execute,
-            _ => return None,
-        };
-        Some(ClassPermission { class: parts[1].to_string(), action })
-    }
-}
-
-// ── State ──────────────────────────────────────────────────────────────────
-
-#[derive(Clone)]
-pub struct KeyEntry {
-    pub consumer: String,
-    pub created_at: chrono::DateTime<chrono::Utc>,
-    #[serde(default)]
-    pub access: Vec<ClassPermission>,
-}
+//    Types defined in b00t-c0re-lib/src/acl_keys.rs — imported via re-export above.
 
 pub struct LlmState {
     pub upstream_url: String,
@@ -296,15 +263,8 @@ impl LlmState {
         let keys = self.keys.read().await;
         let mut map = serde_json::Map::new();
         for (k, v) in keys.iter() {
-            let access_json: Vec<Value> = v.access.iter().map(|p| json!({
-                "class": p.class,
-                "action": serde_json::to_value(&p.action).unwrap_or(json!("execute")),
-            })).collect();
-            map.insert(k.clone(), json!({
-                "consumer": v.consumer,
-                "created_at": v.created_at.to_rfc3339(),
-                "access": access_json,
-            }));
+            // 🤓 Serialize via serde — identical format to b00t-cli's KeyAction::Create
+            map.insert(k.clone(), serde_json::to_value(v).unwrap_or_default());
         }
         let data = json!({"keys": map});
         if let Some(parent) = self.keys_file.parent() {


### PR DESCRIPTION
Action, ClassPermission, KeyEntry moved from b00t-mcp/src/server_llm.rs to b00t-c0re-lib/src/acl_keys.rs — shared between CLI and proxy for identical JSON format.

- CLI (server.rs) now builds typed KeyEntry struct and serializes via serde
- Proxy (server_llm.rs) save_keys_to_file uses serde_json::to_value() instead of manual JSON!
- Both paths guaranteed identical — any struct field change is now compile-time consistent

Note: blocked by #537/#538 submodule issue (b00t-reflect-types missing from workspace)