### PR TITLE
feat(sudo-operator): adversarial-review governance for Block-tier exec

### DIFF
--- a/_b00t_/datums/PRD-SUDO-OPERATOR-GOVERNANCE.tomllmd
+++ b/_b00t_/datums/PRD-SUDO-OPERATOR-GOVERNANCE.tomllmd
@@ -1,0 +1,344 @@
+# b00t:map v1
+# summary: Sudo Operator Governance — extends Reviewer Governance Engine's Satisfies<Constraint> pattern to privileged-command grants; replaces the 300s-TTL block-bypass with adversarial-model review + evidence + pre-grant checkpoint
+# tags: prd, sudo, governance, satisfies, constraint, ledgrrr, evidence, ufo, grant, escalation, checkpoint
+# tier: frontier
+# cmds: b00t exec --justification <text> --cites <hash>..., ledgerr evidence verify --command-id <id>
+# complexity: 9
+
+# ── PRD: Sudo Operator Governance — Satisfies<SudoGrantConstraint> + Adversarial Review ──
+
+[b00t.schema]
+version   = "1"
+type      = "prd"
+type_tags = ["prd", "sudo", "governance", "satisfies", "constraint", "ledgrrr", "evidence", "ufo"]
+
+[prd]
+id     = "PRD-SUDO-OPERATOR-GOVERNANCE"
+title  = "Sudo Operator Governance — adversarial-model review gate for privileged commands, with evidence and pre-grant checkpoint"
+status = "proposed"
+tier   = "frontier"
+extends = "PRD-REVIEWER-GOVERNANCE-ENGINE"
+inherits_from = ["ufo-types::Satisfies<C>", "arc-kit-au::evidence", "job_executor::checkpoint"]
+
+# ── Executive Summary ────────────────────────────────────────────────────────
+# b00t-cli/src/commands/exec.rs already gates Block-tier commands via
+# check_guards(), but a rejected command can be force-executed by simply
+# resubmitting within a 300-second TTL — no justification required
+# (~/.b00t/exec-audit.json, exec-log.jsonl `block-forced` entries carry no
+# rationale or evidence link). This PRD closes that gap by applying the SAME
+# pattern PRD-REVIEWER-GOVERNANCE-ENGINE already designed for review verdicts:
+#
+#   Operator justification (+ cited commit hashes)
+#     → SudoGrantVerdict implements Satisfies<SudoGrantConstraint>
+#     → adversarial model (sm0l) reviews command + justification + `git show`
+#       of cited commits, returns Grant | Deny | Escalate
+#     → Grant produces evidence node (Blake3 of command+justification+verdict)
+#       AND a pre-execution checkpoint (git tag + systemd/k8s state dump)
+#     → without evidence → command DID NOT HAPPEN → not executed
+#     → Escalate fires a webhook (fan-out to Slack/email/SMS via n8n) +
+#       local desktop notification, then denies for now (v1: no synchronous
+#       wait on a human reply — operator re-runs after resolving upstream)
+#
+# This directly replaces the unauthenticated 300s-TTL bypass with a real
+# adversarial-review-then-grant flow, while leaving the existing bare-Block
+# behavior (no --justification given) completely unchanged for anyone not
+# opting into this path.
+
+# ── Architecture ─────────────────────────────────────────────────────────────
+
+[architecture]
+diagram = """
+┌─────────────────────────────────────────────────────────────┐
+│         Operator: b00t exec --justification "..."           │
+│                    --cites <commit-hash>... "<command>"      │
+└─────────────────────┬───────────────────────────────────────┘
+                      │ check_guards() → Block
+                      ▼
+┌─────────────────────────────────────────────────────────────┐
+│      SudoGrantVerdict : Satisfies<SudoGrantConstraint>        │
+│  ┌───────────────────────────────────────────────────────┐  │
+│  │  fn satisfies(&self, constraint: &SudoGrantConstraint) │  │
+│  │    → adversarial model (sm0l) reviews:                 │  │
+│  │        command, justification, `git show --stat` of    │  │
+│  │        each cited commit (grounds review in a real     │  │
+│  │        diff, not just trusted free text)                │  │
+│  │    → SatisfiesResult {                                 │  │
+│  │        disposition: Grant{ttl}|Deny{reason}|Escalate,  │  │
+│  │        confidence: f64,                                 │  │
+│  │        evidence_nodes: Vec<NodeId>,  ← Blake3 hashes    │  │
+│  │        ufo_category: MomentStereotype::Mode             │  │
+│  │      }                                                  │  │
+│  └───────────────────────────────────────────────────────┘  │
+└─────────────────────┬───────────────────────────────────────┘
+                      │ Grant
+                      ▼
+┌─────────────────────────────────────────────────────────────┐
+│              checkpoint_system_state()                       │
+│  git tag checkpoint/sudo/<id> + systemctl show / kubectl get │
+│  -o yaml artifact dump (operator-actionable, not auto-revert) │
+└─────────────────────┬───────────────────────────────────────┘
+                      │ checkpoint recorded
+                      ▼
+┌─────────────────────────────────────────────────────────────┐
+│              Command Execution + Evidence Record              │
+│  Grant    → execute command, record evidence + checkpoint     │
+│  Deny     → refuse, surface reason, no evidence needed         │
+│  Escalate → n8n webhook (→ Slack/email/SMS) + notify-send,     │
+│             deny for now, no evidence recorded (nothing ran)   │
+└─────────────────────────────────────────────────────────────┘
+"""
+
+# ── UFO Grounding ────────────────────────────────────────────────────────────
+
+[ufo_grounding]
+types = [
+    {
+        "type": "SudoGrantVerdict",
+        "ufo_stereotype": "Moment::Mode",
+        "description": "The grant/deny/escalate decision is an intrinsic moment dependent on the review event — mirrors ReviewVerdict's grounding exactly.",
+        "citation": "Guizzardi 2005, §4.3: Mode = intrinsic moment dependent on a single individual"
+    },
+    {
+        "type": "SudoGrantConstraint",
+        "ufo_stereotype": "Abstract",
+        "description": "Constraints (does the justification + cited evidence support this specific command?) are abstract rules governing the moment, independent of any particular grant instance.",
+        "citation": "UFO-B: Abstract category for purely formal entities"
+    },
+    {
+        "type": "SudoReviewEvent",
+        "ufo_stereotype": "Perdurant::Event",
+        "description": "The adversarial review is an event unfolding in time: command received → justification parsed → cited commits inspected → model queried → verdict produced.",
+        "citation": "Guizzardi 2005, §5: Event = perdurant with proper temporal parts"
+    },
+    {
+        "type": "SudoGrantEvidence",
+        "ufo_stereotype": "Endurant::SubKind",
+        "description": "Evidence (the Blake3-hashed record of command+justification+cited-commits+verdict) persists beyond the review event, referenceable by future audits — same subkind as CommandEvidence in the reviewer PRD.",
+        "citation": "Guizzardi 2005, §3.2: SubKind = rigid specialization of a Kind"
+    },
+    {
+        "type": "SystemCheckpoint",
+        "ufo_stereotype": "Endurant::SubKind",
+        "description": "A checkpoint is evidence of pre-command state, sufficient for an operator to manually revert. Rigid specialization of the evidence endurant.",
+    }
+]
+
+# ── Rust Trait Extension ─────────────────────────────────────────────────────
+# 🤓 CORRECTED after reading the actual code (2026-07-02): the reviewer
+#    governance module (b00t-c0re-lib/src/reviewer/{governance,evidence}.rs)
+#    ALREADY EXISTS — 683+204 lines, tested — contradicting this PRD's
+#    original `extends`-only assumption that it was unbuilt. It is, however,
+#    NOT wired into exec.rs anywhere (confirmed by grep — zero call sites).
+#    It is also NOT what the executive summary above describes: it is a
+#    self-contained, dependency-free module — SHA-256 content-addressed
+#    `CommandEvidence`/`EvidenceNode` (NOT Blake3), NO `ufo-types` or
+#    `arc-kit-au` crate dependency from b00t-c0re-lib at all. This PRD's
+#    trait section is corrected below to REUSE those real types directly
+#    (DRY — don't build a parallel Blake3/NodeId system that doesn't exist
+#    anywhere else in this codebase) rather than the aspirational shape
+#    originally drafted here by analogy by from the PRD's own prose.
+
+[traits]
+
+## Reused as-is from b00t-c0re-lib::reviewer — no changes needed
+reused_from_reviewer_module = """
+// b00t_c0re_lib::reviewer::evidence::CommandEvidence — reused directly:
+//   CommandEvidence::new(content: impl AsRef<[u8]>, verdict: &VerdictDisposition, command: impl Into<String>) -> Self
+//   .to_evidence_node() -> EvidenceNode { commit_hash: String (sha256 hex), verdict: String, notes_ref: String }
+//   .verify() -> bool (self-consistency check)
+// b00t_c0re_lib::reviewer::evidence::ProduceEvidence trait — implement this
+//   for SudoReviewEvent instead of inventing a new evidence trait.
+// VerdictDisposition doesn't fit sudo (2 variants, no ttl) — see SudoDisposition below,
+// but CommandEvidence::new() takes `&VerdictDisposition` positionally only to call
+// `.to_string()` on it for the `verdict` field, so SudoDisposition needs its own
+// Display impl and its OWN thin CommandEvidence-shaped struct (SudoGrantEvidence)
+// rather than shoehorning into VerdictDisposition's type — same SHA-256 mechanism,
+// distinct type, avoids polluting the reviewer module with sudo-specific semantics.
+"""
+
+## SudoDisposition — new, sibling of VerdictDisposition (shape differs: 3 variants + ttl)
+sudo_disposition_type = """
+use serde::{Deserialize, Serialize};
+
+/// The disposition of an adversarial sudo-grant review.
+/// UFO: Moment::Mode — intrinsic property of the review event, same
+/// grounding as VerdictDisposition in reviewer::governance.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub enum SudoDisposition {
+    Grant { ttl_seconds: u64 },
+    Deny { reason: String },
+    Escalate { reason: String },
+}
+
+impl std::fmt::Display for SudoDisposition {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            SudoDisposition::Grant { ttl_seconds } => write!(f, "GRANT(ttl={ttl_seconds}s)"),
+            SudoDisposition::Deny { reason } => write!(f, "DENY({reason})"),
+            SudoDisposition::Escalate { reason } => write!(f, "ESCALATE({reason})"),
+        }
+    }
+}
+"""
+
+## SudoGrantEvidence — mirrors CommandEvidence's shape/mechanism exactly (SHA-256, no git dep in the evidence layer itself)
+sudo_grant_evidence_type = """
+use sha2::{Sha256, Digest};
+
+/// Evidence that a sudo-grant review was performed with a given disposition.
+/// Content-addressed via SHA-256 — same mechanism as reviewer::evidence::CommandEvidence,
+/// distinct type because the content being hashed (command + justification + cited
+/// commits' `git show --stat` output) and the disposition shape (3 variants + ttl)
+/// differ from the reviewer's diff+findings shape.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SudoGrantEvidence {
+    pub content_hash: String,   // SHA-256 of command + justification + cited-commit `git show --stat` text
+    pub disposition: String,    // SudoDisposition::to_string()
+    pub command: String,
+    pub checkpoint_ref: Option<String>,   // set after checkpoint_system_state(), None until then
+    pub timestamp: String,      // ISO 8601, chrono::Utc::now().to_rfc3339()
+}
+
+impl SudoGrantEvidence {
+    pub fn new(content: impl AsRef<[u8]>, disposition: &SudoDisposition, command: impl Into<String>) -> Self {
+        let mut hasher = Sha256::new();
+        hasher.update(content.as_ref());
+        let content_hash = format!("{:x}", hasher.finalize());
+        Self {
+            content_hash,
+            disposition: disposition.to_string(),
+            command: command.into(),
+            checkpoint_ref: None,
+            timestamp: chrono::Utc::now().to_rfc3339(),
+        }
+    }
+
+    /// Self-consistency check — same shape as CommandEvidence::verify().
+    pub fn verify(&self) -> bool {
+        self.content_hash.len() == 64
+            && self.content_hash.chars().all(|c| c.is_ascii_hexdigit())
+            && !self.disposition.is_empty()
+    }
+}
+"""
+
+# ── Hook Integration ─────────────────────────────────────────────────────────
+
+[hook_integration]
+hook_flow = """
+1. `b00t exec --justification "..." --cites <hash>... "<cmd>"` invoked
+2. check_guards() evaluates the command — if not Block, existing behavior unchanged
+3. If Block AND --justification present: build SudoReviewEvent, call
+   SudoGrantVerdict::satisfies(&SudoGrantConstraint) — queries sm0l with
+   command + justification + `git show --stat` of each cited commit
+4. Grant  → checkpoint_system_state() → execute command → record evidence + receipt
+5. Deny   → refuse, print reason, no command execution, no evidence needed
+6. Escalate → fire n8n webhook (SudoEscalation event, fans out to configured
+   Slack/email/SMS channels outside b00t) + local `notify-send` → deny for now
+7. If --justification absent: existing 300s-TTL block-then-resubmit path
+   is UNCHANGED — this feature is additive, not a replacement for existing
+   guard usage that doesn't opt in.
+"""
+
+# 🤓 The critical invariant, same as the reviewer-governance PRD: a Granted
+# command MUST have both an evidence node AND a checkpoint reference before
+# it executes. Escalate never executes anything — it only notifies.
+
+# ── Implementation Phases ────────────────────────────────────────────────────
+
+[implementation]
+phases = [
+    {
+        "phase": 1,
+        "name": "Core Traits",
+        "description": "Define SudoGrantConstraint, SudoGrantVerdict, SudoDisposition, SudoCommandTracker in b00t-c0re-lib. Ground in UFO stereotypes. Sibling of the (also unbuilt) reviewer/governance.rs.",
+        "effort": "frontier",
+        "depends_on": [],
+        "deliverable": "b00t-c0re-lib/src/sudo_operator/governance.rs"
+    },
+    {
+        "phase": 2,
+        "name": "Checkpoint",
+        "description": "Generalize job_executor.rs::create_checkpoint's git-tag pattern into checkpoint_system_state(); add systemctl show / kubectl get -o yaml artifact dump for non-git state.",
+        "effort": "ch0nky",
+        "depends_on": ["phase-1"],
+        "deliverable": "b00t-c0re-lib/src/sudo_operator/checkpoint.rs"
+    },
+    {
+        "phase": 3,
+        "name": "Adversarial Verdict",
+        "description": "Build review prompt, call sm0l OpenAI-compat endpoint (:8000), parse structured Grant/Deny/Escalate verdict, shell `git show --stat` for cited commits to ground the review.",
+        "effort": "ch0nky",
+        "depends_on": ["phase-1"],
+        "deliverable": "b00t-c0re-lib/src/sudo_operator/verdict.rs"
+    },
+    {
+        "phase": 4,
+        "name": "exec.rs Integration",
+        "description": "Add --justification/--cites flags to handle_exec. Route Block-tier + justification-present through the new verdict flow; leave the existing 300s-TTL bypass unchanged for the no-flag case.",
+        "effort": "ch0nky",
+        "depends_on": ["phase-2", "phase-3"],
+        "deliverable": "b00t-cli/src/commands/exec.rs (updated)"
+    },
+    {
+        "phase": 5,
+        "name": "Escalation Channel",
+        "description": "Reuse budget_controller.rs::send_alert()'s n8n webhook client for a new SudoEscalation event type. Add notify-send desktop fallback.",
+        "effort": "sm0l",
+        "depends_on": ["phase-4"],
+        "deliverable": "b00t-cli/src/budget_controller.rs (updated)"
+    },
+    {
+        "phase": 6,
+        "name": "Ledgerr MCP Actions (follow-up)",
+        "description": "sudo_grant_record / verify / checkpoint_ref as thin MCP wrappers, mirroring reviewer_evidence_* actions in ledgerr-mcp. NOT in v1 scope.",
+        "effort": "sm0l",
+        "depends_on": ["phase-4"],
+        "deliverable": "ledgerr-mcp/src/actions/sudo_grant.rs"
+    },
+]
+
+# ── Acceptance Criteria ──────────────────────────────────────────────────────
+
+[acceptance]
+must = [
+    "SudoGrantVerdict implements Satisfies<SudoGrantConstraint>",
+    "evidence_node() produces deterministic Blake3 hash from command + justification + cited commits + disposition",
+    "Grant requires BOTH evidence_node() AND checkpoint_system_state() before command executes",
+    "Deny and Escalate never execute the command",
+    "Escalate fires the n8n webhook AND notify-send, then denies (no synchronous wait in v1)",
+    "Commands run WITHOUT --justification are completely unaffected (existing 300s-TTL behavior unchanged)",
+    "Every type has a UFO stereotype grounding comment",
+]
+should = [
+    "Verdict queries sm0l (not ch0nky) — this is a bounded classification decision, not open-ended generation, keep it fast/cheap",
+    "Cited commit hashes are verified to exist in the current repo before being trusted (git show failure → treat as unverifiable, lower confidence)",
+    "Checkpoint artifacts are human-readable (plain git tag + text dump), not a new binary format",
+]
+
+# ── Success Metrics ──────────────────────────────────────────────────────────
+
+[metrics]
+targets = [
+    "Zero Granted commands executed without both evidence AND checkpoint (governance invariant)",
+    "Zero regression: existing Block-then-manual-resubmit behavior identical for non-justification callers",
+    "Escalation reaches at least 2 channels (n8n-fanout + local desktop) within 5s of Escalate verdict",
+]
+
+# ── Related Datums ───────────────────────────────────────────────────────────
+
+[[related]]
+datum = "PRD-REVIEWER-GOVERNANCE-ENGINE"
+note  = "Parent pattern — this PRD is the same Satisfies<Constraint>+evidence+CommandTracker architecture applied to sudo grants instead of review verdicts. Reuses the trait shape, not a parallel design."
+
+[[related]]
+datum = "PRD-TAX-LAWYER-UFO-SDD"
+note  = "Root pattern both this PRD and PRD-REVIEWER-GOVERNANCE-ENGINE inherit from — every action is a thin wrapper over Satisfies<Constraint>, producing arc-kit-au evidence."
+
+[[related]]
+datum = "VENDOR-LEDGRRR"
+note  = "Real, working, actively-committed submodule (arc-kit-au evidence graph) — confirmed via direct research this session, not a stub. NOT used directly by v1 of this PRD (v1 reuses b00t-c0re-lib::reviewer's self-contained SHA-256 evidence pattern instead, matching what's actually implemented there); wiring evidence into the arc-kit-au graph proper is phase-6 follow-up, same as it is for the reviewer-governance PRD."
+
+[[related]]
+datum = "project_gpu_hive_scheduling"
+note  = "sm0l/ch0nky GPU-accounted k8s scheduling, built same session — the adversarial-review model (sm0l) this PRD depends on already runs reliably as a result."

--- a/b00t-c0re-lib/src/lib.rs
+++ b/b00t-c0re-lib/src/lib.rs
@@ -62,6 +62,7 @@ pub mod query_bus;
 pub mod rag;
 pub mod reasoning;
 pub mod reviewer;
+pub mod sudo_operator;
 pub mod redis;
 pub mod rhai_engine;
 pub mod runtime_env;

--- a/b00t-c0re-lib/src/sudo_operator/checkpoint.rs
+++ b/b00t-c0re-lib/src/sudo_operator/checkpoint.rs
@@ -1,0 +1,141 @@
+// b00t-c0re-lib/src/sudo_operator/checkpoint.rs
+// 🤓 Pre-grant system-state checkpoint. Generalizes job_executor.rs's
+//    git-tag checkpoint pattern (b00t-cli/src/job_executor.rs::create_checkpoint,
+//    lines ~213-238) into a standalone function usable outside job execution.
+//
+//    v1 scope: gives an operator what they need to MANUALLY revert (a git
+//    tag + a text dump of relevant systemd/k8s state). Automated rollback
+//    execution is explicit follow-up (see PRD-SUDO-OPERATOR-GOVERNANCE).
+
+use anyhow::Result;
+use duct::cmd;
+use serde::{Deserialize, Serialize};
+use std::path::Path;
+
+/// Where the checkpoint's evidence actually lives — a git tag for repo
+/// state, and/or a text artifact path for systemd/k8s state that isn't
+/// captured by git.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CheckpointRef {
+    pub git_tag: Option<String>,
+    pub state_dump_path: Option<String>,
+}
+
+impl CheckpointRef {
+    pub fn is_empty(&self) -> bool {
+        self.git_tag.is_none() && self.state_dump_path.is_none()
+    }
+
+    /// A single-string reference for embedding in SudoGrantEvidence.checkpoint_ref.
+    pub fn as_evidence_string(&self) -> String {
+        match (&self.git_tag, &self.state_dump_path) {
+            (Some(tag), Some(dump)) => format!("git_tag={tag};state_dump={dump}"),
+            (Some(tag), None) => format!("git_tag={tag}"),
+            (None, Some(dump)) => format!("state_dump={dump}"),
+            (None, None) => "none".to_string(),
+        }
+    }
+}
+
+/// Capture a pre-command checkpoint before a Granted privileged command runs.
+///
+/// `project_root`: git repo to tag, if `Some` and it's actually a git repo
+///   (tagging failure is non-fatal — same "don't block on checkpoint failure"
+///   behavior as job_executor.rs::create_checkpoint).
+/// `checkpoint_id`: unique-ish id for this grant (e.g. the SudoGrantEvidence
+///   content_hash, truncated) — becomes `checkpoint/sudo/<checkpoint_id>`.
+/// `state_dump_cmd`: an optional command (e.g. `["systemctl", "show", "k0scontroller"]`
+///   or `["kubectl", "get", "deployment/ch0nky", "-n", "b00t-inference", "-o", "yaml"]`)
+///   whose output gets written to `~/.b00t/checkpoints/<checkpoint_id>.txt` so a
+///   human has concrete pre-state to compare against if they need to revert.
+pub fn checkpoint_system_state(
+    project_root: Option<&Path>,
+    checkpoint_id: &str,
+    state_dump_cmd: Option<&[String]>,
+) -> Result<CheckpointRef> {
+    let git_tag = project_root.and_then(|root| {
+        let tag_name = format!("checkpoint/sudo/{checkpoint_id}");
+        let message = format!("Sudo-grant checkpoint: {checkpoint_id}");
+        match cmd!("git", "tag", "-a", &tag_name, "-m", &message)
+            .dir(root)
+            .stdout_to_stderr()
+            .run()
+        {
+            Ok(_) => Some(tag_name),
+            Err(e) => {
+                // Non-fatal — don't block the grant on checkpoint failure,
+                // same policy as job_executor.rs's create_checkpoint.
+                eprintln!("⚠️  sudo-operator checkpoint: git tag failed: {e}");
+                None
+            }
+        }
+    });
+
+    let state_dump_path = state_dump_cmd.and_then(|argv| {
+        if argv.is_empty() {
+            return None;
+        }
+        let output = cmd(&argv[0], &argv[1..]).stderr_to_stdout().read();
+        match output {
+            Ok(text) => {
+                let dir = shellexpand::tilde("~/.b00t/checkpoints").to_string();
+                if std::fs::create_dir_all(&dir).is_err() {
+                    return None;
+                }
+                let path = format!("{dir}/{checkpoint_id}.txt");
+                match std::fs::write(&path, text) {
+                    Ok(_) => Some(path),
+                    Err(e) => {
+                        eprintln!("⚠️  sudo-operator checkpoint: failed to write state dump: {e}");
+                        None
+                    }
+                }
+            }
+            Err(e) => {
+                eprintln!("⚠️  sudo-operator checkpoint: state dump command failed: {e}");
+                None
+            }
+        }
+    });
+
+    Ok(CheckpointRef {
+        git_tag,
+        state_dump_path,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_checkpoint_ref_empty() {
+        let r = CheckpointRef {
+            git_tag: None,
+            state_dump_path: None,
+        };
+        assert!(r.is_empty());
+        assert_eq!(r.as_evidence_string(), "none");
+    }
+
+    #[test]
+    fn test_checkpoint_ref_evidence_string_both() {
+        let r = CheckpointRef {
+            git_tag: Some("checkpoint/sudo/abc".into()),
+            state_dump_path: Some("/tmp/abc.txt".into()),
+        };
+        assert!(!r.is_empty());
+        assert_eq!(
+            r.as_evidence_string(),
+            "git_tag=checkpoint/sudo/abc;state_dump=/tmp/abc.txt"
+        );
+    }
+
+    #[test]
+    fn test_checkpoint_no_project_root_no_dump_cmd() {
+        // With nothing to checkpoint, should return an empty-but-Ok ref,
+        // never fail the grant.
+        let result = checkpoint_system_state(None, "test-id", None).unwrap();
+        assert!(result.is_empty());
+    }
+}

--- a/b00t-c0re-lib/src/sudo_operator/governance.rs
+++ b/b00t-c0re-lib/src/sudo_operator/governance.rs
@@ -1,0 +1,202 @@
+// b00t-c0re-lib/src/sudo_operator/governance.rs
+// 🤓 Governance types for the sudo-grant adversarial-review pipeline.
+//    Sibling of reviewer::governance — reuses the SAME evidence mechanism
+//    (SHA-256 content-addressed, no external crate dependency) rather than
+//    inventing a parallel Blake3/NodeId system. See PRD-SUDO-OPERATOR-GOVERNANCE
+//    for the corrected-after-reading-the-real-code rationale.
+//
+//    UFO grounding: SudoDisposition = Moment::Mode (same as VerdictDisposition),
+//    SudoGrantEvidence = Endurant::SubKind (same as CommandEvidence).
+//
+//    Without evidence → command DID NOT HAPPEN. Grant additionally requires
+//    a checkpoint reference before the command executes (see checkpoint.rs).
+
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+
+// ── Sudo Disposition ─────────────────────────────────────────────────────────
+// UFO: Moment::Mode — intrinsic property of the review event.
+
+/// The disposition of an adversarial sudo-grant review.
+/// Three variants (vs VerdictDisposition's two) because a sudo grant needs
+/// a distinct "can't decide, ask a human" state, and Grant carries a TTL.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub enum SudoDisposition {
+    /// Command may execute; grant expires after ttl_seconds.
+    Grant { ttl_seconds: u64 },
+    /// Command must not execute.
+    Deny { reason: String },
+    /// The model can't confidently decide — escalate to a human, deny for now.
+    Escalate { reason: String },
+}
+
+impl std::fmt::Display for SudoDisposition {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            SudoDisposition::Grant { ttl_seconds } => write!(f, "GRANT(ttl={ttl_seconds}s)"),
+            SudoDisposition::Deny { reason } => write!(f, "DENY({reason})"),
+            SudoDisposition::Escalate { reason } => write!(f, "ESCALATE({reason})"),
+        }
+    }
+}
+
+impl SudoDisposition {
+    /// Whether this disposition permits the command to execute.
+    pub fn permits_execution(&self) -> bool {
+        matches!(self, SudoDisposition::Grant { .. })
+    }
+}
+
+// ── Sudo Review Event ────────────────────────────────────────────────────────
+// UFO: Perdurant::Event — the review itself, unfolding: command received →
+// justification parsed → cited commits inspected → model queried → verdict.
+
+/// The full context of a single adversarial sudo-grant review.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SudoReviewEvent {
+    pub command: String,
+    pub justification: String,
+    pub cited_commits: Vec<String>,
+    /// `git show --stat` output for each cited commit that resolved
+    /// successfully — grounds the review in a real diff, not just trusted
+    /// free text. Commits that fail to resolve are simply omitted (treated
+    /// as unverifiable, lowering confidence in the eventual verdict).
+    pub cited_commit_evidence: Vec<String>,
+}
+
+impl SudoReviewEvent {
+    /// The content that gets hashed for evidence — deterministic ordering.
+    pub fn content_bytes(&self) -> Vec<u8> {
+        let mut buf = Vec::new();
+        buf.extend_from_slice(self.command.as_bytes());
+        buf.extend_from_slice(self.justification.as_bytes());
+        for c in &self.cited_commits {
+            buf.extend_from_slice(c.as_bytes());
+        }
+        for e in &self.cited_commit_evidence {
+            buf.extend_from_slice(e.as_bytes());
+        }
+        buf
+    }
+}
+
+// ── Sudo Grant Evidence ──────────────────────────────────────────────────────
+// UFO: Endurant::SubKind — persists beyond the review event, same subkind as
+// reviewer::evidence::CommandEvidence.
+
+/// Evidence that a sudo-grant review was performed with a given disposition.
+/// Content-addressed via SHA-256 — identical mechanism to CommandEvidence,
+/// distinct type because the hashed content and disposition shape differ.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SudoGrantEvidence {
+    pub content_hash: String,
+    pub disposition: String,
+    pub command: String,
+    /// Set by checkpoint_system_state() after a Grant; None until then.
+    pub checkpoint_ref: Option<String>,
+    pub timestamp: String,
+}
+
+impl SudoGrantEvidence {
+    pub fn new(event: &SudoReviewEvent, disposition: &SudoDisposition) -> Self {
+        let mut hasher = Sha256::new();
+        hasher.update(event.content_bytes());
+        hasher.update(disposition.to_string().as_bytes());
+        let content_hash = format!("{:x}", hasher.finalize());
+
+        Self {
+            content_hash,
+            disposition: disposition.to_string(),
+            command: event.command.clone(),
+            checkpoint_ref: None,
+            timestamp: chrono::Utc::now().to_rfc3339(),
+        }
+    }
+
+    pub fn with_checkpoint(mut self, checkpoint_ref: impl Into<String>) -> Self {
+        self.checkpoint_ref = Some(checkpoint_ref.into());
+        self
+    }
+
+    /// Self-consistency check — same shape as CommandEvidence::verify().
+    pub fn verify(&self) -> bool {
+        self.content_hash.len() == 64
+            && self.content_hash.chars().all(|c| c.is_ascii_hexdigit())
+            && !self.disposition.is_empty()
+            && !self.command.is_empty()
+    }
+
+    /// Governance invariant: a Grant's evidence MUST carry a checkpoint
+    /// reference before the command it authorizes may execute.
+    pub fn grant_is_execution_ready(&self) -> bool {
+        self.disposition.starts_with("GRANT") && self.checkpoint_ref.is_some()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_event() -> SudoReviewEvent {
+        SudoReviewEvent {
+            command: "sudo systemctl restart k0scontroller".into(),
+            justification: "kubelet device-plugin registration wedged".into(),
+            cited_commits: vec!["deadbeef".into()],
+            cited_commit_evidence: vec!["1 file changed".into()],
+        }
+    }
+
+    #[test]
+    fn test_evidence_deterministic() {
+        let event = sample_event();
+        let disposition = SudoDisposition::Grant { ttl_seconds: 300 };
+        let a = SudoGrantEvidence::new(&event, &disposition);
+        let b = SudoGrantEvidence::new(&event, &disposition);
+        assert_eq!(a.content_hash, b.content_hash);
+    }
+
+    #[test]
+    fn test_evidence_differs_by_disposition() {
+        let event = sample_event();
+        let grant = SudoGrantEvidence::new(&event, &SudoDisposition::Grant { ttl_seconds: 300 });
+        let deny = SudoGrantEvidence::new(
+            &event,
+            &SudoDisposition::Deny { reason: "no".into() },
+        );
+        assert_ne!(grant.content_hash, deny.content_hash);
+    }
+
+    #[test]
+    fn test_evidence_valid_hash() {
+        let event = sample_event();
+        let evidence = SudoGrantEvidence::new(&event, &SudoDisposition::Grant { ttl_seconds: 60 });
+        assert!(evidence.verify());
+    }
+
+    #[test]
+    fn test_grant_not_execution_ready_without_checkpoint() {
+        let event = sample_event();
+        let evidence = SudoGrantEvidence::new(&event, &SudoDisposition::Grant { ttl_seconds: 60 });
+        assert!(!evidence.grant_is_execution_ready());
+        let with_cp = evidence.with_checkpoint("checkpoint/sudo/abc123");
+        assert!(with_cp.grant_is_execution_ready());
+    }
+
+    #[test]
+    fn test_deny_never_execution_ready() {
+        let event = sample_event();
+        let evidence = SudoGrantEvidence::new(
+            &event,
+            &SudoDisposition::Deny { reason: "insufficient justification".into() },
+        )
+        .with_checkpoint("checkpoint/sudo/should-not-matter");
+        assert!(!evidence.grant_is_execution_ready());
+    }
+
+    #[test]
+    fn test_permits_execution() {
+        assert!(SudoDisposition::Grant { ttl_seconds: 1 }.permits_execution());
+        assert!(!SudoDisposition::Deny { reason: "x".into() }.permits_execution());
+        assert!(!SudoDisposition::Escalate { reason: "x".into() }.permits_execution());
+    }
+}

--- a/b00t-c0re-lib/src/sudo_operator/mod.rs
+++ b/b00t-c0re-lib/src/sudo_operator/mod.rs
@@ -1,0 +1,13 @@
+// b00t-c0re-lib/src/sudo_operator/mod.rs
+// 🤓 Sudo-grant governance — adversarial-model review gate for privileged
+//    commands. Sibling of the `reviewer` module; see PRD-SUDO-OPERATOR-GOVERNANCE.
+//    Reuses reviewer::evidence's SHA-256 content-addressed mechanism rather
+//    than a parallel evidence system.
+
+pub mod checkpoint;
+pub mod governance;
+pub mod verdict;
+
+pub use checkpoint::{checkpoint_system_state, CheckpointRef};
+pub use governance::{SudoDisposition, SudoGrantEvidence, SudoReviewEvent};
+pub use verdict::adversarial_review;

--- a/b00t-c0re-lib/src/sudo_operator/verdict.rs
+++ b/b00t-c0re-lib/src/sudo_operator/verdict.rs
@@ -1,0 +1,261 @@
+// b00t-c0re-lib/src/sudo_operator/verdict.rs
+// 🤓 Adversarial review: queries sm0l (fast/cheap — this is a bounded
+//    classification decision, not open-ended generation) with the command,
+//    justification, and `git show --stat` of any cited commits, and parses
+//    a structured Grant/Deny/Escalate verdict.
+//
+//    Safety property: any failure to get a clean, parseable Grant/Deny
+//    verdict from the model defaults to Escalate, NEVER to Grant. An
+//    ambiguous or malformed model response must never silently authorize
+//    a privileged command.
+
+use super::governance::{SudoDisposition, SudoReviewEvent};
+use anyhow::Result;
+use duct::cmd;
+use serde::Deserialize;
+use std::path::Path;
+
+/// Default sm0l OpenAI-compatible endpoint. `b00t exec` runs on the host,
+/// not inside the k8s cluster, so this must be the NodePort (30801), not
+/// the in-cluster Service port (8000) that hive.toml's B00T_AI_CH0NKY_BASE-
+/// style vars assume for pod-to-pod traffic. Overridable via env.
+const DEFAULT_SM0L_BASE: &str = "http://127.0.0.1:30801/v1";
+const SM0L_API_KEY: &str = "local-b00t";
+
+/// Resolve `git show --stat` for each cited commit hash, in `project_root`.
+/// Commits that fail to resolve are simply omitted — treated as
+/// unverifiable, which the review prompt is told about explicitly so the
+/// model can weigh an unverifiable citation as weaker evidence.
+fn resolve_cited_commits(project_root: &Path, cited_commits: &[String]) -> Vec<String> {
+    cited_commits
+        .iter()
+        .filter_map(|hash| {
+            cmd!("git", "show", "--stat", hash)
+                .dir(project_root)
+                .read()
+                .ok()
+        })
+        .collect()
+}
+
+fn build_review_event(
+    project_root: &Path,
+    command: &str,
+    justification: &str,
+    cited_commits: &[String],
+) -> SudoReviewEvent {
+    let cited_commit_evidence = resolve_cited_commits(project_root, cited_commits);
+    SudoReviewEvent {
+        command: command.to_string(),
+        justification: justification.to_string(),
+        cited_commits: cited_commits.to_vec(),
+        cited_commit_evidence,
+    }
+}
+
+fn build_prompt(event: &SudoReviewEvent) -> String {
+    let unverifiable = event.cited_commits.len().saturating_sub(event.cited_commit_evidence.len());
+    let evidence_block = if event.cited_commit_evidence.is_empty() {
+        "(no cited commits resolved in this repo)".to_string()
+    } else {
+        event.cited_commit_evidence.join("\n---\n")
+    };
+
+    format!(
+        r#"You are a security gate reviewing a request to run a privileged/disruptive command.
+Respond with ONLY a JSON object, no other text: {{"disposition": "grant"|"deny"|"escalate", "reason": "<one sentence>", "ttl_seconds": <int, only if grant>}}
+
+Rules:
+- "grant" only if the justification is specific and plausible, AND either no commits were cited or at least one cited commit's diff genuinely supports the justification.
+- "deny" if the justification is vague, generic, or contradicted by the cited diff.
+- "escalate" if you are not confident either way, or the command's blast radius is ambiguous — this is the SAFE default when uncertain.
+- {unverifiable} of {total} cited commit(s) could not be resolved in this repository — treat unresolved citations as weaker evidence, lean toward escalate/deny if the justification otherwise relies on them.
+
+COMMAND: {command}
+
+JUSTIFICATION: {justification}
+
+CITED COMMIT EVIDENCE:
+{evidence_block}
+"#,
+        unverifiable = unverifiable,
+        total = event.cited_commits.len(),
+        command = event.command,
+        justification = event.justification,
+        evidence_block = evidence_block,
+    )
+}
+
+#[derive(Debug, Deserialize)]
+struct RawVerdict {
+    disposition: String,
+    reason: String,
+    #[serde(default)]
+    ttl_seconds: Option<u64>,
+}
+
+#[derive(Deserialize)]
+struct ChatCompletionResponse {
+    choices: Vec<ChatChoice>,
+}
+
+#[derive(Deserialize)]
+struct ChatChoice {
+    message: ChatMessage,
+}
+
+#[derive(Deserialize)]
+struct ChatMessage {
+    content: String,
+}
+
+/// Extract the first `{...}` JSON object from model output — models often
+/// wrap JSON in prose or markdown fences despite instructions not to.
+fn extract_json_object(text: &str) -> Option<&str> {
+    let start = text.find('{')?;
+    let end = text.rfind('}')?;
+    if end > start {
+        Some(&text[start..=end])
+    } else {
+        None
+    }
+}
+
+fn parse_verdict(raw_content: &str) -> SudoDisposition {
+    let Some(json_str) = extract_json_object(raw_content) else {
+        return SudoDisposition::Escalate {
+            reason: "adversarial model response contained no parseable JSON".into(),
+        };
+    };
+
+    let Ok(raw) = serde_json::from_str::<RawVerdict>(json_str) else {
+        return SudoDisposition::Escalate {
+            reason: "adversarial model response JSON did not match expected shape".into(),
+        };
+    };
+
+    match raw.disposition.to_lowercase().as_str() {
+        "grant" => SudoDisposition::Grant {
+            ttl_seconds: raw.ttl_seconds.unwrap_or(300),
+        },
+        "deny" => SudoDisposition::Deny { reason: raw.reason },
+        "escalate" => SudoDisposition::Escalate { reason: raw.reason },
+        other => SudoDisposition::Escalate {
+            reason: format!("adversarial model returned unrecognized disposition '{other}'"),
+        },
+    }
+}
+
+/// Perform the full adversarial review: build the event, query sm0l,
+/// parse the verdict. Never returns Grant on any error path — falls back
+/// to Escalate so a network/parse failure can't silently authorize a
+/// privileged command.
+pub fn adversarial_review(
+    project_root: &Path,
+    command: &str,
+    justification: &str,
+    cited_commits: &[String],
+) -> Result<(SudoReviewEvent, SudoDisposition)> {
+    let event = build_review_event(project_root, command, justification, cited_commits);
+    let prompt = build_prompt(&event);
+
+    let base_url = std::env::var("B00T_AI_SM0L_BASE").unwrap_or_else(|_| DEFAULT_SM0L_BASE.to_string());
+    let url = format!("{}/chat/completions", base_url.trim_end_matches('/'));
+
+    let body = serde_json::json!({
+        "model": "sm0l",
+        "temperature": 0.0,
+        "max_tokens": 200,
+        "messages": [{"role": "user", "content": prompt}],
+    });
+
+    let client = reqwest::blocking::Client::new();
+    let response = client
+        .post(&url)
+        .bearer_auth(SM0L_API_KEY)
+        .json(&body)
+        .send();
+
+    let disposition = match response {
+        Ok(resp) if resp.status().is_success() => match resp.json::<ChatCompletionResponse>() {
+            Ok(parsed) => match parsed.choices.first() {
+                Some(choice) => parse_verdict(&choice.message.content),
+                None => SudoDisposition::Escalate {
+                    reason: "adversarial model returned no choices".into(),
+                },
+            },
+            Err(e) => SudoDisposition::Escalate {
+                reason: format!("failed to parse adversarial model response: {e}"),
+            },
+        },
+        Ok(resp) => SudoDisposition::Escalate {
+            reason: format!("adversarial model endpoint returned {}", resp.status()),
+        },
+        Err(e) => SudoDisposition::Escalate {
+            reason: format!("failed to reach adversarial model endpoint: {e}"),
+        },
+    };
+
+    Ok((event, disposition))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_extract_json_object_plain() {
+        let text = r#"{"disposition": "grant", "reason": "ok", "ttl_seconds": 60}"#;
+        assert_eq!(extract_json_object(text), Some(text));
+    }
+
+    #[test]
+    fn test_extract_json_object_wrapped_in_prose() {
+        let text = "Sure, here is my verdict:\n```json\n{\"disposition\": \"deny\", \"reason\": \"no\"}\n```\nHope that helps!";
+        let extracted = extract_json_object(text).unwrap();
+        assert!(extracted.starts_with('{') && extracted.ends_with('}'));
+        let parsed: RawVerdict = serde_json::from_str(extracted).unwrap();
+        assert_eq!(parsed.disposition, "deny");
+    }
+
+    #[test]
+    fn test_extract_json_object_none() {
+        assert_eq!(extract_json_object("no json here"), None);
+    }
+
+    #[test]
+    fn test_parse_verdict_grant() {
+        let v = parse_verdict(r#"{"disposition": "grant", "reason": "plausible", "ttl_seconds": 120}"#);
+        assert_eq!(v, SudoDisposition::Grant { ttl_seconds: 120 });
+    }
+
+    #[test]
+    fn test_parse_verdict_grant_default_ttl() {
+        let v = parse_verdict(r#"{"disposition": "GRANT", "reason": "plausible"}"#);
+        assert_eq!(v, SudoDisposition::Grant { ttl_seconds: 300 });
+    }
+
+    #[test]
+    fn test_parse_verdict_deny() {
+        let v = parse_verdict(r#"{"disposition": "deny", "reason": "vague justification"}"#);
+        assert_eq!(v, SudoDisposition::Deny { reason: "vague justification".into() });
+    }
+
+    #[test]
+    fn test_parse_verdict_malformed_json_escalates_not_grants() {
+        let v = parse_verdict("not json at all");
+        assert!(matches!(v, SudoDisposition::Escalate { .. }));
+    }
+
+    #[test]
+    fn test_parse_verdict_unrecognized_disposition_escalates() {
+        let v = parse_verdict(r#"{"disposition": "maybe", "reason": "unsure"}"#);
+        assert!(matches!(v, SudoDisposition::Escalate { .. }));
+    }
+
+    #[test]
+    fn test_parse_verdict_missing_field_escalates() {
+        let v = parse_verdict(r#"{"foo": "bar"}"#);
+        assert!(matches!(v, SudoDisposition::Escalate { .. }));
+    }
+}

--- a/b00t-cli/src/budget_controller.rs
+++ b/b00t-cli/src/budget_controller.rs
@@ -219,6 +219,53 @@ impl BudgetController {
     }
 }
 
+/// n8n webhook payload for a sudo-grant escalation (PRD-SUDO-OPERATOR-GOVERNANCE).
+/// Fired when the adversarial review model can't confidently Grant or Deny.
+/// n8n fans this out to whatever downstream channels (Slack/email/SMS) are
+/// configured in the workflow — b00t itself only needs to know about n8n.
+#[derive(Debug, Serialize)]
+pub struct SudoEscalationAlert {
+    pub event: String,
+    pub command: String,
+    pub justification: String,
+    pub cited_commits: Vec<String>,
+    pub reason: String,
+    pub timestamp: String,
+}
+
+/// Fire a sudo-grant escalation to the configured n8n webhook.
+///
+/// Sync (uses `reqwest::blocking`) because the call site (`b00t exec`'s
+/// `handle_exec`) is a synchronous function — same HTTP-POST-JSON pattern
+/// as `BudgetController::send_alert`, just not tied to the async k8s
+/// reconciliation path that struct lives on. Best-effort: a webhook
+/// failure is logged but never blocks the (already-denied) command path.
+///
+/// Webhook URL comes from `B00T_N8N_WEBHOOK_URL`; if unset, this is a no-op
+/// (same "skip silently" policy as `BudgetController::send_alert` when its
+/// `webhook_url` is `None`).
+pub fn fire_sudo_escalation(command: &str, justification: &str, cited_commits: &[String], reason: &str) {
+    let Ok(webhook_url) = std::env::var("B00T_N8N_WEBHOOK_URL") else {
+        return;
+    };
+
+    let alert = SudoEscalationAlert {
+        event: "sudo_grant_escalation".to_string(),
+        command: command.to_string(),
+        justification: justification.to_string(),
+        cited_commits: cited_commits.to_vec(),
+        reason: reason.to_string(),
+        timestamp: chrono::Utc::now().to_rfc3339(),
+    };
+
+    let client = reqwest::blocking::Client::new();
+    match client.post(&webhook_url).json(&alert).send() {
+        Ok(resp) if resp.status().is_success() => {}
+        Ok(resp) => eprintln!("⚠️  sudo-escalation webhook returned {}", resp.status()),
+        Err(e) => eprintln!("⚠️  sudo-escalation webhook failed: {e}"),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/b00t-cli/src/commands/exec.rs
+++ b/b00t-cli/src/commands/exec.rs
@@ -62,15 +62,36 @@ pub struct ExecArgs {
         help = "Sandbox provider: direct | systemd-run | podman"
     )]
     pub sandbox: String,
+
+    #[clap(
+        long,
+        help = "Justification for a Block-tier command — routes through adversarial-model review instead of the 5-minute resubmit bypass. See PRD-SUDO-OPERATOR-GOVERNANCE."
+    )]
+    pub justification: Option<String>,
+
+    #[clap(
+        long,
+        num_args = 0..,
+        help = "Commit hash(es) supporting --justification; their `git show --stat` grounds the adversarial review"
+    )]
+    pub cites: Vec<String>,
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Default)]
 struct AuditLogEntry {
     ts: String,     // ISO8601
     cmd: String,    // full command string
-    result: String, // "allow" | "warn" | "block-rejected" | "block-forced" | "background"
+    result: String, // "allow" | "warn" | "block-rejected" | "block-forced" | "background" | "sudo-granted" | "sudo-denied" | "sudo-escalated"
     guard_msg: Option<String>,
     pid: Option<u32>, // child PID if executed
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    justification: Option<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    cited_commits: Vec<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    sudo_disposition: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    checkpoint_ref: Option<String>,
 }
 
 /// Load block-cache: cmd_key → unix timestamp of first rejection
@@ -191,6 +212,91 @@ pub fn handle_exec(args: &ExecArgs, path: &str) -> Result<()> {
             // broad authority: proceed without user gate
         }
         GuardResult::Block { message } => {
+          if let Some(justification) = &args.justification {
+            // Adversarial-review path (PRD-SUDO-OPERATOR-GOVERNANCE) —
+            // replaces the anonymous TTL-bypass below when a justification
+            // is supplied. Justification-less Block behavior (the `else`
+            // branch) is completely unchanged.
+            use b00t_c0re_lib::sudo_operator::{adversarial_review, checkpoint_system_state, SudoDisposition, SudoGrantEvidence};
+
+            let project_root = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
+            let (review_event, disposition) =
+                adversarial_review(&project_root, &cmd_str, justification, &args.cites)?;
+
+            match &disposition {
+                SudoDisposition::Grant { ttl_seconds } => {
+                    let checkpoint_id = now_unix().to_string();
+                    let checkpoint =
+                        checkpoint_system_state(Some(&project_root), &checkpoint_id, None)?;
+                    let evidence = SudoGrantEvidence::new(&review_event, &disposition)
+                        .with_checkpoint(checkpoint.as_evidence_string());
+
+                    eprintln!(
+                        "✅ SUDO-GRANT: {} (ttl={}s) evidence={}",
+                        cmd_str, ttl_seconds, evidence.content_hash
+                    );
+                    append_audit_log(
+                        &log_path,
+                        &AuditLogEntry {
+                            ts: Utc::now().to_rfc3339(),
+                            cmd: cmd_str.clone(),
+                            result: "sudo-granted".into(),
+                            guard_msg: Some(message.clone()),
+                            pid: None,
+                            justification: Some(justification.clone()),
+                            cited_commits: args.cites.clone(),
+                            sudo_disposition: Some(disposition.to_string()),
+                            checkpoint_ref: Some(checkpoint.as_evidence_string()),
+                        },
+                    );
+                    // fall through to execution below
+                }
+                SudoDisposition::Deny { reason } => {
+                    eprintln!("🚫 SUDO-DENY: {}", reason);
+                    append_audit_log(
+                        &log_path,
+                        &AuditLogEntry {
+                            ts: Utc::now().to_rfc3339(),
+                            cmd: cmd_str.clone(),
+                            result: "sudo-denied".into(),
+                            guard_msg: Some(message.clone()),
+                            pid: None,
+                            justification: Some(justification.clone()),
+                            cited_commits: args.cites.clone(),
+                            sudo_disposition: Some(disposition.to_string()),
+                            checkpoint_ref: None,
+                        },
+                    );
+                    std::process::exit(1);
+                }
+                SudoDisposition::Escalate { reason } => {
+                    eprintln!("📡 SUDO-ESCALATE: {}", reason);
+                    crate::budget_controller::fire_sudo_escalation(
+                        &cmd_str,
+                        justification,
+                        &args.cites,
+                        reason,
+                    );
+                    notify_send(&format!("b00t sudo escalation: {cmd_str}"), reason);
+                    append_audit_log(
+                        &log_path,
+                        &AuditLogEntry {
+                            ts: Utc::now().to_rfc3339(),
+                            cmd: cmd_str.clone(),
+                            result: "sudo-escalated".into(),
+                            guard_msg: Some(message.clone()),
+                            pid: None,
+                            justification: Some(justification.clone()),
+                            cited_commits: args.cites.clone(),
+                            sudo_disposition: Some(disposition.to_string()),
+                            checkpoint_ref: None,
+                        },
+                    );
+                    eprintln!("   Not executed. Resolve the escalation and re-run.");
+                    std::process::exit(1);
+                }
+            }
+          } else {
             let mut cache = load_block_cache(&cache_path);
             let now = now_unix();
 
@@ -213,6 +319,7 @@ pub fn handle_exec(args: &ExecArgs, path: &str) -> Result<()> {
                             result: "block-forced".into(),
                             guard_msg: Some(message.clone()),
                             pid: None,
+                                                ..Default::default()
                         },
                     );
                     // fall through to execution below
@@ -230,6 +337,7 @@ pub fn handle_exec(args: &ExecArgs, path: &str) -> Result<()> {
                             result: "block-rejected".into(),
                             guard_msg: Some(message.clone()),
                             pid: None,
+                                                ..Default::default()
                         },
                     );
 
@@ -241,6 +349,7 @@ pub fn handle_exec(args: &ExecArgs, path: &str) -> Result<()> {
                     std::process::exit(1);
                 }
             }
+          }
         }
     }
 
@@ -260,6 +369,7 @@ pub fn handle_exec(args: &ExecArgs, path: &str) -> Result<()> {
                 result: "background".into(),
                 guard_msg: None,
                 pid: None,
+                        ..Default::default()
             },
         );
 
@@ -337,6 +447,7 @@ pub fn handle_exec(args: &ExecArgs, path: &str) -> Result<()> {
                 result: format!("{}:{}", result_label, sandbox_kind_label),
                 guard_msg: guard_msg.clone(),
                 pid: Some(pid),
+                        ..Default::default()
             },
         );
         child.wait()?.code().unwrap_or(1)
@@ -353,6 +464,7 @@ pub fn handle_exec(args: &ExecArgs, path: &str) -> Result<()> {
                 result: format!("{}:{}", result_label, sandbox_kind_label),
                 guard_msg,
                 pid: None,
+                        ..Default::default()
             },
         );
 
@@ -364,6 +476,18 @@ pub fn handle_exec(args: &ExecArgs, path: &str) -> Result<()> {
 }
 
 /// Parse simple duration string: "30s", "2m", "1h" → seconds
+/// Best-effort local desktop notification (Linux `notify-send`), used as
+/// one of the "plurality of channels" for a SudoDisposition::Escalate.
+/// Matches the fallback pattern already used for maintenance reminders
+/// (_b00t_/bash.🐚/README-bash.md, skills/b00t-maintenance/SKILL.md).
+/// Never fails the caller — this is a notification, not a gate.
+fn notify_send(summary: &str, body: &str) {
+    let _ = std::process::Command::new("notify-send")
+        .arg(summary)
+        .arg(body)
+        .spawn();
+}
+
 fn parse_duration(s: &str) -> Result<u64> {
     if let Some(n) = s.strip_suffix('s') {
         return Ok(n


### PR DESCRIPTION
Extracted from closed PR #623.

Adds sudo-operator governance module with:
- Adversarial-review gate for Block-tier exec
- Checkpoint helper (git tag + optional state dump)
- Governance types with SHA-256 evidence for grant decisions
- PRD-SUDO-OPERATOR-GOVERNANCE datum