### PR TITLE
docs(browser): extend b00t plugin capability map

### DIFF
--- a/.github/workflows/b00t-cli-container.yml
+++ b/.github/workflows/b00t-cli-container.yml
@@ -29,7 +29,7 @@ jobs:
           ref: ${{ github.event_name == 'release' && github.event.release.tag_name || github.ref }}
 
       - name: Initialize required submodules
-        run: git submodule update --init --depth 1 vendor/l3dg3rr
+        run: git submodule update --init --depth 1 vendor/ledgrrr
 
       - name: Set up Just command runner
         uses: extractions/setup-just@v1

--- a/.github/workflows/l3dg3rr-docs.yml
+++ b/.github/workflows/l3dg3rr-docs.yml
@@ -41,7 +41,7 @@ jobs:
           submodules: false
 
       - name: Initialize workspace submodule deps
-        run: git submodule update --init --depth 1 vendor/embed-anything-b00t
+        run: git submodule update --init --depth 1 vendor/embed-anything-b00t vendor/ledgrrr
 
       - name: Set up Rust toolchain
         uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/l3dg3rr-vendor-docs.yml
+++ b/.github/workflows/l3dg3rr-vendor-docs.yml
@@ -4,15 +4,15 @@ on:
   push:
     branches: [main]
     paths:
-      - 'vendor/l3dg3rr'
-      - 'vendor/l3dg3rr/**'
+      - 'vendor/ledgrrr'
+      - 'vendor/ledgrrr/**'
       - '.gitmodules'
       - '.github/workflows/l3dg3rr-vendor-docs.yml'
   pull_request:
     branches: [main]
     paths:
-      - 'vendor/l3dg3rr'
-      - 'vendor/l3dg3rr/**'
+      - 'vendor/ledgrrr'
+      - 'vendor/ledgrrr/**'
       - '.gitmodules'
       - '.github/workflows/l3dg3rr-vendor-docs.yml'
   workflow_dispatch:
@@ -32,7 +32,7 @@ jobs:
           submodules: false
 
       - name: Initialize l3dg3rr submodule
-        run: git submodule update --init --recursive vendor/l3dg3rr
+        run: git submodule update --init --recursive vendor/ledgrrr
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
@@ -40,14 +40,14 @@ jobs:
       - name: Cache Rust/cargo
         uses: Swatinem/rust-cache@v2
         with:
-          workspaces: vendor/l3dg3rr
+          workspaces: vendor/ledgrrr
 
       - name: Install just
         uses: extractions/setup-just@v1
 
       - name: Install mdBook and plugins
         run: |
-          cd vendor/l3dg3rr
+          cd vendor/ledgrrr
           # 🤓 just docgen checks ~/.cargo/bin/mdbook — install everything via cargo
           # so all tools land in the same place. action-mdbook@v3 was removed because
           # it installs to a different prefix, causing null TOML values in the RenderContext
@@ -60,12 +60,12 @@ jobs:
 
       - name: Build l3dg3rr docs
         run: |
-          cd vendor/l3dg3rr
+          cd vendor/ledgrrr
           just docgen
 
       - name: Verify output
         run: |
-          cd vendor/l3dg3rr
+          cd vendor/ledgrrr
           test -d book/book && echo "✓ book/book directory exists" || { echo "✗ docs build failed"; exit 1; }
           test -f book/book/theory.html && echo "✓ theory.html generated" || { echo "✗ theory.html missing"; exit 1; }
           test -f book/book/index.html && echo "✓ index.html generated" || { echo "✗ index.html missing"; exit 1; }

--- a/.github/workflows/publish-crates.yml
+++ b/.github/workflows/publish-crates.yml
@@ -37,7 +37,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          git submodule update --init --depth 1 vendor/tomllm vendor/irontology-mcp
+          git submodule update --init --depth 1 vendor/tomllm vendor/irontology-mcp vendor/l3dg3rr
 
       - name: Setup Rust toolchain
         uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/publish-crates.yml
+++ b/.github/workflows/publish-crates.yml
@@ -37,7 +37,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          git submodule update --init --depth 1 vendor/tomllm vendor/irontology-mcp vendor/l3dg3rr
+          git submodule update --init --depth 1 vendor/tomllm vendor/irontology-mcp vendor/ledgrrr
 
       - name: Setup Rust toolchain
         uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          git submodule update --init --depth 1 vendor/tomllm vendor/irontology-mcp vendor/embed-anything-b00t vendor/l3dg3rr
+          git submodule update --init --depth 1 vendor/tomllm vendor/irontology-mcp vendor/embed-anything-b00t vendor/ledgrrr
 
       - name: Install just
         if: inputs.run_tests

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          git submodule update --init --depth 1 vendor/tomllm vendor/irontology-mcp vendor/embed-anything-b00t
+          git submodule update --init --depth 1 vendor/tomllm vendor/irontology-mcp vendor/embed-anything-b00t vendor/l3dg3rr
 
       - name: Install just
         if: inputs.run_tests

--- a/.github/workflows/rust-k0mmand3r.yml
+++ b/.github/workflows/rust-k0mmand3r.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Init required vendor submodules
         run: |
           set -euo pipefail
-          git submodule update --init --depth 1 vendor/tomllm vendor/irontology-mcp vendor/embed-anything-b00t vendor/l3dg3rr
+          git submodule update --init --depth 1 vendor/tomllm vendor/irontology-mcp vendor/embed-anything-b00t vendor/ledgrrr
 
       - name: install stable
         uses: actions-rs/toolchain@v1

--- a/.github/workflows/rust-k0mmand3r.yml
+++ b/.github/workflows/rust-k0mmand3r.yml
@@ -15,7 +15,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          # k0mmand3r tests do not require repo submodules.
           # Avoid recursive submodule checkout because orphan gitlinks can
           # break CI checkout before tests run.
           submodules: false
@@ -23,7 +22,7 @@ jobs:
       - name: Init required vendor submodules
         run: |
           set -euo pipefail
-          git submodule update --init --depth 1 vendor/tomllm vendor/irontology-mcp vendor/embed-anything-b00t
+          git submodule update --init --depth 1 vendor/tomllm vendor/irontology-mcp vendor/embed-anything-b00t vendor/l3dg3rr
 
       - name: install stable
         uses: actions-rs/toolchain@v1

--- a/.github/workflows/vendor-l3dg3rr-tests.yml
+++ b/.github/workflows/vendor-l3dg3rr-tests.yml
@@ -4,13 +4,13 @@ on:
   push:
     branches: [main]
     paths:
-      - 'vendor/l3dg3rr/**'
+      - 'vendor/ledgrrr/**'
       - '.gitmodules'
       - '.github/workflows/vendor-l3dg3rr-tests.yml'
   pull_request:
     branches: [main]
     paths:
-      - 'vendor/l3dg3rr/**'
+      - 'vendor/ledgrrr/**'
       - '.gitmodules'
       - '.github/workflows/vendor-l3dg3rr-tests.yml'
   workflow_dispatch:
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     defaults:
       run:
-        working-directory: vendor/l3dg3rr
+        working-directory: vendor/ledgrrr
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -35,7 +35,7 @@ jobs:
       - name: Initialize l3dg3rr submodule
         working-directory: ${{ github.workspace }}
         run: |
-          git submodule update --init --recursive vendor/l3dg3rr
+          git submodule update --init --recursive vendor/ledgrrr
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -43,7 +43,7 @@ jobs:
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@v2
         with:
-          workspaces: vendor/l3dg3rr
+          workspaces: vendor/ledgrrr
 
       - name: Build tests (compile check only)
         run: cargo test --workspace --no-run

--- a/.github/workflows/vendor-l3dg3rr-tests.yml
+++ b/.github/workflows/vendor-l3dg3rr-tests.yml
@@ -37,6 +37,18 @@ jobs:
         run: |
           git submodule update --init --recursive vendor/ledgrrr
 
+      - name: Install Linux native dependencies
+        working-directory: ${{ github.workspace }}
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            libayatana-appindicator3-dev \
+            libglib2.0-dev \
+            libgtk-3-dev \
+            librsvg2-dev \
+            libwebkit2gtk-4.1-dev \
+            pkg-config
+
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
 

--- a/.gitmodules
+++ b/.gitmodules
@@ -91,8 +91,8 @@
 	url = https://github.com/PromptExecution/just-mcp
 
 [submodule "vendor/ledgrrr"]
-	path = vendor/l3dg3rr
-	url = https://github.com/PromptExecution/l3dg3rr.git
+	path = vendor/ledgrrr
+	url = https://github.com/PromptExecution/ledgrrr.git
 
 [submodule "vendor/llama-patch"]
 	path = vendor/llama-patch
@@ -121,6 +121,3 @@
 [submodule "vscode.🆚/vscode-docs"]
 	path = vscode.🆚/vscode-docs
 	url = https://github.com/microsoft/vscode-docs
-
-[submodule "vendor/ledgrrr"]
-	path = vendor/ledgrrr

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,7 +73,7 @@ b00t-embed = { path = "b00t-embed" }
 b00t-datum-core = { path = "b00t-datum-core" }
 b00t-zellij = { path = "b00t-zellij" }
 b00t-admin = { path = "b00t-admin" }
-b00t-reflect-types = { path = "vendor/l3dg3rr/crates/b00t-reflect-types" }
+b00t-reflect-types = { path = "vendor/ledgrrr/crates/b00t-reflect-types" }
 mti = "1.1.1"
 
 

--- a/_b00t_/datums/BROWSER-USE-B00T-PLUGIN.tomllmd
+++ b/_b00t_/datums/BROWSER-USE-B00T-PLUGIN.tomllmd
@@ -52,6 +52,39 @@ capabilities = [
 visible_tab  = "chrome.tabs.captureVisibleTab (instant)"
 full_page    = "CDP Page.captureScreenshot + viewport resize to content dimensions"
 
+[full_access_tab_snapshot]
+goal = "Produce a single agent-readable snapshot of the active tab without requiring fragile CSS selector discovery."
+sources = [
+  "DOM: window.__b00t.findB00t('*') flattened into stable element records",
+  "Accessibility: ARIA role/name/state when available; never rely only on CSS classes",
+  "Viewport: visible screenshot via chrome.tabs.captureVisibleTab",
+  "Full page: CDP Page.captureScreenshot after layout metrics + temporary viewport override",
+  "Runtime: document.title, URL, scroll position, focused element, selected text, local form values",
+  "Network: optional HAR-like summary from CDP Network events when debugger is attached",
+]
+output_contract = "TabSnapshot { url, title, timestamp, viewport, elements[], forms[], tables[], screenshots{visible,full?}, network_summary? }"
+privacy_boundary = "Default snapshot excludes cookies, localStorage, sessionStorage, request bodies, password inputs, and Authorization headers unless an explicit guarded workflow requests them."
+storage = "Store snapshots under .b00t/browser-snapshots/<session>/<timestamp>.json with screenshot blobs beside the JSON; promote stable fixtures into tests only after redaction."
+
+[capability_map]
+driver_primary = "Playwright for normal RPA: cross-browser, auto-waiting, tracing, codegen, locator semantics."
+driver_performance = "b00t-rpa/chromiumoxide for high-throughput Chrome CDP, local Rust execution, and direct enrichment injection."
+driver_extension = "Chrome extension for in-browser DOM enrichment, side panel command curation, visible/full-page screenshots, and chrome.debugger access."
+driver_selector_authoring = "Selector Forge as complementary human-in-the-loop selector generation; do not duplicate its re-verification UI."
+novel_surface = "data-b00t-* enrichment + ontology-classed TabSnapshot records; this is the b00t-specific capability."
+avoid_reinventing = [
+  "Do not rebuild Playwright auto-waiting, trace viewer, browser installation, or cross-browser abstraction.",
+  "Do not build a general CSS/XPath selector recommender when Selector Forge can cover authoring.",
+  "Do not keep bespoke relay code when socat/netsh/Rust tcp proxy can provide a smaller WSL bridge.",
+]
+missing_now = [
+  "LLM action planner over TabSnapshot",
+  "Record/replay event capture",
+  "Cross-tab workflow identity",
+  "Session save/load with redacted encrypted storage",
+  "Extraction pipeline for tables, PDFs, and ledgerr ingestion",
+]
+
 [command_palette]
 interface     = "Chrome sidePanel (panel.html)"
 filter        = "fzf-like fuzzy search on type"
@@ -69,6 +102,51 @@ cli_commands  = [
 ]
 tui_controls = "j/k navigate, Enter add, Backspace remove, Esc exit, type to filter"
 
+[workflow_mapping]
+stage_1_observe = "Capture TabSnapshot from extension or b00t-rpa; normalize DOM, forms, tables, screenshots, and page state."
+stage_2_orient = "Classify elements against b00t ontology classes: b00t:Button, b00t:Input, b00t:Form, b00t:Navigation, b00t:TransactionTable, b00t:DownloadLink."
+stage_3_decide = "Use sm0l for element shortlist, ch0nky for workflow step selection, frontier only for ambiguous page semantics."
+stage_4_act = "Execute through Playwright by default; fall back to b00t-rpa CDP when extension-only capability or high-throughput Rust path is needed."
+stage_5_verify = "Re-snapshot after each action; compare expected ontology state transition before continuing."
+stage_6_audit = "Persist action log + before/after snapshot hashes as ledgerr evidence nodes."
+
+[install_deploy_plan]
+local_dev = "b00t-rpa plugin copies _b00t_/browser-plugin into a Chrome user-data-dir and launches Chrome with --load-extension."
+wsl_bridge = "Prefer netsh portproxy or embedded Rust TCP forwarder over the current Python relay; keep socat recipe for operator debugging."
+managed_extension = "Package b00t-browser-ext separately when enterprise policy or Chrome Web Store deployment is required."
+ci_smoke = "Headless Playwright test opens a fixture page, injects content.js, verifies data-b00t attributes, captures a snapshot, and validates JSON schema."
+mcp_surface = "Expose snapshot, act, verify, and extract as MCP tools after the snapshot contract is stable."
+
+[cache_wasm_options]
+snapshot_cache = "Content-address TabSnapshot JSON by hash(url, dom_version, viewport, enrichment_version); expire on navigation, mutation burst, or explicit refresh."
+asset_cache = "Cache screenshots and downloaded files by SHA-256; store only redacted metadata in ledgerr evidence by default."
+wasm_candidate = "Move pure enrichment/classification functions into a WASM module only after the JS implementation stabilizes and test fixtures exist."
+wasm_not_now = "Do not port the CDP bridge, Playwright driver, or Chrome extension APIs to WASM; those are host/browser-bound integration surfaces."
+offline_eval = "Replay cached snapshots through sm0l/ch0nky planners without launching Chrome; use this for regression tests and fine-tuning examples."
+
+[ontological_evaluation]
+classes = [
+  "b00t:BrowserTab",
+  "b00t:TabSnapshot",
+  "b00t:EnrichedElement",
+  "b00t:FormField",
+  "b00t:ActionPlan",
+  "b00t:WorkflowTransition",
+  "b00t:EvidenceNode",
+]
+constraints = [
+  "Every ActionPlan MUST cite at least one EnrichedElement selector or a page-level operation.",
+  "Every workflow step MUST have before_snapshot_hash and after_snapshot_hash when executed.",
+  "Password-like fields MUST be redacted in persisted snapshots.",
+  "A successful action MUST satisfy the expected ontology transition before the next step starts.",
+]
+metrics = [
+  "selector_survival_rate across CSS redesign fixtures",
+  "snapshot_redaction_pass_rate for sensitive fields",
+  "planner_action_accuracy on cached workflow fixtures",
+  "time_to_first_action for Playwright vs b00t-rpa CDP path",
+]
+
 [[related]]
 datum = "B00T-FINETUNE-PIPELINE"
 note  = "Fine-tuned ch0nky subagent uses this plugin for browser-based eval"
@@ -82,8 +160,8 @@ datum = "PRD-ARCH-009-OTEL-SESSION-METRICS"
 note  = "CDP telemetry → session metrics for agent OODA loop"
 
 # b00t:map v1
-# summary: Chrome extension + CDP bridge for DOM enrichment, screen capture, and RPA command palette
-# tags: browser, rpa, cdp, dom-enrichment, screenshot, plugin, ch0nky
+# summary: Chrome extension + CDP bridge with TabSnapshot capability map, workflow plan, cache/WASM boundaries, and ontology evaluation
+# tags: browser, rpa, cdp, dom-enrichment, screenshot, plugin, tabsnapshot, workflow, wasm, ch0nky
 # tier: ch0nky
-# cmds: b00t-rpa plugin, b00t-rpa start, b00t-rpa --url <url>
-# complexity: 6
+# cmds: b00t-rpa plugin, b00t-rpa start, b00t-rpa --url <url>, b00t-rpa snapshot
+# complexity: 8

--- a/_b00t_/datums/BROWSER-USE-B00T-PLUGIN.tomllmd
+++ b/_b00t_/datums/BROWSER-USE-B00T-PLUGIN.tomllmd
@@ -164,4 +164,7 @@ note  = "CDP telemetry → session metrics for agent OODA loop"
 # tags: browser, rpa, cdp, dom-enrichment, screenshot, plugin, tabsnapshot, workflow, wasm, ch0nky
 # tier: ch0nky
 # cmds: b00t-rpa plugin, b00t-rpa start, b00t-rpa --url <url>, b00t-rpa snapshot
+# @tribal: complexity 8 because 6 new architecture sections (TabSnapshot contract,
+#   capability map, OODA workflow, install/deploy plan, cache/WASM boundaries,
+#   ontology evaluation) — no longer a simple capability sketch.
 # complexity: 8

--- a/_b00t_/datums/CAP-ONTOLOGY-INDEX.tomllmd
+++ b/_b00t_/datums/CAP-ONTOLOGY-INDEX.tomllmd
@@ -61,21 +61,21 @@ note      = "Edges = shared role membership, not semantic predicate graph"
 tier      = "sm0l"
 
 [native.holon_node_type_graph]
-location  = "vendor/l3dg3rr/crates/holon-viz + b00t-reflect-types"
+location  = "vendor/ledgrrr/crates/holon-viz + b00t-reflect-types"
 what      = "HolonEmit proc-macro → HolonNode → TypeRelationshipGraph → Cytoscape JSON"
 invoke    = "DatumType::datum_nodes(); VizDomain::emit_nodes()"
 note      = "l3dg3rr workspace only — not wired to b00t-cli binary yet"
 tier      = "sm0l"
 
 [native.ufo_stereotypes]
-location  = "vendor/l3dg3rr/crates/ufo-types/src/"
+location  = "vendor/ledgrrr/crates/ufo-types/src/"
 what      = "EndurantStereotype, PerdurantStereotype, MomentStereotype, UfoCategory; Satisfies<C> trait"
 invoke    = "b00t learn ufo-types"
 note      = "Rust types only; the UFO narrative spec is external (see [external.ufo_spec])"
 tier      = "ch0nky"
 
 [native.rust_ast_extractor]
-location  = "vendor/l3dg3rr/crates/ontology-extractor/src/lib.rs"
+location  = "vendor/ledgrrr/crates/ontology-extractor/src/lib.rs"
 what      = "Walks Rust source via syn → RustTerm/OntologyGraph (Entity vs Action classification)"
 invoke    = "cargo run -p ontology-extractor -- --crate-path <PATH>"
 tier      = "ch0nky"
@@ -173,7 +173,7 @@ hier_fields = ["rdfs:subClassOf"]
 entry_count_approx = 80
 
 [external.ufo_spec.adapter]
-# Native Rust: ufo-types crate in vendor/l3dg3rr IS the Rust implementation
+# Native Rust: ufo-types crate in vendor/ledgrrr IS the Rust implementation
 b00t_skill  = "ufo-types"
 learn_cmd   = "b00t learn ufo-types"
 sparql_when_oxigraph = "SELECT ?class WHERE { ?class rdfs:subClassOf gufo:Endurant }"

--- a/_b00t_/datums/PRD-ARCH-005-MBSE-VISUALIZATION.tomllmd
+++ b/_b00t_/datums/PRD-ARCH-005-MBSE-VISUALIZATION.tomllmd
@@ -13,13 +13,13 @@ tier   = "ch0nky"
 closes_task = 28
 
 # ─── Executive Summary ───────────────────────────────────────────────────────
-# vendor/l3dg3rr contains a KerML/SysMLv2 ontology with typed domains, relations,
+# vendor/ledgrrr contains a KerML/SysMLv2 ontology with typed domains, relations,
 # and classifiers. irontology-mcp can query DatumNodes but has no diagram export.
 # This PRD adds `b00t ontology diagram` to generate Mermaid and SysMLv2 graphs
 # from the live irontology-mcp knowledge graph — enabling MBSE visualization.
 
 [current_state]
-l3dg3rr_types = "vendor/l3dg3rr/types/domain.kerm — KerML [[type]] arrays"
+l3dg3rr_types = "vendor/ledgrrr/types/domain.kerm — KerML [[type]] arrays"
 irontology    = "vendor/irontology-mcp — DatumNode store, query via mcp tool"
 missing       = ["diagram export", "Mermaid codegen", "SysMLv2 part definition export"]
 
@@ -27,7 +27,7 @@ missing       = ["diagram export", "Mermaid codegen", "SysMLv2 part definition e
 # domain.kerm defines [[type]] blocks: id, label, kind, supertype, ufo_category
 # irontology DatumStore indexes by class → can query by supertype chain
 # New: traverse supertype graph → emit Mermaid classDiagram or SysMLv2 block def
-kerm_source   = "vendor/l3dg3rr/types/domain.kerm"
+kerm_source   = "vendor/ledgrrr/types/domain.kerm"
 datum_class   = "b00t:KermTypeNode"
 query_pattern = "b00t ontology query --class <id> --depth=3"
 

--- a/_b00t_/datums/PRD-ARCH-013-VLLM-OODA-STATIG.tomllmd
+++ b/_b00t_/datums/PRD-ARCH-013-VLLM-OODA-STATIG.tomllmd
@@ -19,7 +19,7 @@ closes_task = 48
 # C. Add A2A sm0l error classification: route errors through local sm0l HTTP endpoint.
 #
 # Status of statig: v0.4.1 on crates.io; NOT yet in b00t workspace Cargo.toml.
-# Status of kani: used only in vendor/l3dg3rr/kani-proofs; NOT in main workspace.
+# Status of kani: used only in vendor/ledgrrr/kani-proofs; NOT in main workspace.
 # Status of quadlet: hive.rs generates .service units only; no .container codegen.
 # Status of sm0l: hive profile defined but no Rust classifier exists.
 

--- a/_b00t_/datums/PRD-F0UNDRY-AGENT-ONTOLOGY.tomllmd
+++ b/_b00t_/datums/PRD-F0UNDRY-AGENT-ONTOLOGY.tomllmd
@@ -114,7 +114,7 @@ p40_composite_mat  = "HiveProfile composes Agents + Skills + MCPs → composite 
 
 [kerml_sysml_fusion]
 # KerML = kernel of SysMLv2. Provides the semantic backbone for composition.
-# Both are expressed as [[type]] TOML arrays in vendor/l3dg3rr/types/domain.kerm.
+# Both are expressed as [[type]] TOML arrays in vendor/ledgrrr/types/domain.kerm.
 
 [kerml_sysml_fusion.mapping_table]
 # KerML concept     → Rust construct              → b00t usage
@@ -431,7 +431,7 @@ fusion_point = "b00t-mcp.mcp.toml + SysMLv2 port def + UFO Moment::Relator"
 [[synergy_map.synergy]]
 name = "KerML Feature Typing × Satisfies<C>"
 description = "KerML Feature typing constrains which entities compose. Satisfies<C> is the Rust implementation of this constraint at runtime. The f0undry bridges compile-time (KerML type system) and runtime (Satisfies evaluation with evidence nodes)."
-fusion_point = "ufo-types/src/satisfies.rs Satisfies<C> + vendor/l3dg3rr/types/domain.kerm"
+fusion_point = "ufo-types/src/satisfies.rs Satisfies<C> + vendor/ledgrrr/types/domain.kerm"
 
 [[synergy_map.synergy]]
 name = "UFO Moment::Relator × SatisfiesBinding"
@@ -503,7 +503,7 @@ items = [
 # ═══════════════════════════════════════════════════════════════════════════════
 
 [b00t_kerm_types]
-# Following the format of vendor/l3dg3rr/types/domain.kerm.
+# Following the format of vendor/ledgrrr/types/domain.kerm.
 # This block declares what should be written to _b00t_/types/b00tyverse.kerm.
 file_to_create = "_b00t_/types/b00tyverse.kerm"
 

--- a/_b00t_/datums/PRD-ONTOLOGY-OODA-UFO-SYSML.tomllmd
+++ b/_b00t_/datums/PRD-ONTOLOGY-OODA-UFO-SYSML.tomllmd
@@ -46,11 +46,11 @@ acceptance_criteria = [
 ]
 
 # ─── KerML-profile type layer (b00t 'physics') ───────────────────────────────
-# @tribal: KerML is the kernel of SysMLv2; domain.kerm in vendor/l3dg3rr/types/
+# @tribal: KerML is the kernel of SysMLv2; domain.kerm in vendor/ledgrrr/types/
 #          uses [[type]] TOML arrays — we follow the same format for b00t ontology.
 [kerml_profile]
 file_to_create = "_b00t_/types/b00t_ooda.kerm"
-extends        = "vendor/l3dg3rr/types/domain.kerm"
+extends        = "vendor/ledgrrr/types/domain.kerm"
 
 # KerML 'Classifier' hierarchy for OODA phases
 [[kerml_profile.type]]

--- a/_b00t_/datums/PRD-TAX-LAWYER-UFO-SDD.tomllmd
+++ b/_b00t_/datums/PRD-TAX-LAWYER-UFO-SDD.tomllmd
@@ -233,9 +233,9 @@ iso      = "crates/ufo-types/src/iso.rs"
 cargo    = "crates/ufo-types/Cargo.toml"
 
 [issue.510.docs_to_update_on_ship]
-- "vendor/l3dg3rr/AGENTS.md: add section on ufo-types module"
-- "vendor/l3dg3rr/docs/architecture.md: add ufo-types layer to architecture diagram"
-- "vendor/l3dg3rr/book/src/theory.md: add UFO grounding section"
+- "vendor/ledgrrr/AGENTS.md: add section on ufo-types module"
+- "vendor/ledgrrr/docs/architecture.md: add ufo-types layer to architecture diagram"
+- "vendor/ledgrrr/book/src/theory.md: add UFO grounding section"
 
 # ═══════════════════════════════════════════════════════════════════════════════
 # ISSUE #511: AU R&D Tax Incentive — domain ontology + satisfies impls
@@ -362,9 +362,9 @@ au_rd        = "crates/ledger-core/src/au_rd.rs"
 evidence_ext = "crates/arc-kit-au/src/node.rs"  // extended
 
 [issue.511.docs_to_update_on_ship]
-- "vendor/l3dg3rr/docs/mcp-capability-contract.md: add au_rd_* actions"
-- "vendor/l3dg3rr/AGENTS.md: add AU R&D section"
-- "vendor/l3dg3rr/rules/ONTOLOGY.md: add classify_au_rd_eligible.rhai"
+- "vendor/ledgrrr/docs/mcp-capability-contract.md: add au_rd_* actions"
+- "vendor/ledgrrr/AGENTS.md: add AU R&D section"
+- "vendor/ledgrrr/rules/ONTOLOGY.md: add classify_au_rd_eligible.rhai"
 
 # ═══════════════════════════════════════════════════════════════════════════════
 # ISSUE #512: US R&D Tax Credit — domain ontology + satisfies impls
@@ -424,8 +424,8 @@ DoD: Both methods produce correct values for known test cases.
 us_rdc = "crates/ledger-core/src/us_rdc.rs"
 
 [issue.512.docs_to_update_on_ship]
-- "vendor/l3dg3rr/book/src/tax.md: add US R&D Tax Credit chapter"
-- "vendor/l3dg3rr/docs/mcp-capability-contract.md: add us_rdc_* actions"
+- "vendor/ledgrrr/book/src/tax.md: add US R&D Tax Credit chapter"
+- "vendor/ledgrrr/docs/mcp-capability-contract.md: add us_rdc_* actions"
 
 # ═══════════════════════════════════════════════════════════════════════════════
 # ISSUE #513: Crypto cost basis — cross-jurisdiction ontology + satisfies
@@ -502,8 +502,8 @@ crypto     = "crates/ledger-core/src/crypto.rs"
 rules_au   = "rules/classify_crypto_au.rhai"
 
 [issue.513.docs_to_update_on_ship]
-- "vendor/l3dg3rr/rules/ONTOLOGY.md: add crypto-au rule docs"
-- "vendor/l3dg3rr/docs/crypto.md: new crypto tax reference"
+- "vendor/ledgrrr/rules/ONTOLOGY.md: add crypto-au rule docs"
+- "vendor/ledgrrr/docs/crypto.md: new crypto tax reference"
 
 # ═══════════════════════════════════════════════════════════════════════════════
 # ISSUE #514: MCP action layer — thin JSON-RPC wrappers over Satisfies
@@ -615,8 +615,8 @@ us_rdc_handler = "crates/ledgerr-mcp/src/us_rdc.rs"       // NEW: thin handlers
 crypto_handler = "crates/ledgerr-mcp/src/crypto.rs"       // NEW: thin handlers
 
 [issue.514.docs_to_update_on_ship]
-- "vendor/l3dg3rr/docs/mcp-capability-contract.md: regenerated"
-- "vendor/l3dg3rr/docs/agent-mcp-runbook.md: regenerated"
+- "vendor/ledgrrr/docs/mcp-capability-contract.md: regenerated"
+- "vendor/ledgrrr/docs/agent-mcp-runbook.md: regenerated"
 - "scripts/mcp_cli_demo.sh: regenerated"
 
 # ═══════════════════════════════════════════════════════════════════════════════
@@ -766,22 +766,22 @@ becomes the uniform evaluation pattern — every tax check is
 # ═══════════════════════════════════════════════════════════════════════════════
 [documents_to_update]
 by_issue = '''
-#510 → vendor/l3dg3rr/AGENTS.md (add ufo-types section)
-       vendor/l3dg3rr/docs/architecture.md (add ontology layer)
-       vendor/l3dg3rr/book/src/theory.md (add UFO grounding)
+#510 → vendor/ledgrrr/AGENTS.md (add ufo-types section)
+       vendor/ledgrrr/docs/architecture.md (add ontology layer)
+       vendor/ledgrrr/book/src/theory.md (add UFO grounding)
 
-#511 → vendor/l3dg3rr/docs/mcp-capability-contract.md (au_rd_* actions)
-       vendor/l3dg3rr/AGENTS.md (AU R&D workflow)
-       vendor/l3dg3rr/rules/ONTOLOGY.md (classify_au_rd_eligible.rhai)
+#511 → vendor/ledgrrr/docs/mcp-capability-contract.md (au_rd_* actions)
+       vendor/ledgrrr/AGENTS.md (AU R&D workflow)
+       vendor/ledgrrr/rules/ONTOLOGY.md (classify_au_rd_eligible.rhai)
 
-#512 → vendor/l3dg3rr/book/src/tax.md (US R&D credit chapter)
-       vendor/l3dg3rr/docs/mcp-capability-contract.md (us_rdc_* actions)
+#512 → vendor/ledgrrr/book/src/tax.md (US R&D credit chapter)
+       vendor/ledgrrr/docs/mcp-capability-contract.md (us_rdc_* actions)
 
-#513 → vendor/l3dg3rr/rules/ONTOLOGY.md (classify_crypto_au.rhai)
-       vendor/l3dg3rr/docs/crypto.md (new crypto tax reference)
+#513 → vendor/ledgrrr/rules/ONTOLOGY.md (classify_crypto_au.rhai)
+       vendor/ledgrrr/docs/crypto.md (new crypto tax reference)
 
-#514 → vendor/l3dg3rr/docs/mcp-capability-contract.md (regenerated)
-       vendor/l3dg3rr/docs/agent-mcp-runbook.md (regenerated)
+#514 → vendor/ledgrrr/docs/mcp-capability-contract.md (regenerated)
+       vendor/ledgrrr/docs/agent-mcp-runbook.md (regenerated)
        scripts/mcp_cli_demo.sh (regenerated)
 
 #515 → AGENTS.md (tax-lawyer skills)

--- a/_b00t_/datums/VENDOR-L3DG3RR.tomllmd
+++ b/_b00t_/datums/VENDOR-L3DG3RR.tomllmd
@@ -2,7 +2,7 @@
 # 🤓 Rust ledger and governance system for b00t — accounting, audit, Xero integration
 #    Repo: github.com/PromptExecution/ledgrrr
 #    Language: Rust
-#    Path: vendor/l3dg3rr
+#    Path: vendor/ledgrrr
 
 [b00t]
 name = "VENDOR-L3DG3RR"
@@ -14,12 +14,12 @@ schema = 1
 content = "stable"
 
 [b00t.vendor]
-path = "vendor/l3dg3rr"
+path = "vendor/ledgrrr"
 upstream = "git@github.com:PromptExecution/ledgrrr.git"
 branch = "main"
-build_command = "cargo build --manifest-path vendor/l3dg3rr/Cargo.toml --release"
-install_command = "cp vendor/l3dg3rr/target/release/ledgerr-mcp ~/.local/bin/ && cp vendor/l3dg3rr/target/release/host-tauri ~/.local/bin/"
-health_check = "vendor/l3dg3rr/target/release/ledgerr-mcp --version || test -x vendor/l3dg3rr/target/release/ledgerr-mcp"
+build_command = "cargo build --manifest-path vendor/ledgrrr/Cargo.toml --release"
+install_command = "cp vendor/ledgrrr/target/release/ledgerr-mcp ~/.local/bin/ && cp vendor/ledgrrr/target/release/host-tauri ~/.local/bin/"
+health_check = "vendor/ledgrrr/target/release/ledgerr-mcp --version || test -x vendor/ledgrrr/target/release/ledgerr-mcp"
 required_tools = ["rustc", "cargo", "just"]
 
 [b00t.maintenance]
@@ -69,7 +69,7 @@ accounting workflows.
 
 Build all binaries:
 ```
-cargo build --manifest-path vendor/l3dg3rr/Cargo.toml --release
+cargo build --manifest-path vendor/ledgrrr/Cargo.toml --release
 ```
 
 Tauri desktop host requires system libs (webkit2gtk on Linux).

--- a/_b00t_/datums/VENDOR-LEDGRRR.tomllmd
+++ b/_b00t_/datums/VENDOR-LEDGRRR.tomllmd
@@ -31,12 +31,12 @@ review_required = true
 ## What is it?
 
 A direct git checkout of the same PromptExecution/ledgrrr repository that
-vendor/l3dg3rr references as a submodule. This separate checkout exists for
+vendor/ledgrrr references as a submodule. This separate checkout exists for
 development workflows that need an independent working tree.
 
 ## Notes
 
-- Shares identical codebase with vendor/l3dg3rr
+- Shares identical codebase with vendor/ledgrrr
 - Same build commands, binaries, and interfaces
 - Used for parallel development or testing without affecting the submodule
 - See VENDOR-L3DG3RR.tomllmd for full documentation of capabilities

--- a/_b00t_/ledgrrr.cli.toml
+++ b/_b00t_/ledgrrr.cli.toml
@@ -1,10 +1,10 @@
 [b00t]
 name = "ledgrrr"
 type = "cli"
-hint = "FinOps ledger — consumes/produces FOCUS records via gRPC/Arrow transport. Polyseme: l3dg3rr[#proto] → ledgerr-mcp[#linux] → ledg3rr[#cloud/stable] → ledgrrr[#windows/lts]. Vendored at vendor/l3dg3rr/crates/ledgerr-mcp/."
+hint = "FinOps ledger — consumes/produces FOCUS records via gRPC/Arrow transport. Polyseme: l3dg3rr[#proto] → ledgerr-mcp[#linux] → ledg3rr[#cloud/stable] → ledgrrr[#windows/lts]. Vendored at vendor/ledgrrr/crates/ledgerr-mcp/."
 
 # @tribal: polyseme mapping — platform-targeted variants of the same ledger:
-#   l3dg3rr      — proto/repo name (vendor/l3dg3rr/)
+#   l3dg3rr      — proto/repo name (vendor/ledgrrr/)
 #   ledgerr-mcp  — Linux native (vendored crate prefix, stdio MCP transport)
 #   ledg3rr      — cloud/remote (gRPC/Arrow, SaaS deployment)
 #   ledgrrr      — Windows native (tray-icon, Slint desktop host, Credential Manager)
@@ -22,7 +22,7 @@ hint = "FinOps ledger — consumes/produces FOCUS records via gRPC/Arrow transpo
 # LTS phase: ledgrrr — production FinOps ledger with FOCUS crate
 
 detect = [
-    "test -f vendor/l3dg3rr/Cargo.toml",
+    "test -f vendor/ledgrrr/Cargo.toml",
     "echo '0.1.0-proto'",
 ]
 version_regex = '(?P<version>[\\d.]+)'
@@ -42,7 +42,7 @@ connect_timeout_sec = 5
 stream_type = "dataframe"
 
 [b00t.providers.focus]
-# FOCUS v1.3 crate at vendor/l3dg3rr/crates/ledgerr-focus/
+# FOCUS v1.3 crate at vendor/ledgrrr/crates/ledgerr-focus/
 # Full spec: https://focus.finops.org/focus-specification/v1-3/
 # GitHub: https://github.com/FinOps-Open-Cost-and-Usage-Spec/FOCUS_Spec
 # CostAndUsage dataset: BilledCost, EffectiveCost, ChargeCategory, etc.

--- a/_b00t_/plans/b00t-server-architecture.tomllmd
+++ b/_b00t_/plans/b00t-server-architecture.tomllmd
@@ -119,7 +119,7 @@ export OPENAI_API_KEY=$(cat /tmp/rust-doc-key.env | grep -oP 'b00t-sk-\S+')
 ## Phase 3: Usage Telemetry ("Spotlight" — renamed from FOCUS to avoid collision)
 
 🚩 **Naming**: "FOCUS records" already exists in b00t as FinOps billing records
-(`b00t-cli/src/commands/focus.rs`, sourced from `vendor/l3dg3rr`). The new
+(`b00t-cli/src/commands/focus.rs`, sourced from `vendor/ledgrrr`). The new
 popularity/usage concept is renamed **Spotlight** in this plan. (Bikeshed: `Focus`
 → `Spotlight` preserves the mental model of "what's getting attention" while
 sidestepping the FinOps collision.)

--- a/_b00t_/schema/INSTALLER-CAPABILITY.tomllmd
+++ b/_b00t_/schema/INSTALLER-CAPABILITY.tomllmd
@@ -185,8 +185,8 @@ vendor_datum = "VENDOR-LEDGRRR"
 
 [[b00t.check]]
 name = "l3dg3rr-mcp"
-check_command = "vendor/l3dg3rr/target/release/ledgerr-mcp --version || test -x vendor/l3dg3rr/target/release/ledgerr-mcp"
-remediation = "cargo build --manifest-path vendor/l3dg3rr/Cargo.toml --release && cp vendor/l3dg3rr/target/release/ledgerr-mcp ~/.local/bin/ && cp vendor/l3dg3rr/target/release/host-tauri ~/.local/bin/"
+check_command = "vendor/ledgrrr/target/release/ledgerr-mcp --version || test -x vendor/ledgrrr/target/release/ledgerr-mcp"
+remediation = "cargo build --manifest-path vendor/ledgrrr/Cargo.toml --release && cp vendor/ledgrrr/target/release/ledgerr-mcp ~/.local/bin/ && cp vendor/ledgrrr/target/release/host-tauri ~/.local/bin/"
 required = true
 vendor_datum = "VENDOR-L3DG3RR"
 

--- a/_b00t_/scripts/wow/check-vendor-dockerfile.rhai
+++ b/_b00t_/scripts/wow/check-vendor-dockerfile.rhai
@@ -1,8 +1,8 @@
 // check-vendor-dockerfile.rhai — WOW rule C9: vendor IS upstream
 // Verifies the Dockerfile lives in the vendored source, not in dotfiles root.
-if file_exists("vendor/l3dg3rr/Dockerfile.ledgerr-mcp") {
-    log_success("vendor Dockerfile exists at vendor/l3dg3rr/Dockerfile.ledgerr-mcp");
+if file_exists("vendor/ledgrrr/Dockerfile.ledgerr-mcp") {
+    log_success("vendor Dockerfile exists at vendor/ledgrrr/Dockerfile.ledgerr-mcp");
 } else {
     log_error("Dockerfile not found in vendor tree");
-    throw("C9: Dockerfile must live in vendor/l3dg3rr/, not in dotfiles root");
+    throw("C9: Dockerfile must live in vendor/ledgrrr/, not in dotfiles root");
 }


### PR DESCRIPTION
## Summary

- Extends BROWSER-USE-B00T-PLUGIN datum with a full-access TabSnapshot contract
- Adds browser/RPA capability map with explicit boundaries against Playwright and Selector Forge reinvention
- Adds workflow mapping, install/deploy plan, cache/WASM boundaries, and ontology evaluation metrics

## Validation

- tomlq -r '.datum.id' _b00t_/datums/BROWSER-USE-B00T-PLUGIN.tomllmd
- git diff --check -- _b00t_/datums/BROWSER-USE-B00T-PLUGIN.tomllmd
- b00t task list -> no active tasks

## Notes

- AES-GCM tracking already exists as #544; no duplicate issue created.
