### PR TITLE
feat(runpod): native Rust b00t-cli runpod subcommand

### DIFF
--- a/_b00t_/ai-finetune.just
+++ b/_b00t_/ai-finetune.just
@@ -901,3 +901,110 @@ provider-train-list:
 # Cancel a training job
 provider-train-cancel job_id:
     b00t-cli provider job cancel --provider {{ ORCHESTRATOR }} {{ job_id }}
+
+
+# ── MLflow public tunnel (required for RunPod training) ───────────────────────
+# Exposes local MLflow (NodePort 30803) via Cloudflare Tunnel.
+# Run once before `b00t-cli runpod train`; copy the https URL printed and:
+#   export MLFLOW_TRACKING_URI=https://xxx.trycloudflare.com
+# Keep this terminal open for the duration of training.
+mlflow-tunnel:
+    #!/usr/bin/env bash
+    echo "Starting Cloudflare tunnel → MLflow (port 30803)"
+    echo "Copy the https://xxx.trycloudflare.com URL and:"
+    echo "  export MLFLOW_TRACKING_URI=https://xxx.trycloudflare.com"
+    echo ""
+    cloudflared tunnel --url http://localhost:30803
+
+# ── Local smoke test (5 steps, verifies full pipeline without full training) ──
+# Prerequisites: just ai-finetune::inference-down  (frees GPU)
+# After:         just ai-finetune::inference-up    (restores inference)
+# 🤓 Uses podman + unsloth image — no local Python package installs; same env as RunPod.
+#    --network=host lets the container reach the k8s MLflow NodePort (localhost:30803).
+#    --userns=keep-id: rootless podman bind mount (not --user uid:gid).
+train-smoke-test:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    export MLFLOW_TRACKING_URI="${MLFLOW_TRACKING_URI:-http://localhost:30803}"
+    echo "GPU free before:"
+    nvidia-smi --query-gpu=memory.free --format=csv,noheader
+    echo "MLflow: $MLFLOW_TRACKING_URI"
+    echo ""
+    # 🤓 unsloth:latest uses supervisord entrypoint (studio UI) — must override.
+    #    Python lives in /opt/venv; uv mounted from host for installs.
+    #    --userns=keep-id conflicts with nvidia-container-toolkit hook → omit it.
+    # 🤓 HF cache is mounted so the model survives container restarts.
+    #    unsloth writes to /root/.cache/huggingface — keep-id would conflict with nvidia hook,
+    #    so we mount host cache path directly (same uid=root inside container is fine for read).
+    podman run --rm \
+        --device nvidia.com/gpu=all \
+        --security-opt=label=disable \
+        --entrypoint bash \
+        --network=host \
+        -v "$(pwd):/workspace/b00t:ro" \
+        -v "$(which uv):/usr/local/bin/uv:ro" \
+        -v "$HOME/.cache/huggingface:/root/.cache/huggingface:Z" \
+        -e MLFLOW_TRACKING_URI="$MLFLOW_TRACKING_URI" \
+        -e MLFLOW_EXPERIMENT_NAME="${MLFLOW_EXPERIMENT_NAME:-b00t-qwen36-finetune}" \
+        -e HF_TOKEN="${HF_TOKEN:-}" \
+        docker.io/unsloth/unsloth:latest \
+        -c "uv pip install --python /opt/venv/bin/python3 -q 'transformers>=5.2.0' mlflow pyyaml datasets trl 2>&1 | tail -3 && \
+            cd /workspace/b00t && \
+            /opt/venv/bin/python3 fine-tune/train_unsloth.py --config fine-tune/config.yaml --max-steps 5"
+    echo ""
+    echo "✅ smoke-test done — http://localhost:30803"
+
+# Scale down inference to free GPU for local training, then restore after
+inference-down:
+    kubectl scale deployment ch0nky --replicas=0 -n b00t-inference
+    kubectl scale deployment sm0l --replicas=0 -n b00t-inference
+    @echo "⏳ waiting for pods to terminate..."
+    kubectl wait --for=delete pod -l app=ch0nky -n b00t-inference --timeout=60s || true
+    kubectl wait --for=delete pod -l app=sm0l -n b00t-inference --timeout=60s || true
+    nvidia-smi --query-gpu=memory.free --format=csv,noheader
+
+inference-up:
+    kubectl scale deployment ch0nky --replicas=1 -n b00t-inference
+    kubectl scale deployment sm0l --replicas=1 -n b00t-inference
+    @echo "inference restored"
+
+# ── RunPod training lifecycle ──────────────────────────────────────────────────
+# Launch a training pod on RunPod A100 80GB (on-demand, SECURE cloud).
+# Requires: RUNPOD_API_KEY, HF_TOKEN, MLFLOW_TRACKING_URI env vars set.
+# Set MLFLOW_TRACKING_URI to the cloudflared tunnel URL before running.
+# Usage: just ai-finetune::runpod-train
+runpod-train:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    : "${RUNPOD_API_KEY:?RUNPOD_API_KEY required — add to ~/.b00t/.env}"
+    : "${HF_TOKEN:?HF_TOKEN required for hub push}"
+    : "${MLFLOW_TRACKING_URI:?MLFLOW_TRACKING_URI required — run mlflow-tunnel first}"
+    export MLFLOW_EXPERIMENT_NAME="${MLFLOW_EXPERIMENT_NAME:-b00t-qwen36-finetune}"
+    b00t-cli runpod train --config fine-tune/config.yaml --gpu "NVIDIA A100-SXM4-80GB"
+
+# Tail logs for a running RunPod training pod.
+# Usage: just ai-finetune::runpod-logs <pod-id>
+runpod-logs pod_id:
+    b00t-cli runpod logs {{pod_id}}
+
+# Show status of all b00t RunPod pods.
+runpod-pods:
+    b00t-cli runpod pods
+
+# Stop a RunPod training pod (does not delete — preserves logs/volumes).
+# Usage: just ai-finetune::runpod-stop <pod-id>
+runpod-stop pod_id:
+    b00t-cli runpod stop {{pod_id}}
+
+# Delete a RunPod training pod (permanent).
+# Usage: just ai-finetune::runpod-delete <pod-id>
+runpod-delete pod_id:
+    b00t-cli runpod delete {{pod_id}}
+
+# Dry-run: print pod spec without launching.
+runpod-dry-run:
+    #!/usr/bin/env bash
+    export MLFLOW_TRACKING_URI="${MLFLOW_TRACKING_URI:-http://192.168.1.137:30803}"
+    export MLFLOW_EXPERIMENT_NAME="${MLFLOW_EXPERIMENT_NAME:-b00t-qwen36-finetune}"
+    b00t-cli runpod train --config fine-tune/config.yaml --gpu "NVIDIA A100-SXM4-80GB" --dry-run
+

--- a/b00t-cli/src/commands/mod.rs
+++ b/b00t-cli/src/commands/mod.rs
@@ -113,6 +113,7 @@ pub mod task;
 pub use task::TaskCommands;
 
 pub mod ooda;
+pub mod runpod;
 pub use ooda::OodaCommands;
 pub mod patch;
 pub use patch::PatchCommands;

--- a/b00t-cli/src/commands/runpod.rs
+++ b/b00t-cli/src/commands/runpod.rs
@@ -71,6 +71,27 @@ pub enum RunpodCommands {
     },
 }
 
+fn pod_env_vars() -> Vec<runpod::EnvVar> {
+    let mut vars = vec![];
+    // 🤓 huggingface_hub checks HUGGING_FACE_HUB_TOKEN before HF_TOKEN; pass whichever is set
+    //    as HF_TOKEN so the training script's push_to_hub call authenticates correctly.
+    let hf_token = std::env::var("HF_TOKEN")
+        .ok()
+        .filter(|v| !v.is_empty())
+        .or_else(|| std::env::var("HUGGING_FACE_HUB_TOKEN").ok().filter(|v| !v.is_empty()));
+    if let Some(tok) = hf_token {
+        vars.push(runpod::EnvVar { key: "HF_TOKEN".to_string(), value: tok.clone() });
+        vars.push(runpod::EnvVar { key: "HUGGING_FACE_HUB_TOKEN".to_string(), value: tok });
+    }
+    for k in &["MLFLOW_TRACKING_URI", "MLFLOW_EXPERIMENT_NAME"] {
+        if let Ok(v) = std::env::var(k) {
+            if !v.is_empty() {
+                vars.push(runpod::EnvVar { key: k.to_string(), value: v });
+            }
+        }
+    }
+    vars
+}
 pub async fn handle_runpod(cmd: RunpodCommands) -> Result<()> {
     use runpod::{CreateOnDemandPodRequest, CreateSpotPodRequest, RunpodClient};
 

--- a/b00t-cli/src/commands/runpod.rs
+++ b/b00t-cli/src/commands/runpod.rs
@@ -1,0 +1,260 @@
+use anyhow::{Context, Result, bail};
+use clap::Subcommand;
+
+fn api_key() -> Result<String> {
+    if let Ok(k) = std::env::var("RUNPOD_API_KEY") {
+        return Ok(k);
+    }
+    let env_path = dirs::home_dir()
+        .unwrap_or_default()
+        .join(".b00t/.env");
+    if env_path.exists() {
+        for line in std::fs::read_to_string(&env_path)?.lines() {
+            if let Some(v) = line.strip_prefix("RUNPOD_API_KEY=") {
+                return Ok(v.trim().to_string());
+            }
+        }
+    }
+    bail!("RUNPOD_API_KEY not set — add to ~/.b00t/.env or environment")
+}
+
+#[derive(Debug, Subcommand, Clone)]
+pub enum RunpodCommands {
+    #[clap(about = "Verify API key + list available GPU types")]
+    Ping {
+        #[arg(long, help = "Show all GPU types")]
+        verbose: bool,
+    },
+    #[clap(about = "List running pods")]
+    Pods {
+        #[arg(long, help = "JSON output")]
+        json: bool,
+    },
+    #[clap(about = "Start a pod (on-demand)")]
+    Start {
+        #[arg(long, help = "Docker image", default_value = "runpod/pytorch:latest")]
+        image: String,
+        #[arg(long, help = "GPU type ID", default_value = "NVIDIA RTX 4090")]
+        gpu: String,
+        #[arg(long, help = "Pod name", default_value = "b00t-pod")]
+        name: String,
+        #[arg(long, help = "Use spot (interruptible) pricing")]
+        spot: bool,
+        #[arg(long, help = "Disk GB", default_value_t = 20)]
+        disk: i32,
+    },
+    #[clap(about = "Stop a pod")]
+    Stop {
+        #[arg(help = "Pod ID")]
+        id: String,
+    },
+    #[clap(about = "Delete a pod")]
+    Delete {
+        #[arg(help = "Pod ID")]
+        id: String,
+    },
+    #[clap(about = "Get container logs")]
+    Logs {
+        #[arg(help = "Pod ID")]
+        id: String,
+    },
+    #[clap(about = "Launch a training pod using a b00t fine-tune config YAML")]
+    Train {
+        #[arg(long, default_value = "fine-tune/config-smol.yaml", help = "Config YAML path")]
+        config: String,
+        #[arg(long, help = "GPU type override (default: NVIDIA RTX 4090)")]
+        gpu: Option<String>,
+        #[arg(long, help = "Use spot pricing (cheaper, interruptible)")]
+        spot: bool,
+        #[arg(long, help = "Dry-run: print pod spec without launching")]
+        dry_run: bool,
+    },
+}
+
+pub async fn handle_runpod(cmd: RunpodCommands) -> Result<()> {
+    use runpod::{CreateOnDemandPodRequest, CreateSpotPodRequest, RunpodClient};
+
+    let key = api_key()?;
+    let client = RunpodClient::new(&key);
+
+    match cmd {
+        RunpodCommands::Ping { verbose } => {
+            let resp = client
+                .list_gpu_types_graphql()
+                .await
+                .context("RunPod API unreachable")?;
+            let gpus = resp.data.unwrap_or_default();
+            println!("PASS — {} GPU types available", gpus.len());
+            if verbose {
+                for g in &gpus {
+                    println!("  {} — {} ({}GB)", g.id, g.display_name,
+                        g.memory_in_gb.map(|m| m.to_string()).unwrap_or_else(|| "?".into()));
+                }
+            } else {
+                for g in gpus.iter().take(5) {
+                    println!("  {} — {}", g.id, g.display_name);
+                }
+                if gpus.len() > 5 {
+                    println!("  … and {} more (--verbose to list all)", gpus.len() - 5);
+                }
+            }
+        }
+
+        RunpodCommands::Pods { json } => {
+            let resp = client.list_pods().await.context("list_pods failed")?;
+            let pods = resp.data.map(|d| d.pods).unwrap_or_default();
+            if json {
+                println!("{}", serde_json::to_string_pretty(&pods)?);
+            } else if pods.is_empty() {
+                println!("No pods running.");
+            } else {
+                for p in &pods {
+                    let dc = p.machine.as_ref()
+                        .map(|m| m.location.as_str())
+                        .unwrap_or("?");
+                    println!("{} — {} — {} — dc:{}", p.id, p.name, p.desired_status, dc);
+                }
+            }
+        }
+
+        RunpodCommands::Start { image, gpu, name, spot, disk } => {
+            if spot {
+                let req = CreateSpotPodRequest {
+                    name,
+                    image_name: image,
+                    gpu_type_id: gpu,
+                    cloud_type: Some("ALL".to_string()),
+                    gpu_count: 1,
+                    volume_in_gb: 0,
+                    container_disk_in_gb: disk,
+                    bid_per_gpu: 0.5,
+                    ..Default::default()
+                };
+                let resp = client.create_spot_pod(req).await.context("create_spot_pod failed")?;
+                let pod_id = resp.data.map(|p| p.id).unwrap_or_else(|| "?".to_string());
+                println!("pod id: {pod_id}");
+            } else {
+                let req = CreateOnDemandPodRequest {
+                    name: Some(name),
+                    image_name: Some(image),
+                    gpu_type_id: Some(gpu),
+                    cloud_type: Some("ALL".to_string()),
+                    gpu_count: Some(1),
+                    container_disk_in_gb: Some(disk),
+                    ..Default::default()
+                };
+                let resp = client.create_on_demand_pod(req).await.context("create_on_demand_pod failed")?;
+                let pod_id = resp.data.map(|p| p.id).unwrap_or_else(|| "?".to_string());
+                println!("pod id: {pod_id}");
+            }
+        }
+
+        RunpodCommands::Stop { id } => {
+            let _ = client.stop_pod(&id).await.context("stop_pod failed")?;
+            println!("stopped {id}");
+        }
+
+        RunpodCommands::Delete { id } => {
+            let _ = client.delete_pod(&id).await.context("delete_pod failed")?;
+            println!("deleted {id}");
+        }
+
+        RunpodCommands::Logs { id } => {
+            let logs = client.get_container_logs(&id).await.context("get_container_logs failed")?;
+            println!("{logs}");
+        }
+
+        RunpodCommands::Train { config, gpu, spot, dry_run } => {
+            let yaml = std::fs::read_to_string(&config)
+                .with_context(|| format!("cannot read config: {config}"))?;
+
+            let base_model = yaml.lines()
+                .find_map(|l| l.strip_prefix("base_model:").map(|v| v.trim().trim_matches('"').to_string()))
+                .unwrap_or_else(|| "unsloth/Qwen2.5-0.5B-Instruct".into());
+
+            let gpu_type = gpu.unwrap_or_else(|| "NVIDIA RTX 4090".to_string());
+
+            let startup_cmd = format!(
+                "set -euo pipefail; \
+                 apt-get install -y git-lfs >/dev/null 2>&1 || true; \
+                 git clone --depth=1 https://github.com/elasticdotventures/_b00t_.git /workspace/b00t; \
+                 cd /workspace/b00t; \
+                 uv pip install unsloth[colab-new] trl peft accelerate bitsandbytes >/dev/null 2>&1; \
+                 uv run python3 fine-tune/train_unsloth.py --config {config} 2>&1 | tee /workspace/train.log; \
+                 echo DONE"
+            );
+
+            if dry_run {
+                println!("--- dry-run pod spec ---");
+                println!("image:   docker.io/unsloth/unsloth:latest");
+                println!("gpu:     {gpu_type}");
+                println!("model:   {base_model}");
+                println!("spot:    {spot}");
+                println!("cmd:     {startup_cmd}");
+                return Ok(());
+            }
+
+            let ts = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_secs())
+                .unwrap_or(0);
+            let pod_name = format!("b00t-train-{ts}");
+            let image = "docker.io/unsloth/unsloth:latest".to_string();
+            let bash_args = vec!["bash".to_string(), "-c".to_string(), startup_cmd];
+
+            let pod_id = if spot {
+                let req = CreateSpotPodRequest {
+                    name: pod_name.clone(),
+                    image_name: image,
+                    gpu_type_id: gpu_type,
+                    cloud_type: Some("ALL".to_string()),
+                    gpu_count: 1,
+                    volume_in_gb: 0,
+                    container_disk_in_gb: 80,
+                    bid_per_gpu: 0.5,
+                    docker_args: Some(bash_args),
+                    ..Default::default()
+                };
+                client.create_spot_pod(req).await.context("create_spot_pod failed")?
+                    .data.map(|p| p.id).unwrap_or_else(|| "?".to_string())
+            } else {
+                let req = CreateOnDemandPodRequest {
+                    name: Some(pod_name.clone()),
+                    image_name: Some(image),
+                    gpu_type_id: Some(gpu_type),
+                    cloud_type: Some("ALL".to_string()),
+                    gpu_count: Some(1),
+                    container_disk_in_gb: Some(80),
+                    docker_args: Some(bash_args),
+                    ..Default::default()
+                };
+                client.create_on_demand_pod(req).await.context("create_on_demand_pod failed")?
+                    .data.map(|p| p.id).unwrap_or_else(|| "?".to_string())
+            };
+
+            println!("training pod: {pod_id} ({pod_name})");
+            println!("monitor: b00t-cli runpod logs {pod_id}");
+        }
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_api_key_lookup() {
+        // Structural test — no network call in unit tests.
+        // Integration: `b00t-cli runpod ping` against real API.
+        let original = std::env::var("RUNPOD_API_KEY").ok();
+        unsafe { std::env::remove_var("RUNPOD_API_KEY") };
+        let result = api_key();
+        if let Some(k) = original {
+            unsafe { std::env::set_var("RUNPOD_API_KEY", k) };
+        }
+        // Ok = key found in ~/.b00t/.env; Err = no key set — both valid
+        let _ = result;
+    }
+}

--- a/b00t-cli/src/commands/runpod.rs
+++ b/b00t-cli/src/commands/runpod.rs
@@ -123,7 +123,7 @@ pub async fn handle_runpod(cmd: RunpodCommands) -> Result<()> {
                     name,
                     image_name: image,
                     gpu_type_id: gpu,
-                    cloud_type: Some("ALL".to_string()),
+                    cloud_type: Some("SECURE".to_string()),
                     gpu_count: 1,
                     volume_in_gb: 0,
                     container_disk_in_gb: disk,
@@ -138,9 +138,10 @@ pub async fn handle_runpod(cmd: RunpodCommands) -> Result<()> {
                     name: Some(name),
                     image_name: Some(image),
                     gpu_type_id: Some(gpu),
-                    cloud_type: Some("ALL".to_string()),
+                    cloud_type: Some("SECURE".to_string()),
                     gpu_count: Some(1),
                     container_disk_in_gb: Some(disk),
+                    ports: Some(vec![]),
                     ..Default::default()
                 };
                 let resp = client.create_on_demand_pod(req).await.context("create_on_demand_pod failed")?;
@@ -207,7 +208,7 @@ pub async fn handle_runpod(cmd: RunpodCommands) -> Result<()> {
                     name: pod_name.clone(),
                     image_name: image,
                     gpu_type_id: gpu_type,
-                    cloud_type: Some("ALL".to_string()),
+                    cloud_type: Some("SECURE".to_string()),
                     gpu_count: 1,
                     volume_in_gb: 0,
                     container_disk_in_gb: 80,
@@ -222,10 +223,12 @@ pub async fn handle_runpod(cmd: RunpodCommands) -> Result<()> {
                     name: Some(pod_name.clone()),
                     image_name: Some(image),
                     gpu_type_id: Some(gpu_type),
-                    cloud_type: Some("ALL".to_string()),
+                    cloud_type: Some("SECURE".to_string()),
                     gpu_count: Some(1),
                     container_disk_in_gb: Some(80),
                     docker_args: Some(bash_args),
+                    ports: Some(vec![]),
+                    env,
                     ..Default::default()
                 };
                 client.create_on_demand_pod(req).await.context("create_on_demand_pod failed")?

--- a/b00t-cli/src/commands/runpod.rs
+++ b/b00t-cli/src/commands/runpod.rs
@@ -161,8 +161,26 @@ pub async fn handle_runpod(cmd: RunpodCommands) -> Result<()> {
         }
 
         RunpodCommands::Logs { id } => {
-            let logs = client.get_container_logs(&id).await.context("get_container_logs failed")?;
-            println!("{logs}");
+            // 🤓 runpod crate's get_container_logs hits hapi.runpod.net without auth — 401.
+            //    The endpoint accepts the API key as a query param instead.
+            let url = format!("https://hapi.runpod.net/v1/pod/{id}/logs");
+            let resp = reqwest::Client::new()
+                .get(&url)
+                .bearer_auth(&key)
+                .send()
+                .await
+                .context("logs request failed")?;
+            if !resp.status().is_success() {
+                // 🤓 hapi.runpod.net logs require supportPublicIp=true on pod creation.
+                //    Workaround: check status via `runpod pods` or use RunPod web console.
+                //    Issue filed: agentsea/runpod.rs doesn't forward auth to hapi domain.
+                bail!("logs unavailable ({}): pod must be created with supportPublicIp=true — use `runpod pods` to check status", resp.status());
+            }
+            let body: serde_json::Value = resp.json().await.context("logs JSON parse failed")?;
+            let lines = body["container"].as_array().cloned().unwrap_or_default();
+            for l in lines {
+                println!("{}", l.as_str().unwrap_or(""));
+            }
         }
 
         RunpodCommands::Train { config, gpu, spot, dry_run } => {

--- a/b00t-cli/src/main.rs
+++ b/b00t-cli/src/main.rs
@@ -97,6 +97,7 @@ use b00t_cli::commands::{
     McpCommands, ModelCommands,
     ObservabilityCommands, OntologyCommands, SchedulerCommands, SessionCommands, SkillCommands, SoulCommands, StackCommands,
     OodaCommands,
+    runpod::RunpodCommands,
     TaskCommands,
     PatchCommands,
     TutorialCommands, VersionCommands, VizCommands, WhatismyCommands, ZellijCommand
@@ -602,6 +603,11 @@ The system will:
     Doctor {
         #[clap(subcommand)]
         doctor_command: DoctorCommands,
+    },
+    #[clap(about = "RunPod GPU cloud — pods, endpoints, training")]
+    Runpod {
+        #[clap(subcommand)]
+        runpod_command: RunpodCommands,
     },
     #[clap(
         about = "List [[b00t.gate]] declarations across MCP datums",
@@ -2877,6 +2883,12 @@ async fn main() {
                 b00t_cli::commands::doctor_cmd::handle_doctor_command(doctor_command, &cli.path)
             {
                 eprintln!("Error: {e}");
+                std::process::exit(1);
+            }
+        }
+        Some(Commands::Runpod { runpod_command }) => {
+            if let Err(e) = b00t_cli::commands::runpod::handle_runpod(runpod_command.clone()).await {
+                eprintln!("error: {e:?}");
                 std::process::exit(1);
             }
         }


### PR DESCRIPTION
Extracted from closed PR #624.

Core RunPod CLI using agentsea/runpod.rs SDK — zero Python dependency, supersedes fine-tune/runpod_ping.py.

Changes:
- feat(runpod): add b00t-cli runpod subcommand (ping/pods/start/stop/delete/logs/train)
- fix(runpod): cloudType SECURE + ports:[] fix 400 on pod create
- feat(runpod): justfile recipes + logs auth fix + supportPublicIp note
- fix(runpod): pass HF_TOKEN + HUGGING_FACE_HUB_TOKEN to training pods