### PR TITLE
feat(hive): GPU timeshare infrastructure — batch profiles, k8s time-slicing, local provider

### DIFF
--- a/_b00t_/datums/PROVIDER-LOCAL.provider.tomllmd
+++ b/_b00t_/datums/PROVIDER-LOCAL.provider.tomllmd
@@ -1,0 +1,58 @@
+# Local GPU — podman/docker Compute Provider
+#
+# Runs a containerized batch job on the local machine's GPU via podman
+# (preferred, CDI passthrough) or docker (--gpus all fallback). No account,
+# no billing, no network egress required — the tradeoff is the local GPU is
+# a single time-shared resource: only one heavy job runs at a time, and
+# other GPU work (inference, fine-tuning) must be stopped first.
+#
+# Auth: none. GPU access via CDI (nvidia-ctk cdi generate) or nvidia-docker.
+#
+# b00t CLI: b00t provider job submit-batch|status|cancel|list --provider local
+
+[b00t.schema]
+version   = "1"
+type      = "api"
+type_tags = ["provider", "inference", "batch", "gpu", "local"]
+
+[resource]
+name        = "Local GPU"
+api_key_env = ""
+console_url = ""
+
+# There is exactly one local GPU flavor: whatever is physically installed.
+# 🤓 vram_gb reflects this host's RTX 3090; update if hardware changes.
+[resource.flavors]
+"local-gpu" = { vram_gb = 24, vcpus = 0, ram_gb = 0, price_per_hr = 0.0, tier = "sm0l" }
+
+[resource.gate]
+# Refuse to start a batch job below this free VRAM — mirrors
+# [b00t.hive.resources.gate] in finetune.hive.toml so both paths agree on
+# what "the GPU is busy" means.
+gpu_free_mb = 4000
+
+[resource.image_contract]
+notes = "Image must carry its own ENTRYPOINT; the job's config is bind-mounted at /workspace/request.json and passed as the trailing entrypoint arg."
+
+[[resource.usages]]
+description = "Submit a local batch job (e.g. an app4dog SAM runner image)"
+command     = "b00t-cli provider job submit-batch --provider local --image app4dog/sam1-runner:local --config ./request.json"
+
+[[resource.usages]]
+description = "Check job status"
+command     = "b00t-cli provider job status --provider local <container-id>"
+
+[[resource.usages]]
+description = "Cancel/remove a job"
+command     = "b00t-cli provider job cancel --provider local <container-id>"
+
+[[resource.usages]]
+description = "List b00t-managed local batch containers"
+command     = "b00t-cli provider job list --provider local"
+
+# b00t:map v1
+# summary: Local GPU provider — podman/docker batch jobs on the local machine, no cloud account needed
+# tags: provider, local, gpu, podman, docker, batch
+# tier: sm0l
+# cmds: b00t-cli provider job submit-batch --provider local
+# complexity: 3

--- a/_b00t_/finetune.hive.toml
+++ b/_b00t_/finetune.hive.toml
@@ -20,10 +20,15 @@ group = "primary-workload"
 priority = 5  # lower than inference; inference restores when finetune exits
 
 [b00t.hive.services]
-# 🤓 k8s-first on sm3lly: scale down inference via initContainer in k8s Job (rbac.yaml)
-# systemd units listed for reference only (inactive on sm3lly)
-stop = []
-# k8s equivalent: kubectl scale deployment sm0l --replicas=0 -n b00t-inference
+# 🤓 the systemd units below are the ones actually observed running LLM
+#    inference on this host (`systemctl --user list-units | grep b00t@`) —
+#    the original k8s-only assumption here didn't match reality, so
+#    activating this profile stopped nothing and never freed the GPU.
+stop = [
+  "b00t@inference-qwen36-27b-llamacpp.service",
+  "b00t@inference-qwen36-35b-a3b-llamacpp.service",
+]
+# k8s equivalent (when running there instead): kubectl scale deployment sm0l --replicas=0 -n b00t-inference
 # handled automatically by job.yaml initContainer (finetune-scaler ServiceAccount)
 
 [b00t.hive.mcp_tools]

--- a/_b00t_/k8s.🚢/b00t-inference/ch0nky-deployment.yaml
+++ b/_b00t_/k8s.🚢/b00t-inference/ch0nky-deployment.yaml
@@ -1,9 +1,10 @@
 ---
-# Qwen3.6-27B Q4_K_M — ch0nky inference endpoint
-# 🤓 No nvidia.com/gpu resource request — training job holds the only GPU allocation.
-#    NVIDIA_VISIBLE_DEVICES=all + runtimeClassName=nvidia injects CUDA via runtime env
-#    without going through k8s device plugin scheduling. Physical VRAM: ~17GB needed,
-#    ~20GB free alongside training (which only uses 3.4GB with gradient checkpointing).
+# Qwen3.6-35B-A3B UD-IQ4_XS — ch0nky inference endpoint (highest-priority tier)
+# 🤓 Holds an accounted nvidia.com/gpu:1 claim — k8s device-plugin scheduling now
+#    enforces exclusivity against any other GPU-requesting pod on this single-GPU
+#    node, replacing the old runtimeClassName+NVIDIA_VISIBLE_DEVICES bypass (which
+#    gave k8s zero visibility into VRAM usage and allowed silent double-booking).
+#    17.7GB VRAM + ~6GB KV cache headroom at 64k context on RTX 3090 (24GB).
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -12,9 +13,11 @@ metadata:
   labels:
     app: ch0nky
     b00t.tier: ch0nky
-    b00t.io/model: qwen3.6-27b
+    b00t.io/model: qwen3.6-35b-a3b
 spec:
   replicas: 1
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       app: ch0nky
@@ -24,6 +27,7 @@ spec:
         app: ch0nky
         b00t.tier: ch0nky
     spec:
+      priorityClassName: b00t-gpu-primary
       runtimeClassName: nvidia
       tolerations:
         - key: node-role.kubernetes.io/control-plane
@@ -34,7 +38,7 @@ spec:
           image: ghcr.io/ggml-org/llama.cpp:server-cuda
           args:
             - --model
-            - /hf/hub/models--unsloth--Qwen3.6-27B-GGUF/blobs/5ed60d0af4650a854b1755bd392f9aef4872643dc25a254bc68043fa638392a0
+            - /hf/models--unsloth--Qwen3.6-35B-A3B-GGUF/snapshots/a483e9e6cbd595906af30beda3187c2663a1118c/Qwen3.6-35B-A3B-UD-IQ4_XS.gguf
             - --host
             - "0.0.0.0"
             - --port
@@ -44,41 +48,59 @@ spec:
             - -fa
             - "on"
             - -c
-            - "4096"
+            - "65536"
             - -n
-            - "1024"
+            - "4096"
             - --jinja
+            - --reasoning-format
+            - deepseek
+            - --reasoning-budget
+            - "4096"
             - --temp
-            - "0.7"
+            - "0.6"
             - --top-p
             - "0.95"
+            - --top-k
+            - "20"
             - --min-p
             - "0.00"
+            - --presence-penalty
+            - "0.0"
             - --alias
             - ch0nky
             - --api-key
             - local-b00t
-          env:
-            - name: NVIDIA_VISIBLE_DEVICES
-              value: "all"
-            - name: NVIDIA_DRIVER_CAPABILITIES
-              value: "compute,utility"
           ports:
             - containerPort: 8001
               name: http
           resources:
             requests:
-              memory: "4Gi"
+              memory: "6Gi"
               cpu: "2"
+              nvidia.com/gpu: "1"
             limits:
               memory: "20Gi"
+              nvidia.com/gpu: "1"
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 8001
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            failureThreshold: 6
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 8001
+            initialDelaySeconds: 60
+            periodSeconds: 30
           volumeMounts:
             - name: hf-cache
               mountPath: /hf
       volumes:
         - name: hf-cache
           hostPath:
-            path: /home/brianh/.cache/huggingface
+            path: /home/brianh/.cache/huggingface/hub
             type: Directory
 ---
 apiVersion: v1

--- a/_b00t_/k8s.🚢/b00t-inference/priorityclass.yaml
+++ b/_b00t_/k8s.🚢/b00t-inference/priorityclass.yaml
@@ -1,0 +1,14 @@
+---
+# PriorityClass for persistent GPU inference tiers (ch0nky, future sm0l/nomic-embed upgrades).
+# 🤓 Replaces the dead [b00t.hive.exclusion] priority field from .hive.toml — this is
+#    enforced by the k8s scheduler/kubelet (preemption), not just documented intent.
+#    Value sits well below system-cluster-critical (2000000000) and above the unset
+#    default (0) that any future unlabeled batch/Job pod would get, so batch work
+#    yields the GPU to inference tiers automatically instead of racing for it.
+apiVersion: scheduling.k8s.io/v1
+kind: PriorityClass
+metadata:
+  name: b00t-gpu-primary
+value: 1000
+globalDefault: false
+description: "Persistent GPU inference services (ch0nky) — preempts unlabeled/batch GPU pods on the single-GPU node."

--- a/_b00t_/k8s.🚢/cluster/nvidia-device-plugin-config.yaml
+++ b/_b00t_/k8s.🚢/cluster/nvidia-device-plugin-config.yaml
@@ -1,0 +1,34 @@
+---
+# GPU time-slicing config for the nvidia-device-plugin daemonset (kube-system).
+# 🤓 Single RTX 3090, no MIG support — time-slicing is the only native k8s-scheduler
+#    mechanism to let multiple pods concurrently hold an nvidia.com/gpu slot on one
+#    physical card. It gives real admission control (a 4th GPU pod queues instead of
+#    silently piling on) but NO VRAM isolation — replica count is a manually-chosen
+#    budget, not a guarantee. Sized for sm0l (~4GB) + ch0nky (~19GB) coexisting today,
+#    +1 spare slot for a batch/fine-tune job. Don't raise replicas without checking
+#    actual VRAM headroom first (see `nvidia-smi`).
+#
+# Apply: kubectl apply -f _b00t_/k8s.🚢/cluster/nvidia-device-plugin-config.yaml
+# Then patch the daemonset to consume it (one-time, not yet in a repo manifest —
+# the daemonset itself was installed ad-hoc, not from a tracked source file):
+#   kubectl patch daemonset nvidia-device-plugin-daemonset -n kube-system --type=strategic -p '
+#   {"spec":{"template":{"spec":{
+#     "containers":[{"name":"nvidia-device-plugin-ctr","args":["--config-file=/etc/nvidia-device-plugin/config.yaml"],
+#       "volumeMounts":[{"name":"config","mountPath":"/etc/nvidia-device-plugin"}]}],
+#     "volumes":[{"name":"config","configMap":{"name":"nvidia-device-plugin-config"}}]
+#   }}}}'
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: nvidia-device-plugin-config
+  namespace: kube-system
+data:
+  config.yaml: |
+    version: v1
+    sharing:
+      timeSlicing:
+        renameByDefault: false
+        failRequestsGreaterThanOne: false
+        resources:
+        - name: nvidia.com/gpu
+          replicas: 3

--- a/_b00t_/k8s.🚢/sm0l/deployment.yaml
+++ b/_b00t_/k8s.🚢/sm0l/deployment.yaml
@@ -15,6 +15,8 @@ metadata:
     b00t.hive: sm3lly
 spec:
   replicas: 1
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       app: sm0l
@@ -24,37 +26,11 @@ spec:
         app: sm0l
         b00t.tier: sm0l
     spec:
+      runtimeClassName: nvidia
       containers:
         - name: llamacpp
           image: ghcr.io/ggml-org/llama.cpp:server-cuda
-          args:
-            - --model
-            - /hf/models--Qwen--Qwen2.5-3B-Instruct-GGUF/blobs/6dcc22694c8654b045ec40bbe350212b88893fd9010e8474bae5b19a43578ba1
-            - --host
-            - "0.0.0.0"
-            - --port
-            - "8000"
-            - -ngl
-            - "999"
-            - -fa
-            - "on"
-            - -c
-            - "32768"
-            - -n
-            - "2048"
-            - --jinja
-            - --temp
-            - "0.7"
-            - --top-p
-            - "0.95"
-            - --top-k
-            - "20"
-            - --min-p
-            - "0.00"
-            - --alias
-            - sm0l
-            - --api-key
-            - local-b00t
+          command: ["/bin/bash", "/scripts/entrypoint.sh"]
           ports:
             - containerPort: 8000
               name: http
@@ -67,6 +43,8 @@ spec:
             - name: hf-cache
               mountPath: /hf
               readOnly: true
+            - name: entrypoint
+              mountPath: /scripts
           readinessProbe:
             httpGet:
               path: /health
@@ -85,6 +63,9 @@ spec:
           hostPath:
             path: /home/brianh/.cache/huggingface/hub
             type: Directory
+        - name: entrypoint
+          configMap:
+            name: sm0l-entrypoint
       tolerations:
         - key: node-role.kubernetes.io/control-plane
           operator: Exists

--- a/_b00t_/k8s.🚢/sm0l/entrypoint-configmap.yaml
+++ b/_b00t_/k8s.🚢/sm0l/entrypoint-configmap.yaml
@@ -1,0 +1,89 @@
+---
+# GPU-preferred / CPU-fallback state machine for sm0l.
+# 🤓 llama-server doesn't crash when CUDA is unavailable — it logs a warning and
+#    silently continues on CPU (confirmed the hard way: sm0l ran CPU-only for
+#    days without anyone noticing, because there was no runtimeClassName AND no
+#    visible state transition). This wrapper makes the GPU->CPU decision explicit,
+#    logged, and terminally fails loudly instead of degrading silently.
+# States: gpu (preferred) -> cpu (guardrailed fallback) -> failed (out of service).
+# "Alternate" = re-probe GPU on every pod restart, not live in-process switching
+# (YAGNI: continuous background re-polling while serving needs graceful child
+# process draining — real complexity jump not justified for a 3B dev-tier model).
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: sm0l-entrypoint
+  namespace: b00t-inference
+data:
+  entrypoint.sh: |
+    #!/bin/bash
+    set -u
+
+    STATE_FILE=/tmp/b00t-sm0l-state.json
+    MODEL=/hf/models--Qwen--Qwen2.5-3B-Instruct-GGUF/blobs/6dcc22694c8654b045ec40bbe350212b88893fd9010e8474bae5b19a43578ba1
+    COMMON_ARGS=(--host 0.0.0.0 --port 8000 -fa on -n 2048 --jinja --temp 0.7 --top-p 0.95 --top-k 20 --min-p 0.00 --alias sm0l --api-key local-b00t --model "$MODEL")
+
+    log_state() {
+      local mode="$1" reason="$2" recoverable="$3" resolution="$4"
+      echo "B00T_SM0L_STATE mode=${mode} reason=${reason} recoverable=${recoverable} resolution=\"${resolution}\""
+      printf '{"mode":"%s","reason":"%s","recoverable":%s,"resolution":"%s","ts":"%s"}\n' \
+        "$mode" "$reason" "$recoverable" "$resolution" "$(date -u +%FT%TZ)" > "$STATE_FILE"
+    }
+
+    wait_healthy() {
+      local timeout="$1" waited=0
+      while [ "$waited" -lt "$timeout" ]; do
+        if curl -sf -m 2 http://127.0.0.1:8000/health >/dev/null 2>&1; then
+          return 0
+        fi
+        sleep 2
+        waited=$((waited + 2))
+      done
+      return 1
+    }
+
+    # --- Attempt 1: GPU preferred ---
+    log_state "starting" "gpu_probe" "true" "attempting GPU launch (-ngl 999)"
+    /app/llama-server "${COMMON_ARGS[@]}" -ngl 999 -c 32768 > /tmp/sm0l-gpu-attempt.log 2>&1 &
+    GPU_PID=$!
+
+    GPU_FAILED=0
+    for _ in $(seq 1 15); do
+      if grep -q "no usable GPU found" /tmp/sm0l-gpu-attempt.log 2>/dev/null; then
+        GPU_FAILED=1
+        break
+      fi
+      if ! kill -0 "$GPU_PID" 2>/dev/null; then
+        GPU_FAILED=1
+        break
+      fi
+      sleep 1
+    done
+
+    if [ "$GPU_FAILED" -eq 0 ] && wait_healthy 60; then
+      log_state "gpu" "ok" "true" "serving on GPU"
+      cat /tmp/sm0l-gpu-attempt.log
+      wait "$GPU_PID"
+      exit $?
+    fi
+
+    kill "$GPU_PID" 2>/dev/null
+    wait "$GPU_PID" 2>/dev/null
+    log_state "cpu" "cuda_unavailable" "true" "check nvidia-device-plugin capacity (kubectl describe node | grep nvidia.com/gpu) and pod runtimeClassName; will retry gpu on next pod restart"
+
+    # --- Attempt 2: CPU fallback ---
+    /app/llama-server "${COMMON_ARGS[@]}" -ngl 0 -c 8192 > /tmp/sm0l-cpu-attempt.log 2>&1 &
+    CPU_PID=$!
+
+    if wait_healthy 60; then
+      log_state "cpu" "ok" "true" "serving on CPU (degraded — GPU unavailable at startup)"
+      cat /tmp/sm0l-cpu-attempt.log
+      wait "$CPU_PID"
+      exit $?
+    fi
+
+    kill "$CPU_PID" 2>/dev/null
+    wait "$CPU_PID" 2>/dev/null
+    log_state "failed" "cpu_and_gpu_both_failed" "false" "neither GPU nor CPU launch became healthy within timeout — check model file exists at ${MODEL}, check host RAM/VRAM, inspect /tmp/sm0l-gpu-attempt.log and /tmp/sm0l-cpu-attempt.log for the real llama-server error; this requires operator intervention, restarting the pod will not fix it"
+    cat /tmp/sm0l-gpu-attempt.log /tmp/sm0l-cpu-attempt.log
+    exit 78

--- a/_b00t_/learn/b00t-cli.md
+++ b/_b00t_/learn/b00t-cli.md
@@ -10,3 +10,4 @@ just module invocation: Justfile modules (e.g., 'mod b00t') must be invoked from
 
 ---
 🦨 b00t-run-hallucination: The help text says b00t run <name> but b00t run is not a CLI command. It's a hidden shortcut RunDatum that the help text describes as datum dispatch. Should be b00t <name> directly, not b00t run <name>. Fix help text and auto-dispatch.
+datum validation paths: Use absolute paths when validating project-local datum files from recipes; relative paths may resolve as global datum keys.

--- a/_b00t_/local-gpu-batch.hive.toml
+++ b/_b00t_/local-gpu-batch.hive.toml
@@ -1,0 +1,69 @@
+[b00t]
+name = "local-gpu-batch"
+type = "hive_profile"
+hint = "Free the local GPU for a one-off batch job (e.g. LocalProvider SAM runs) by stopping LLM inference — treats the GPU as a time-shared resource"
+
+[b00t.hive.resources]
+# 🤓 headroom for a single local batch container (see LOCAL_GPU_FREE_MB_GATE
+#    in b00t-cli/src/commands/provider.rs — keep these in sync)
+ram_gb = 2
+gpu_mb = 4000
+cpu_cores = 2
+
+[b00t.hive.resources.gate]
+ram_free_gb = 1
+gpu_free_mb = 4000
+
+[b00t.hive.exclusion]
+group = "primary-workload"
+priority = 8  # lower priority than interactive inference; inference resumes when the batch job exits
+
+[b00t.hive.services]
+# 🤓 these are the systemd units actually observed running LLM inference on
+#    this host (`systemctl --user list-units | grep b00t@`) — unlike
+#    finetune.hive.toml's original k8s-only assumption, this host runs
+#    inference via systemd directly, so we stop it here for real.
+stop = [
+  "b00t@inference-qwen36-27b-llamacpp.service",
+  "b00t@inference-qwen36-35b-a3b-llamacpp.service",
+]
+
+# 🤓 the embedding model (nomic-embed-text, used for docs/codebase search)
+#    is intentionally NOT in the stop list above. It runs as a k8s pod
+#    (containerd-shim-runc-v2, not a b00t@ systemd unit) with `-ngl 0`
+#    (zero GPU layers — CPU-only), so it never competes for VRAM and is
+#    structurally unaffected by this profile regardless.
+
+[b00t.hive.mcp_tools]
+deactivate = ["vllm-local"]
+
+[[b00t.hive.guards]]
+pattern = "pip install"
+action = "warn"
+message = "🦨 use uv pip install"
+redirect = "uv pip install"
+
+[[b00t.hive.guards]]
+pattern = "docker run"
+action = "warn"
+message = "🦨 use podman --device nvidia.com/gpu=all"
+redirect = "podman run --device nvidia.com/gpu=all --security-opt=label=disable"
+
+[[b00t.usage]]
+description = "Free the GPU and run a local batch job (e.g. app4dog SAM runner)"
+command = "b00t hive activate local-gpu-batch && b00t provider job submit-batch --provider local --image app4dog/sam1-runner:local --config ./request.json"
+
+[[b00t.usage]]
+description = "Preview what would stop/start without doing it"
+command = "b00t hive plan local-gpu-batch"
+
+[[b00t.usage]]
+description = "Return to normal inference after the batch job finishes"
+command = "b00t hive activate inference-qwen36-35b-a3b-llamacpp"
+
+# b00t:map v1
+# summary: GPU time-share profile — stops local LLM inference so a one-off local-gpu batch job can run; embedding model is CPU-only and unaffected
+# tags: hive, gpu, local, batch, timeshare
+# tier: sm0l
+# cmds: b00t hive activate local-gpu-batch
+# complexity: 3

--- a/b00t-cli/src/commands/provider.rs
+++ b/b00t-cli/src/commands/provider.rs
@@ -1,16 +1,23 @@
 //! Multi-provider compute abstraction — inference endpoints + training jobs.
 //!
-//! Providers: runpod (native crate), hf (CLI wrapper for `hf jobs`)
+//! Providers: runpod (native crate), hf (CLI wrapper for `hf jobs`), local (podman)
 //! Single source of truth: PROVIDER-*.provider.tomllmd datums
 //!
 //! b00t provider endpoint deploy|status|teardown|list --provider runpod|hf
 //! b00t provider job submit|status|cancel|list      --provider runpod|hf
+//! b00t provider job submit-batch|status|cancel|list --provider runpod|hf|local
 
+use crate::hive::SystemSnapshot;
+use crate::model_manager::{detect_container_runtime, runtime_bin, ContainerRuntime};
 use anyhow::{bail, Context, Result};
 use async_trait::async_trait;
 use clap::Parser;
 use serde::{Deserialize, Serialize};
 use std::process::Command;
+
+/// Minimum free VRAM (MB) required before a local batch job is allowed to start.
+/// Matches the gate style already used by `[b00t.hive.resources.gate]` profiles.
+const LOCAL_GPU_FREE_MB_GATE: u32 = 4000;
 
 // ── Public types ─────────────────────────────────────────────────────────────
 
@@ -62,6 +69,19 @@ pub struct TrainingJobSpec {
     pub timeout_hours: f32,
 }
 
+/// A generic containerized batch job — the image carries its own entrypoint,
+/// unlike `TrainingJobSpec` which always drives a fine-tuning script.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BatchJobSpec {
+    pub image: String,
+    /// Local file path or provider-specific URI (e.g. `hf://...`); each
+    /// provider decides how to make this reachable inside the job.
+    pub config_path: String,
+    pub env: std::collections::HashMap<String, String>,
+    pub flavor: String,
+    pub timeout_hours: f32,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct JobHandle {
     pub id: String,
@@ -80,6 +100,7 @@ pub trait ComputeProvider: Send + Sync {
     async fn list_endpoints(&self) -> Result<Vec<EndpointHandle>>;
 
     async fn submit_training_job(&self, spec: &TrainingJobSpec) -> Result<JobHandle>;
+    async fn submit_batch_job(&self, spec: &BatchJobSpec) -> Result<JobHandle>;
     async fn job_status(&self, handle: &JobHandle) -> Result<String>;
     async fn cancel_job(&self, handle: &JobHandle) -> Result<()>;
     async fn list_jobs(&self) -> Result<Vec<JobHandle>>;
@@ -89,7 +110,8 @@ pub fn get_provider(name: &str) -> Result<Box<dyn ComputeProvider>> {
     match name {
         "runpod" => Ok(Box::new(RunpodProvider::new()?)),
         "hf" => Ok(Box::new(HfProvider::new())),
-        other => bail!("unknown provider '{}'; supported: runpod, hf", other),
+        "local" => Ok(Box::new(LocalProvider::new())),
+        other => bail!("unknown provider '{}'; supported: runpod, hf, local", other),
     }
 }
 
@@ -227,6 +249,20 @@ impl ComputeProvider for RunpodProvider {
         })
     }
 
+    async fn submit_batch_job(&self, spec: &BatchJobSpec) -> Result<JobHandle> {
+        let req = runpod_batch_request(spec);
+        let pod = self
+            .client
+            .create_on_demand_pod(req)
+            .await
+            .context("RunPod create_on_demand_pod failed")?;
+        let id = pod.data.context("RunPod returned no pod data")?.id;
+        Ok(JobHandle {
+            id,
+            provider: "runpod".into(),
+        })
+    }
+
     async fn job_status(&self, handle: &JobHandle) -> Result<String> {
         let info = self
             .client
@@ -275,6 +311,39 @@ fn hf_flavor_to_runpod_gpu(flavor: &str) -> &str {
     }
 }
 
+/// Pure request builder, split out so tests can assert the exact shape
+/// without a live RunPod API key or network call.
+fn runpod_batch_request(spec: &BatchJobSpec) -> runpod::CreateOnDemandPodRequest {
+    use runpod::EnvVar;
+    let gpu_type = hf_flavor_to_runpod_gpu(&spec.flavor).to_string();
+    // 🤓 no hardcoded TRAINING_CONFIG/UNSLOTH_CACHE_DIR here — the image's own
+    //    ENTRYPOINT drives the job; env is exactly what the caller asked for.
+    let env = spec
+        .env
+        .iter()
+        .map(|(key, value)| EnvVar {
+            key: key.clone(),
+            value: value.clone(),
+        })
+        .collect();
+    // 🤓 known limitation: config_path must already be reachable inside the pod
+    //    (e.g. a path under network_volume_id) — RunPod pods run on a remote
+    //    host, so a local filesystem path is not auto-uploaded. Passed through
+    //    as the entrypoint arg on the assumption the caller has arranged that.
+    runpod::CreateOnDemandPodRequest {
+        name: Some("b00t-batch".into()),
+        image_name: Some(spec.image.clone()),
+        gpu_type_id: Some(gpu_type),
+        cloud_type: Some("SECURE".into()),
+        gpu_count: Some(1),
+        volume_in_gb: Some(50),
+        container_disk_in_gb: Some(20),
+        docker_args: Some(vec![spec.config_path.clone()]),
+        env,
+        ..Default::default()
+    }
+}
+
 // ── HF provider (CLI wrapper) ─────────────────────────────────────────────────
 
 pub struct HfProvider;
@@ -298,6 +367,39 @@ impl HfProvider {
         }
         Ok(String::from_utf8_lossy(&out.stdout).to_string())
     }
+}
+
+/// Pure argv builder, split out so tests can assert the exact `hf jobs run`
+/// invocation without the `hf` CLI installed.
+fn hf_batch_args(spec: &BatchJobSpec) -> Result<Vec<String>> {
+    // 🤓 unlike submit_training_job, no hardcoded script/`--` command here —
+    //    the image's own ENTRYPOINT runs. `hf jobs run` can't upload an
+    //    arbitrary local file, so config_path must already be an hf:// URI
+    //    the job can mount (e.g. via --volume) or reference directly.
+    if !spec.config_path.starts_with("hf://") {
+        bail!(
+            "hf batch jobs require config_path to be an hf:// URI reachable inside the job, got '{}'",
+            spec.config_path
+        );
+    }
+    let timeout = format!("{}h", spec.timeout_hours.ceil() as u32);
+    let mut args: Vec<String> = vec![
+        "jobs".into(),
+        "run".into(),
+        spec.image.clone(),
+        "--flavor".into(),
+        spec.flavor.clone(),
+        "--timeout".into(),
+        timeout,
+    ];
+    for (key, value) in &spec.env {
+        args.push("--env".into());
+        args.push(format!("{key}={value}"));
+    }
+    // trailing entrypoint arg — same convention as the local/runpod providers.
+    args.push("--".into());
+    args.push(spec.config_path.clone());
+    Ok(args)
 }
 
 #[async_trait]
@@ -354,6 +456,21 @@ impl ComputeProvider for HfProvider {
         })
     }
 
+    async fn submit_batch_job(&self, spec: &BatchJobSpec) -> Result<JobHandle> {
+        let args = hf_batch_args(spec)?;
+        let arg_refs: Vec<&str> = args.iter().map(String::as_str).collect();
+        let output = self.run_hf(&arg_refs)?;
+        let id = output
+            .lines()
+            .find(|l| l.len() == 24 && l.chars().all(|c| c.is_ascii_hexdigit()))
+            .unwrap_or(output.trim())
+            .to_string();
+        Ok(JobHandle {
+            id,
+            provider: "hf".into(),
+        })
+    }
+
     async fn job_status(&self, handle: &JobHandle) -> Result<String> {
         self.run_hf(&["jobs", "inspect", &handle.id])
     }
@@ -378,6 +495,202 @@ impl ComputeProvider for HfProvider {
             })
             .collect();
         Ok(handles)
+    }
+}
+
+// ── Local (podman/docker) provider ────────────────────────────────────────────
+
+/// Label attached to every container this provider starts, so `list_jobs`/
+/// `cancel_job` only ever touch b00t-managed batch containers.
+const LOCAL_PROVIDER_LABEL: &str = "b00t.provider=local";
+
+pub struct LocalProvider {
+    runtime: ContainerRuntime,
+}
+
+impl LocalProvider {
+    pub fn new() -> Self {
+        Self { runtime: detect_container_runtime(Some("podman")) }
+    }
+
+    fn run(bin: &str, args: &[String]) -> Result<String> {
+        let output = Command::new(bin)
+            .args(args)
+            .output()
+            .with_context(|| format!("failed to run `{bin} {}`", args.join(" ")))?;
+        if !output.status.success() {
+            bail!(
+                "{} {} failed: {}",
+                bin,
+                args.join(" "),
+                String::from_utf8_lossy(&output.stderr)
+            );
+        }
+        Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
+    }
+}
+
+/// Pure argv builder, split out so tests can assert the exact `podman`/
+/// `docker run` invocation without touching the GPU gate or a real runtime.
+/// Returns `Err` if `config_path` is not a clean absolute path — colons in
+/// the path would silently corrupt the `-v src:dst:opts` volume spec.
+fn local_batch_args(name: &str, runtime: &ContainerRuntime, spec: &BatchJobSpec) -> Result<Vec<String>> {
+    // Validate config_path before interpolating into the bind-mount spec.
+    // A colon in the path breaks `src:dst:opts` parsing; non-absolute paths
+    // are unreachable inside the container after chroot.
+    let p = std::path::Path::new(&spec.config_path);
+    if !p.is_absolute() {
+        bail!("config_path must be absolute, got: {:?}", spec.config_path);
+    }
+    if spec.config_path.contains(':') {
+        bail!("config_path must not contain ':', got: {:?}", spec.config_path);
+    }
+    if !p.is_file() {
+        bail!("config_path does not exist or is not a file: {:?}", spec.config_path);
+    }
+
+    let mut args: Vec<String> = vec![
+        "run".into(),
+        "-d".into(),
+        "--name".into(),
+        name.to_string(),
+        "--label".into(),
+        LOCAL_PROVIDER_LABEL.into(),
+    ];
+
+    match runtime {
+        ContainerRuntime::Podman => {
+            args.push("--device".into());
+            args.push("nvidia.com/gpu=all".into());
+        }
+        ContainerRuntime::Docker => {
+            args.push("--gpus".into());
+            args.push("all".into());
+        }
+    }
+
+    for (key, value) in &spec.env {
+        args.push("-e".into());
+        args.push(format!("{key}={value}"));
+    }
+
+    // 🤓 config_path is a host path here — bind-mounted at a fixed in-container
+    //    location and passed as the trailing entrypoint arg, matching how the
+    //    app4dog sam-runner images expect their request JSON.
+    args.push("-v".into());
+    args.push(format!("{}:/workspace/request.json:ro", spec.config_path));
+    args.push(spec.image.clone());
+    args.push("/workspace/request.json".into());
+
+    Ok(args)
+}
+
+#[async_trait]
+impl ComputeProvider for LocalProvider {
+    fn name(&self) -> &str {
+        "local"
+    }
+
+    async fn deploy_inference_endpoint(&self, _cfg: &EndpointConfig) -> Result<EndpointHandle> {
+        bail!("local provider has no persistent endpoints; use provider=runpod")
+    }
+
+    async fn endpoint_status(&self, _id: &str) -> Result<EndpointHandle> {
+        bail!("local provider has no persistent endpoints; use provider=runpod")
+    }
+
+    async fn teardown_endpoint(&self, _id: &str) -> Result<()> {
+        bail!("local provider has no persistent endpoints; use provider=runpod")
+    }
+
+    async fn list_endpoints(&self) -> Result<Vec<EndpointHandle>> {
+        Ok(vec![])
+    }
+
+    async fn submit_training_job(&self, _spec: &TrainingJobSpec) -> Result<JobHandle> {
+        bail!("local provider does not run fine-tuning jobs; use provider=hf or provider=runpod")
+    }
+
+    async fn submit_batch_job(&self, spec: &BatchJobSpec) -> Result<JobHandle> {
+        // 🤓 mirrors the GPU resource-gate pattern from [b00t.hive.resources.gate]
+        //    (see finetune.hive.toml) — refuse to start rather than OOM-kill later.
+        let snapshot = SystemSnapshot::capture().context("capturing local GPU/RAM state")?;
+        let free_mb = match snapshot.gpu_free_mb {
+            None => bail!("no GPU detected by SystemSnapshot; LocalProvider requires CUDA-capable hardware"),
+            Some(mb) => mb,
+        };
+        if free_mb < LOCAL_GPU_FREE_MB_GATE {
+            bail!(
+                "GPU: need {}MB free, have {}MB — stop inference/fine-tuning first (see `b00t hive status`)",
+                LOCAL_GPU_FREE_MB_GATE,
+                free_mb
+            );
+        }
+
+        let bin = runtime_bin(&self.runtime);
+        let name = format!("b00t-batch-{}", uuid::Uuid::new_v4());
+        let args = local_batch_args(&name, &self.runtime, spec)?;
+
+        let id = Self::run(bin, &args)?;
+        Ok(JobHandle {
+            id,
+            provider: "local".into(),
+        })
+    }
+
+    async fn job_status(&self, handle: &JobHandle) -> Result<String> {
+        let bin = runtime_bin(&self.runtime);
+        Self::run(
+            bin,
+            &[
+                "inspect".into(),
+                "--format".into(),
+                "{{.State.Status}}".into(),
+                handle.id.clone(),
+            ],
+        )
+    }
+
+    async fn cancel_job(&self, handle: &JobHandle) -> Result<()> {
+        let bin = runtime_bin(&self.runtime);
+        // Guard: only remove containers b00t itself created — reject crafted handles.
+        let label = Self::run(
+            bin,
+            &[
+                "inspect".into(),
+                "--format".into(),
+                "{{index .Config.Labels \"b00t.provider\"}}".into(),
+                handle.id.clone(),
+            ],
+        )
+        .unwrap_or_default();
+        if label.trim() != "local" {
+            bail!("container {} is not a b00t-managed local batch job", handle.id);
+        }
+        Self::run(bin, &["rm".into(), "-f".into(), handle.id.clone()])?;
+        Ok(())
+    }
+
+    async fn list_jobs(&self) -> Result<Vec<JobHandle>> {
+        let bin = runtime_bin(&self.runtime);
+        let out = Self::run(
+            bin,
+            &[
+                "ps".into(),
+                "-a".into(),
+                "--filter".into(),
+                format!("label={LOCAL_PROVIDER_LABEL}"),
+                "--format".into(),
+                "{{.ID}}".into(),
+            ],
+        )?;
+        Ok(out
+            .lines()
+            .map(|id| JobHandle {
+                id: id.trim().to_string(),
+                provider: "local".into(),
+            })
+            .collect())
     }
 }
 
@@ -445,6 +758,21 @@ pub enum ProviderJobCommands {
         flavor: String,
         #[clap(long, default_value_t = 10.0)]
         timeout_hours: f32,
+    },
+    #[clap(about = "Submit a generic containerized batch job (image runs its own entrypoint)")]
+    SubmitBatch {
+        #[clap(long, default_value = "local")]
+        provider: String,
+        #[clap(long, help = "Path/URI the provider resolves into the job's config")]
+        config: String,
+        #[clap(long)]
+        image: String,
+        #[clap(long, default_value = "local-gpu")]
+        flavor: String,
+        #[clap(long, default_value_t = 1.0)]
+        timeout_hours: f32,
+        #[clap(long = "env", help = "KEY=VALUE, may be repeated")]
+        env: Vec<String>,
     },
     #[clap(about = "Show job status")]
     Status {
@@ -536,6 +864,32 @@ async fn handle_job(cmd: ProviderJobCommands) -> Result<()> {
             let handle = p.submit_training_job(&spec).await?;
             println!("{}", serde_json::to_string_pretty(&handle)?);
         }
+        ProviderJobCommands::SubmitBatch {
+            provider,
+            config,
+            image,
+            flavor,
+            timeout_hours,
+            env,
+        } => {
+            let p = get_provider(&provider)?;
+            let mut env_map = std::collections::HashMap::new();
+            for pair in env {
+                let (key, value) = pair
+                    .split_once('=')
+                    .with_context(|| format!("--env expects KEY=VALUE, got '{pair}'"))?;
+                env_map.insert(key.to_string(), value.to_string());
+            }
+            let spec = BatchJobSpec {
+                image,
+                config_path: config,
+                env: env_map,
+                flavor,
+                timeout_hours,
+            };
+            let handle = p.submit_batch_job(&spec).await?;
+            println!("{}", serde_json::to_string_pretty(&handle)?);
+        }
         ProviderJobCommands::Status { provider, id } => {
             let p = get_provider(&provider)?;
             let handle = JobHandle {
@@ -561,4 +915,94 @@ async fn handle_job(cmd: ProviderJobCommands) -> Result<()> {
         }
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod batch_job_tests {
+    use super::*;
+
+    fn sample_spec(image: &str, config_path: &str) -> BatchJobSpec {
+        let mut env = std::collections::HashMap::new();
+        env.insert("SAM_RUNNER_MODE".to_string(), "real".to_string());
+        BatchJobSpec {
+            image: image.to_string(),
+            config_path: config_path.to_string(),
+            env,
+            flavor: "a10g-small".to_string(),
+            timeout_hours: 1.0,
+        }
+    }
+
+    #[test]
+    fn runpod_batch_request_carries_image_gpu_and_config_path() {
+        let spec = sample_spec("app4dog/sam3-runner:cloud", "/net-volume/request.json");
+        let req = runpod_batch_request(&spec);
+        assert_eq!(req.image_name.as_deref(), Some("app4dog/sam3-runner:cloud"));
+        assert_eq!(req.docker_args, Some(vec!["/net-volume/request.json".to_string()]));
+        assert!(req.env.iter().any(|e| e.key == "SAM_RUNNER_MODE" && e.value == "real"));
+        // TRAINING_CONFIG/UNSLOTH_CACHE_DIR must not leak into batch jobs.
+        assert!(!req.env.iter().any(|e| e.key == "TRAINING_CONFIG"));
+    }
+
+    #[test]
+    fn hf_batch_args_requires_hf_uri_config_path() {
+        let spec = sample_spec("app4dog/sam3-runner:cloud", "/local/request.json");
+        let err = hf_batch_args(&spec).unwrap_err();
+        assert!(err.to_string().contains("hf://"));
+    }
+
+    #[test]
+    fn hf_batch_args_builds_expected_argv_for_hf_uri() {
+        let spec = sample_spec(
+            "app4dog/sam3-runner:cloud",
+            "hf://datasets/x/request.json",
+        );
+        let args = hf_batch_args(&spec).expect("hf:// config_path should be accepted");
+        assert_eq!(args[0], "jobs");
+        assert_eq!(args[1], "run");
+        assert_eq!(args[2], "app4dog/sam3-runner:cloud");
+        assert!(args.contains(&"--flavor".to_string()));
+        assert!(args.contains(&"a10g-small".to_string()));
+        assert!(args.contains(&"--env".to_string()));
+        assert!(args.contains(&"SAM_RUNNER_MODE=real".to_string()));
+        // trailing entrypoint arg after `--`
+        assert_eq!(args.last(), Some(&"hf://datasets/x/request.json".to_string()));
+    }
+
+    #[test]
+    fn local_batch_args_uses_podman_cdi_gpu_flags() {
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        let path = tmp.path().to_str().unwrap().to_string();
+        let spec = sample_spec("app4dog/sam1-runner:local", &path);
+        let args = local_batch_args("b00t-batch-test", &ContainerRuntime::Podman, &spec).unwrap();
+        assert!(args.contains(&"--device".to_string()));
+        assert!(args.contains(&"nvidia.com/gpu=all".to_string()));
+        assert!(!args.contains(&"--gpus".to_string()));
+        assert_eq!(args.last().unwrap(), "/workspace/request.json");
+        assert!(args.contains(&"app4dog/sam1-runner:local".to_string()));
+        assert!(args.iter().any(|a| a.ends_with(":/workspace/request.json:ro")));
+    }
+
+    #[test]
+    fn local_batch_args_uses_docker_gpus_flag() {
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        let path = tmp.path().to_str().unwrap().to_string();
+        let spec = sample_spec("app4dog/sam1-runner:local", &path);
+        let args = local_batch_args("b00t-batch-test", &ContainerRuntime::Docker, &spec).unwrap();
+        assert!(args.contains(&"--gpus".to_string()));
+        assert!(args.contains(&"all".to_string()));
+        assert!(!args.contains(&"--device".to_string()));
+    }
+
+    #[test]
+    fn local_batch_args_rejects_colon_in_path() {
+        let spec = sample_spec("img:latest", "/some/path:with:colons/req.json");
+        assert!(local_batch_args("b00t-batch-test", &ContainerRuntime::Podman, &spec).is_err());
+    }
+
+    #[test]
+    fn local_batch_args_rejects_relative_path() {
+        let spec = sample_spec("img:latest", "relative/path/req.json");
+        assert!(local_batch_args("b00t-batch-test", &ContainerRuntime::Podman, &spec).is_err());
+    }
 }

--- a/b00t-cli/src/model_manager.rs
+++ b/b00t-cli/src/model_manager.rs
@@ -24,12 +24,12 @@ const MODEL_SUFFIXES: [&str; 4] = [".model.toml", ".ai_model.toml", ".model.ai.t
 /// Podman uses CDI spec: --device nvidia.com/gpu=all --security-opt=label=disable
 /// Docker uses: --gpus all
 #[derive(Debug, Clone, PartialEq)]
-enum ContainerRuntime {
+pub(crate) enum ContainerRuntime {
     Docker,
     Podman,
 }
 
-fn detect_container_runtime(override_hint: Option<&str>) -> ContainerRuntime {
+pub(crate) fn detect_container_runtime(override_hint: Option<&str>) -> ContainerRuntime {
     // 🤓 datum metadata `container_runtime = "podman"` takes precedence
     if let Some(hint) = override_hint {
         if hint.to_lowercase() == "podman" {
@@ -50,7 +50,7 @@ fn detect_container_runtime(override_hint: Option<&str>) -> ContainerRuntime {
     ContainerRuntime::Docker
 }
 
-fn runtime_bin(rt: &ContainerRuntime) -> &'static str {
+pub(crate) fn runtime_bin(rt: &ContainerRuntime) -> &'static str {
     match rt {
         ContainerRuntime::Docker => "docker",
         ContainerRuntime::Podman => "podman",

--- a/justfile
+++ b/justfile
@@ -2624,6 +2624,13 @@ ch0nky-probe endpoint="":
         scripts/probe-ch0nky.sh
     fi
 
+# Show sm0l's current gpu/cpu/failed state (see _b00t_/k8s.🚢/sm0l/entrypoint-configmap.yaml)
+sm0l-status:
+    #!/bin/bash
+    POD=$(kubectl get pod -n b00t-inference -l app=sm0l -o name | head -1)
+    [[ -z "$POD" ]] && { echo "no sm0l pod"; exit 1; }
+    kubectl exec -n b00t-inference "$POD" -- cat /tmp/b00t-sm0l-state.json 2>&1 | python3 -m json.tool
+
 
 # ── Git object recovery (EXPERIMENTAL) ────────────────────────────────────────
 # 🤓 LFMF: never rm .git/objects/* without proving BOTH corrupt AND unreachable.


### PR DESCRIPTION
Extracted from closed PR #623.

Changes:
- feat(hive): add local-gpu-batch profile, fix finetune's stale stop list
- feat(hive): GPU device-plugin time-slicing + ch0nky 35B-A3B upgrade + sm0l GPU/CPU fallback
- feat(provider): local podman batch-job provider (LocalProvider) + PROVIDER-LOCAL datum