### PR TITLE
feat(mcp): dynamic tool routing — stack load/unload + tools/list_changed notifications

### DIFF
--- a/b00t-cli/src/lib.rs
+++ b/b00t-cli/src/lib.rs
@@ -2255,6 +2255,7 @@ pub fn load_runtime_datum(name: &str, path: &str) -> Result<RuntimeConfig> {
 }
 
 /// Datum dispatch resolution — what action to take for `b00t <name>`.
+#[derive(Clone)]
 pub enum DatumDispatch {
     /// Launch via sandbox (runtime datum)
     Runtime(RuntimeConfig),

--- a/b00t-mcp/src/clap_reflection.rs
+++ b/b00t-mcp/src/clap_reflection.rs
@@ -169,6 +169,9 @@ pub struct McpCommandRegistry {
     commands: Arc<Vec<Box<dyn Fn() -> Tool + Send + Sync>>>,
     executors:
         Arc<HashMap<String, Box<dyn Fn(&HashMap<String, Value>) -> Result<String> + Send + Sync>>>,
+    /// Post-execute hooks keyed by tool name. Called after a successful tool execution.
+    /// Used to fire tools/list_changed notifications when stack load/unload runs.
+    post_hooks: Arc<HashMap<String, Arc<dyn Fn() + Send + Sync>>>,
 }
 
 impl McpCommandRegistry {
@@ -176,6 +179,7 @@ impl McpCommandRegistry {
         Self {
             commands: Arc::new(Vec::new()),
             executors: Arc::new(HashMap::new()),
+            post_hooks: Arc::new(HashMap::new()),
         }
     }
 
@@ -271,10 +275,14 @@ impl McpCommandRegistry {
             .collect()
     }
 
-    /// Execute a tool call
+    /// Execute a tool call, then fire any registered post-hook for that tool.
     pub fn execute(&self, tool_name: &str, params: &HashMap<String, Value>) -> Result<String> {
         if let Some(executor) = self.executors.get(tool_name) {
-            executor(params)
+            let result = executor(params)?;
+            if let Some(hook) = self.post_hooks.get(tool_name) {
+                hook();
+            }
+            Ok(result)
         } else {
             anyhow::bail!("Unknown tool: {}", tool_name)
         }
@@ -286,6 +294,7 @@ pub struct McpCommandRegistryBuilder {
     commands: Vec<Box<dyn Fn() -> Tool + Send + Sync>>,
     executors:
         HashMap<String, Box<dyn Fn(&HashMap<String, Value>) -> Result<String> + Send + Sync>>,
+    post_hooks: HashMap<String, Arc<dyn Fn() + Send + Sync>>,
 }
 
 impl McpCommandRegistryBuilder {
@@ -293,7 +302,16 @@ impl McpCommandRegistryBuilder {
         Self {
             commands: Vec::new(),
             executors: HashMap::new(),
+            post_hooks: HashMap::new(),
         }
+    }
+
+    /// Register a callback to fire after successful execution of `tool_name`.
+    ///
+    /// Primary use: fire `notifications/tools/list_changed` after stack load/unload.
+    pub fn add_post_hook(&mut self, tool_name: &str, hook: Arc<dyn Fn() + Send + Sync>) -> &mut Self {
+        self.post_hooks.insert(tool_name.to_string(), hook);
+        self
     }
 
     /// Register a command that implements both McpReflection and McpExecutor
@@ -318,6 +336,7 @@ impl McpCommandRegistryBuilder {
         McpCommandRegistry {
             commands: Arc::new(self.commands),
             executors: Arc::new(self.executors),
+            post_hooks: Arc::new(self.post_hooks),
         }
     }
 }

--- a/b00t-mcp/src/mcp_server_rusty.rs
+++ b/b00t-mcp/src/mcp_server_rusty.rs
@@ -55,10 +55,34 @@ impl B00tMcpServerRusty {
     pub fn new<P: AsRef<Path>>(working_dir: P, _config_path: &str, code_mode: bool) -> Result<Self> {
         let working_dir = working_dir.as_ref().to_path_buf();
 
+        // Build the peer Arc first so the notify closure can capture it before self exists.
+        let notification_peer: std::sync::Arc<tokio::sync::Mutex<Option<Peer<RoleServer>>>> =
+            std::sync::Arc::new(tokio::sync::Mutex::new(None));
+
+        let notify_fn: std::sync::Arc<dyn Fn() + Send + Sync> = {
+            let peer_arc = std::sync::Arc::clone(&notification_peer);
+            std::sync::Arc::new(move || {
+                let peer_arc = std::sync::Arc::clone(&peer_arc);
+                tokio::spawn(async move {
+                    let guard = peer_arc.lock().await;
+                    if let Some(peer) = guard.as_ref() {
+                        let notification = ToolListChangedNotification {
+                            method: ToolListChangedNotificationMethod,
+                            extensions: Extensions::new(),
+                        };
+                        let msg = ServerNotification::ToolListChangedNotification(notification);
+                        if let Err(e) = peer.send_notification(msg).await {
+                            tracing::warn!("tools/list_changed notification failed: {e}");
+                        }
+                    }
+                });
+            })
+        };
+
         let registry = if code_mode {
             create_code_mode_registry()
         } else {
-            create_mcp_registry()
+            crate::mcp_tools::create_mcp_registry_with_notify(notify_fn)
         };
 
         Ok(Self {
@@ -66,7 +90,7 @@ impl B00tMcpServerRusty {
             registry,
             chat_runtime: ChatRuntime::global(),
             client_info: std::sync::Arc::new(std::sync::Mutex::new(None)),
-            notification_peer: std::sync::Arc::new(tokio::sync::Mutex::new(None)),
+            notification_peer,
         })
     }
 

--- a/b00t-mcp/src/mcp_server_rusty.rs
+++ b/b00t-mcp/src/mcp_server_rusty.rs
@@ -1,5 +1,6 @@
 use anyhow::Result;
 use rmcp::{
+    Peer,
     handler::server::ServerHandler,
     model::{
         Annotated,
@@ -18,6 +19,10 @@ use rmcp::{
         ResourceContents,
         ServerCapabilities,
         ServerInfo,
+        ServerNotification,
+        ToolListChangedNotification,
+        ToolListChangedNotificationMethod,
+        Extensions,
     },
     service::{RequestContext, RoleServer},
 };
@@ -41,6 +46,9 @@ pub struct B00tMcpServerRusty {
     /// Captured from MCP initialize request — identifies the host client
     /// (e.g., "hermes", "claude-code", "opencode") for response customization.
     client_info: std::sync::Arc<std::sync::Mutex<Option<rmcp::model::Implementation>>>,
+    /// Peer handle stored on_initialized; used to send tools/list_changed notifications
+    /// when b00t_mcp_stack_load/unload dynamically changes the active tool set.
+    notification_peer: std::sync::Arc<tokio::sync::Mutex<Option<Peer<RoleServer>>>>,
 }
 
 impl B00tMcpServerRusty {
@@ -58,6 +66,7 @@ impl B00tMcpServerRusty {
             registry,
             chat_runtime: ChatRuntime::global(),
             client_info: std::sync::Arc::new(std::sync::Mutex::new(None)),
+            notification_peer: std::sync::Arc::new(tokio::sync::Mutex::new(None)),
         })
     }
 
@@ -74,6 +83,27 @@ impl B00tMcpServerRusty {
     /// Get the number of available tools
     pub fn tool_count(&self) -> usize {
         self.registry.get_tools().len()
+    }
+
+    /// Send `notifications/tools/list_changed` to the connected client.
+    ///
+    /// Call after dynamically loading/unloading an MCP stack so the host (Claude,
+    /// opencode, hermes) re-fetches the tool list without requiring reconnect.
+    pub fn notify_tools_changed(&self) {
+        let peer_arc = std::sync::Arc::clone(&self.notification_peer);
+        tokio::spawn(async move {
+            let guard = peer_arc.lock().await;
+            if let Some(peer) = guard.as_ref() {
+                let notification = ToolListChangedNotification {
+                    method: ToolListChangedNotificationMethod,
+                    extensions: Extensions::new(),
+                };
+                let msg = ServerNotification::ToolListChangedNotification(notification);
+                if let Err(e) = peer.send_notification(msg).await {
+                    tracing::warn!("tools/list_changed notification failed: {e}");
+                }
+            }
+        });
     }
 }
 
@@ -317,6 +347,9 @@ impl ServerHandler for B00tMcpServerRusty {
         &self,
         context: rmcp::service::NotificationContext<rmcp::service::RoleServer>,
     ) {
+        // Store peer handle for tools/list_changed notifications (dynamic stack load/unload)
+        *self.notification_peer.lock().await = Some(context.peer.clone());
+
         // Capture client info from peer metadata (hermes, claude-code, opencode, etc.)
         if let Some(peer_info) = context.peer.peer_info() {
             let client_name = peer_info.client_info.name.clone();

--- a/b00t-mcp/src/mcp_tools.rs
+++ b/b00t-mcp/src/mcp_tools.rs
@@ -1510,6 +1510,16 @@ impl crate::clap_reflection::McpExecutor for BStackUnloadCommand {
 
 /// Use create_full_mcp_registry() for debug/migration compatibility.
 pub fn create_mcp_registry() -> McpCommandRegistry {
+    create_mcp_registry_with_notify(std::sync::Arc::new(|| {}))
+}
+
+/// Same as create_mcp_registry but fires  after stack load/unload.
+///
+/// The notify closure is injected by B00tMcpServerRusty::new() with the peer handle
+/// captured at connection time — this completes the dynamic tool-list-changed loop.
+pub fn create_mcp_registry_with_notify(
+    notify_fn: std::sync::Arc<dyn Fn() + Send + Sync>,
+) -> McpCommandRegistry {
     let mut builder = McpCommandRegistry::builder();
     // Surface: learn + whoami + status + exec + discover + viz + log + verify + stack_load + stack_unload + DataFramerr (21 tools)
     builder
@@ -1522,7 +1532,9 @@ pub fn create_mcp_registry() -> McpCommandRegistry {
         .register::<BLogCommand>()
         .register::<BVerifyCommand>()
         .register::<BStackLoadCommand>()
-        .register::<BStackUnloadCommand>();
+        .register::<BStackUnloadCommand>()
+        .add_post_hook("b00t_mcp_stack_load", std::sync::Arc::clone(&notify_fn))
+        .add_post_hook("b00t_mcp_stack_unload", notify_fn);
     crate::soul_dataframerr_tools::register_dataframerr_tools(&mut builder);
     builder.build()
 }

--- a/b00t-mcp/src/mcp_tools.rs
+++ b/b00t-mcp/src/mcp_tools.rs
@@ -1426,10 +1426,92 @@ impl crate::clap_reflection::McpExecutor for BVerifyCommand {
     }
 }
 
+/// Activate a named b00t hive profile (stack-role binding).
+///
+/// Runs `b00t hive activate=<profile>` which transitions system state, starts
+/// declared services, and enforces resource exclusion groups. After activation,
+/// the MCP server sends a `notifications/tools/list_changed` event so the host
+/// client re-fetches the tool list automatically.
+///
+/// Examples:
+///   b00t_mcp_stack_load("finetune")   → activates finetune.hive.toml, claims GPU
+///   b00t_mcp_stack_load("inference")  → activates inference.hive.toml, starts vLLM
+#[derive(Parser, Clone)]
+pub struct BStackLoadCommand {
+    #[arg(help = "Hive profile name to activate (matches _b00t_/<name>.hive.toml)")]
+    pub profile: String,
+    #[arg(long, help = "Dry-run: print plan without activating")]
+    pub dry_run: bool,
+}
+impl crate::clap_reflection::McpReflection for BStackLoadCommand {
+    fn mcp_tool_name() -> String { "b00t_mcp_stack_load".to_string() }
+    fn command_path() -> Vec<String> { vec!["hive".into(), "activate".into()] }
+}
+impl crate::clap_reflection::McpExecutor for BStackLoadCommand {
+    fn execute_mcp_call(params: &std::collections::HashMap<String, serde_json::Value>) -> anyhow::Result<String> {
+        let profile = params.get("profile").and_then(|v| v.as_str())
+            .ok_or_else(|| anyhow::anyhow!("b00t_mcp_stack_load requires profile: string"))?;
+        let dry_run = params.get("dry_run").and_then(|v| v.as_bool()).unwrap_or(false);
+
+        let activate_arg = format!("activate={profile}");
+        let mut args = vec!["hive", &activate_arg];
+        if dry_run { args.push("--dry-run"); }
+
+        let output = std::process::Command::new("b00t-cli")
+            .args(&args)
+            .output()
+            .map_err(|e| anyhow::anyhow!("b00t-cli exec failed: {e}"))?;
+
+        let stdout = String::from_utf8_lossy(&output.stdout).to_string();
+        let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+
+        if output.status.success() {
+            Ok(format!("✅ Stack '{profile}' activated\n{stdout}"))
+        } else {
+            anyhow::bail!("hive activate={profile} failed:\n{stderr}")
+        }
+    }
+}
+
+/// Deactivate a named b00t hive profile (releases resources, stops declared services).
+///
+/// Runs `b00t hive deactivate=<profile>` and sends `notifications/tools/list_changed`
+/// so the host client re-fetches the updated tool list.
+#[derive(Parser, Clone)]
+pub struct BStackUnloadCommand {
+    #[arg(help = "Hive profile name to deactivate")]
+    pub profile: String,
+}
+impl crate::clap_reflection::McpReflection for BStackUnloadCommand {
+    fn mcp_tool_name() -> String { "b00t_mcp_stack_unload".to_string() }
+    fn command_path() -> Vec<String> { vec!["hive".into(), "deactivate".into()] }
+}
+impl crate::clap_reflection::McpExecutor for BStackUnloadCommand {
+    fn execute_mcp_call(params: &std::collections::HashMap<String, serde_json::Value>) -> anyhow::Result<String> {
+        let profile = params.get("profile").and_then(|v| v.as_str())
+            .ok_or_else(|| anyhow::anyhow!("b00t_mcp_stack_unload requires profile: string"))?;
+
+        let deactivate_arg = format!("deactivate={profile}");
+        let output = std::process::Command::new("b00t-cli")
+            .args(["hive", &deactivate_arg])
+            .output()
+            .map_err(|e| anyhow::anyhow!("b00t-cli exec failed: {e}"))?;
+
+        let stdout = String::from_utf8_lossy(&output.stdout).to_string();
+        let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+
+        if output.status.success() {
+            Ok(format!("✅ Stack '{profile}' deactivated\n{stdout}"))
+        } else {
+            anyhow::bail!("hive deactivate={profile} failed:\n{stderr}")
+        }
+    }
+}
+
 /// Use create_full_mcp_registry() for debug/migration compatibility.
 pub fn create_mcp_registry() -> McpCommandRegistry {
     let mut builder = McpCommandRegistry::builder();
-    // Surface: learn + whoami + status + exec + discover + viz + log + verify + DataFramerr (19 tools)
+    // Surface: learn + whoami + status + exec + discover + viz + log + verify + stack_load + stack_unload + DataFramerr (21 tools)
     builder
         .register::<LearnCommand>()
         .register::<WhoamiCommand>()
@@ -1438,7 +1520,9 @@ pub fn create_mcp_registry() -> McpCommandRegistry {
         .register::<BDiscoverCommand>()
         .register::<BVizGenerateCommand>()
         .register::<BLogCommand>()
-        .register::<BVerifyCommand>();
+        .register::<BVerifyCommand>()
+        .register::<BStackLoadCommand>()
+        .register::<BStackUnloadCommand>();
     crate::soul_dataframerr_tools::register_dataframerr_tools(&mut builder);
     builder.build()
 }
@@ -1766,7 +1850,7 @@ mod tests {
         assert!(surface_names.contains(&"learn"),   "learn must be in surface");
         assert!(surface_names.contains(&"exec"),    "exec must be in surface");
         assert!(surface_names.contains(&"discover"),"discover must be in surface");
-        assert_eq!(surface_tools.len(), 6, "surface registry must expose exactly 6 tools");
+        assert_eq!(surface_tools.len(), 21, "surface registry must expose exactly 21 tools (learn+whoami+status+exec+discover+viz+log+verify+stack_load+stack_unload+DataFramerr)");
 
         // Full registry: all tools for debug/migration
         let full = create_full_mcp_registry();


### PR DESCRIPTION
Extracted from closed PR #623.

Changes:
- feat(mcp): tools/list_changed notification + stack load/unload surface tools
- feat(mcp): complete notify_tools_changed wiring via post-execute hook

Adds MCP stack load/unload tools with post-exec hooks and sends notifications/tools/list_changed to connected peers.