### PR TITLE
ci: remove legacy l3dg3rr submodule init

### DIFF
--- a/.github/workflows/rust-k0mmand3r.yml
+++ b/.github/workflows/rust-k0mmand3r.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Init required vendor submodules
         run: |
           set -euo pipefail
-          git submodule update --init --depth 1 vendor/tomllm vendor/irontology-mcp vendor/embed-anything-b00t vendor/ledgrrr vendor/l3dg3rr
+          git submodule update --init --depth 1 vendor/tomllm vendor/irontology-mcp vendor/embed-anything-b00t vendor/ledgrrr
 
       - name: install stable
         uses: actions-rs/toolchain@v1


### PR DESCRIPTION
## Summary
- rebase browser plugin branch onto current origin/main
- keep vendor/ledgrrr canonical and remove vendor/l3dg3rr from K0mmand3r submodule init

## Verification
- YAML parse for .github/workflows/rust-k0mmand3r.yml
- git diff --check origin/main..HEAD