### PR TITLE
feat(desktop): add just recipes for Tauri host (build/launch/deps)

### DIFF
--- a/justfile
+++ b/justfile
@@ -188,6 +188,24 @@ dev-link:
       "${CARGO_HOME:-$HOME/.cargo}/bin/b00t"
     @echo "🔗 ${CARGO_HOME:-$HOME/.cargo}/bin/b00t → {{justfile_directory()}}/target/debug/b00t"
 
+# 🖥️  Build the Tauri desktop host (ledgerr-tauri) from the vendor submodule.
+#    Requires: libwebkit2gtk-4.1-dev + 9 other packages (run check-tauri-deps.sh).
+desktop-build:
+    cargo build -p ledgerr-tauri --manifest-path vendor/ledgrrr/Cargo.toml
+    ln -sf "{{justfile_directory()}}/vendor/ledgrrr/target/debug/ledgerr-tauri" \
+      "${CARGO_HOME:-$HOME/.cargo}/bin/ledgerr-tauri"
+    @echo "🖥️  Built ledgerr-tauri → ~/.cargo/bin/ledgerr-tauri"
+
+# 🖥️  Launch the Tauri desktop host on the current display.
+#    Use `just desktop-launch &` to background it.
+desktop-launch display=":0":
+    @echo "🖥️  Launching ledgerr-tauri on DISPLAY={{display}}..."
+    ledgerr-tauri
+
+# 🖥️  Check Tauri v2 build dependencies (read-only).
+desktop-deps:
+    bash {{justfile_directory()}}/scripts/check-tauri-deps.sh
+
 # Bump patch version + cargo install — always pair these together
 # 🤓 never cargo install without bumping version; tracks deployed vs source
 # ⚠️ Warning: `cargo install --force` overwrites the dev symlink in ~/.cargo/bin.

--- a/scripts/check-tauri-deps.sh
+++ b/scripts/check-tauri-deps.sh
@@ -200,12 +200,18 @@ verify_after_install() {
   echo ""
   local errors=0
   for pc in "${!PC_CHECKS[@]}"; do
+    local apt_pkg="${PC_CHECKS[$pc]}"
     if pkg-config --exists "$pc" 2>/dev/null; then
       local ver
       ver=$(pkg-config --modversion "$pc" 2>/dev/null)
       echo -e "  ${GREEN}✅${NC} $pc  (v${ver})"
+    elif dpkg -s "$apt_pkg" 2>/dev/null | grep -q 'Status: install ok installed'; then
+      # Some packages (e.g. libxdo-dev) don't ship a .pc file
+      local ver
+      ver=$(dpkg -s "$apt_pkg" 2>/dev/null | grep '^Version:' | cut -d' ' -f2)
+      echo -e "  ${GREEN}✅${NC} $pc  (installed via $apt_pkg ${ver:+v$ver}${ver:+, no .pc file})"
     else
-      echo -e "  ${RED}❌${NC} $pc  (NOT FOUND)"
+      echo -e "  ${RED}❌${NC} $pc  (NOT FOUND — install: $apt_pkg)"
       ((errors++))
     fi
   done
@@ -215,6 +221,7 @@ verify_after_install() {
     echo "  Run: cd vendor/ledgrrr/crates/ledgerr-tauri && cargo check"
   else
     echo -e "${RED}✖ ${errors} dependencies still missing.${NC}"
+    echo "  Run: sudo apt-get install -y ${missing_list[*]}"
     return 1
   fi
 }


### PR DESCRIPTION
- just desktop-build — builds ledgerr-tauri from vendor submodule
- just desktop-launch — launches the Tauri desktop window on WSLg
- just desktop-deps — runs check-tauri-deps.sh (read-only dep scanner)
- Binary auto-symlinked to ~/.cargo/bin/ledgerr-tauri