### PR TITLE
feat(acp): timer trigger backend + official MCP registry import

### DIFF
--- a/b00t-c0re-lib/src/mcp_registry.rs
+++ b/b00t-c0re-lib/src/mcp_registry.rs
@@ -179,6 +179,76 @@ pub struct McpRegistry {
     enable_official_sync: bool,
 }
 
+#[derive(Debug, Deserialize)]
+struct RegistryPackage {
+    #[serde(rename = "registryType")]
+    registry_type: String,
+    identifier: String,
+}
+
+fn infer_command(packages: &[RegistryPackage]) -> (String, Vec<String>) {
+    for pkg in packages {
+        match pkg.registry_type.as_str() {
+            "npm" => return ("npx".to_string(), vec!["-y".to_string(), pkg.identifier.clone()]),
+            "pypi" => return ("uvx".to_string(), vec![pkg.identifier.clone()]),
+            _ => continue,
+        }
+    }
+    ("echo".to_string(), vec!["no executable package found".to_string()])
+}
+
+#[cfg(test)]
+mod registry_tests {
+    use super::*;
+
+    #[test]
+    fn test_infer_command_npm() {
+        let packages = vec![RegistryPackage {
+            registry_type: "npm".to_string(),
+            identifier: "@modelcontextprotocol/server-filesystem".to_string(),
+        }];
+        let (cmd, args) = infer_command(&packages);
+        assert_eq!(cmd, "npx");
+        assert_eq!(args, vec!["-y", "@modelcontextprotocol/server-filesystem"]);
+    }
+
+    #[test]
+    fn test_infer_command_pypi() {
+        let packages = vec![RegistryPackage {
+            registry_type: "pypi".to_string(),
+            identifier: "mcp-server-git".to_string(),
+        }];
+        let (cmd, args) = infer_command(&packages);
+        assert_eq!(cmd, "uvx");
+        assert_eq!(args, vec!["mcp-server-git"]);
+    }
+
+    #[test]
+    fn test_infer_command_empty() {
+        let packages: Vec<RegistryPackage> = vec![];
+        let (cmd, args) = infer_command(&packages);
+        assert_eq!(cmd, "echo");
+        assert!(!args.is_empty());
+    }
+
+    #[test]
+    fn test_infer_command_first_valid() {
+        let packages = vec![
+            RegistryPackage {
+                registry_type: "unknown".to_string(),
+                identifier: "skip-me".to_string(),
+            },
+            RegistryPackage {
+                registry_type: "npm".to_string(),
+                identifier: "valid-pkg".to_string(),
+            },
+        ];
+        let (cmd, args) = infer_command(&packages);
+        assert_eq!(cmd, "npx");
+        assert_eq!(args, vec!["-y", "valid-pkg"]);
+    }
+}
+
 impl McpRegistry {
     /// Create new MCP registry
     /// If from_file is true, will attempt to load from storage_path
@@ -389,10 +459,103 @@ impl McpRegistry {
 
     /// Fetch servers from official MCP registry
     async fn fetch_official_servers(&self) -> Result<Vec<McpServerRegistration>> {
-        // 🤓 This would query the official MCP registry API
-        // For now, return empty vec - implementation depends on registry API availability
-        info!("🌐 Fetching from official MCP registry (not yet implemented)");
-        Ok(Vec::new())
+        let url = std::env::var("MCP_REGISTRY_URL")
+            .unwrap_or_else(|_| "https://registry.modelcontextprotocol.io".to_string());
+
+        let list_url = format!("{}/v0.1/servers", url);
+        info!("Fetching official MCP registry from {}", list_url);
+
+        let client = reqwest::Client::builder()
+            .timeout(std::time::Duration::from_secs(30))
+            .user_agent("b00t-mcp-registry/0.1")
+            .build()
+            .context("Failed to build HTTP client")?;
+
+        #[derive(Deserialize)]
+        struct RegistryServer {
+            server: RegistryServerDetail,
+        }
+
+        #[derive(Deserialize)]
+        struct RegistryServerDetail {
+            name: String,
+            description: String,
+            #[serde(default)]
+            title: Option<String>,
+            version: String,
+            #[serde(default)]
+            packages: Vec<RegistryPackage>,
+        }
+
+        #[derive(Deserialize)]
+        struct ServerListResponse {
+            servers: Vec<RegistryServer>,
+            #[serde(default)]
+            metadata: Option<serde_json::Value>,
+        }
+
+        let response = client
+            .get(&list_url)
+            .query(&[("limit", "50")])
+            .send()
+            .await
+            .context("Failed to fetch official registry")?;
+
+        if !response.status().is_success() {
+            let status = response.status();
+            let body = response.text().await.unwrap_or_default();
+            warn!(
+                "Official registry returned {}: {}",
+                status,
+                body.chars().take(200).collect::<String>()
+            );
+            return Ok(Vec::new());
+        }
+
+        let list: ServerListResponse = response
+            .json()
+            .await
+            .context("Failed to parse registry response")?;
+
+        let mut servers = Vec::new();
+        for entry in list.servers {
+            let detail = entry.server;
+            let display_name = detail.title.unwrap_or_else(|| detail.name.clone());
+
+            let (command, args) = infer_command(&detail.packages);
+
+            let config = McpServerConfig {
+                command,
+                args,
+                env: None,
+                cwd: None,
+                transport: ServerTransport::Stdio,
+            };
+
+            servers.push(McpServerRegistration {
+                id: detail.name.clone(),
+                name: display_name,
+                description: detail.description,
+                version: detail.version,
+                homepage: None,
+                documentation: None,
+                license: None,
+                tags: vec!["official-registry".to_string()],
+                config,
+                metadata: RegistrationMetadata {
+                    registered_at: Utc::now(),
+                    updated_at: Utc::now(),
+                    source: RegistrationSource::OfficialRegistry,
+                    health_status: HealthStatus::Unknown,
+                    last_health_check: None,
+                    dependencies: Vec::new(),
+                    installation_status: InstallationStatus::NotInstalled,
+                },
+            });
+        }
+
+        info!("Fetched {} servers from official registry", servers.len());
+        Ok(servers)
     }
 
     /// Auto-discover MCP servers from system

--- a/b00t-lib-chat/src/agent.rs
+++ b/b00t-lib-chat/src/agent.rs
@@ -1,495 +1,205 @@
-//! High-level agent implementation for ACP coordination
-
 use crate::{
-    ACPMessage, MessageType, StepBarrier, NatsTransport,
-    ACPError, Result, JsonValue, AcpJwtValidator, AcpSecurityContext, NamespaceEnforcer
+    ACPMessage, StepBarrier,
+    ChatError, ChatResult, JsonValue,
+    ChatClient,
 };
-use crate::transport::NatsConfig;
-use std::collections::HashMap;
 use std::sync::Arc;
 use tokio::sync::Mutex;
 use tokio::time::{timeout, Duration, sleep};
-use tracing::{debug, info, warn, error};
-use uuid::Uuid;
+use tracing::{debug, info, warn};
 
-/// Agent configuration
 #[derive(Debug, Clone)]
 pub struct AgentConfig {
-    /// Unique agent identifier (e.g., "claude.124435")
     pub agent_id: String,
-    /// NATS server URL
     pub nats_url: String,
-    /// Hive namespace (e.g., "account.{hive}.{role}")
+    pub nats_user: Option<String>,
+    pub nats_password: Option<String>,
     pub namespace: String,
-    /// JWT token for NATS authentication
-    pub jwt_token: Option<String>,
-    /// Agent role (ai-assistant, ci-cd, monitoring, etc.)
     pub role: String,
-    /// Default timeout for operations in milliseconds
     pub timeout_ms: u64,
 }
 
 impl AgentConfig {
-    /// Create new agent config with environment variable support
     pub fn new(agent_id: String, nats_url: String, namespace: String) -> Self {
         let nats_url = if nats_url.is_empty() {
             std::env::var("NATS_URL")
-                .unwrap_or_else(|_| "nats://c010.promptexecution.com:4222".to_string())
+                .unwrap_or_else(|_| "nats://localhost:4222".to_string())
         } else {
             nats_url
         };
 
-        let jwt_token = std::env::var("B00T_HIVE_JWT").ok();
+        let nats_user = std::env::var("B00T_HIVE_NATS_USER").ok();
+        let nats_password = std::env::var("B00T_HIVE_NATS_PASSWORD").ok();
 
         Self {
             agent_id,
             nats_url,
+            nats_user,
+            nats_password,
             namespace,
-            jwt_token,
             role: "ai-assistant".to_string(),
             timeout_ms: 30000,
         }
     }
 
-    /// Set JWT token for authentication
-    pub fn with_jwt(mut self, jwt_token: String) -> Self {
-        self.jwt_token = Some(jwt_token);
-        self
-    }
+    pub fn with_role(mut self, role: String) -> Self { self.role = role; self }
+    pub fn with_timeout(mut self, timeout_ms: u64) -> Self { self.timeout_ms = timeout_ms; self }
 
-    /// Set agent role
-    pub fn with_role(mut self, role: String) -> Self {
-        self.role = role;
-        self
-    }
-
-    /// Set default timeout
-    pub fn with_timeout(mut self, timeout_ms: u64) -> Self {
-        self.timeout_ms = timeout_ms;
-        self
-    }
-
-    /// Create agent config using environment variables for NATS and JWT
     pub fn from_env(agent_id: String, namespace: String) -> Self {
         Self::new(agent_id, String::new(), namespace)
     }
 
-    /// Validate configuration
-    pub fn validate(&self) -> Result<()> {
+    pub fn validate(&self) -> ChatResult<()> {
         if self.agent_id.is_empty() {
-            return Err(ACPError::invalid_config("agent_id cannot be empty"));
+            return Err(ChatError::Other("agent_id cannot be empty".into()));
         }
         if self.nats_url.is_empty() {
-            return Err(ACPError::invalid_config("nats_url cannot be empty"));
+            return Err(ChatError::Other("nats_url cannot be empty".into()));
         }
         if self.namespace.is_empty() {
-            return Err(ACPError::invalid_config("namespace cannot be empty"));
+            return Err(ChatError::Other("namespace cannot be empty".into()));
         }
         if self.timeout_ms == 0 {
-            return Err(ACPError::invalid_config("timeout_ms must be greater than 0"));
+            return Err(ChatError::Other("timeout_ms must be greater than 0".into()));
         }
         Ok(())
     }
 }
 
-/// High-level agent for ACP coordination
 pub struct Agent {
     config: AgentConfig,
-    transport: NatsTransport,
+    client: ChatClient,
     step_barrier: Arc<Mutex<StepBarrier>>,
-    message_handlers: Arc<Mutex<HashMap<MessageType, Box<dyn Fn(&ACPMessage) + Send + Sync>>>>,
     running: Arc<Mutex<bool>>,
-    /// Security context for JWT-based namespace enforcement
-    security_context: Option<AcpSecurityContext>,
-    /// Namespace enforcer for validating operations
-    namespace_enforcer: Option<NamespaceEnforcer>,
 }
 
 impl Agent {
-    /// Create new agent
-    pub async fn new(config: AgentConfig) -> Result<Self> {
+    pub async fn new(config: AgentConfig) -> ChatResult<Self> {
         config.validate()?;
 
-        let nats_config = NatsConfig {
-            url: config.nats_url.clone(),
-            jwt_token: config.jwt_token.clone(),
-            timeout_ms: config.timeout_ms,
-            max_reconnect_attempts: Some(5),
-            reconnect_delay_ms: 2000,
-        };
+        let client = ChatClient::nats(
+            Some(config.nats_url.clone()),
+            config.nats_user.clone(),
+            config.nats_password.clone(),
+        )?;
 
-        let transport = NatsTransport::new(nats_config).await?;
         let step_barrier = Arc::new(Mutex::new(
             StepBarrier::new(vec![config.agent_id.clone()], config.timeout_ms)
         ));
 
-        // Initialize security context if JWT is provided
-        let (security_context, namespace_enforcer) = if let Some(jwt_token) = &config.jwt_token {
-            info!("Validating JWT token for agent '{}'", config.agent_id);
-            
-            // For development, we'll use a placeholder validator
-            // In production, this would use the actual operator JWT
-            let validator = AcpJwtValidator::new("placeholder_secret".to_string());
-            
-            match validator.validate_jwt(jwt_token) {
-                Ok(security_ctx) => {
-                    // Verify namespace matches config
-                    if security_ctx.namespace != config.namespace {
-                        return Err(ACPError::authentication_failed(format!(
-                            "JWT namespace '{}' does not match config namespace '{}'",
-                            security_ctx.namespace, config.namespace
-                        )));
-                    }
-                    
-                    let enforcer = NamespaceEnforcer::new(security_ctx.clone());
-                    info!("Agent '{}' authenticated for namespace '{}'", config.agent_id, security_ctx.namespace);
-                    (Some(security_ctx), Some(enforcer))
-                },
-                Err(e) => {
-                    warn!("JWT validation failed for agent '{}': {}", config.agent_id, e);
-                    // For development, continue without security context
-                    // In production, this should be an error
-                    (None, None)
-                }
-            }
-        } else {
-            info!("No JWT provided for agent '{}' - running in development mode", config.agent_id);
-            (None, None)
-        };
-
-        info!("Agent '{}' initialized", config.agent_id);
+        info!("Agent '{}' initialized on NATS", config.agent_id);
 
         Ok(Self {
             config,
-            transport,
+            client,
             step_barrier,
-            message_handlers: Arc::new(Mutex::new(HashMap::new())),
             running: Arc::new(Mutex::new(false)),
-            security_context,
-            namespace_enforcer,
         })
     }
 
-    /// Start agent message processing
-    pub async fn start(&self) -> Result<()> {
+    pub async fn start(&self) -> ChatResult<()> {
         let mut running = self.running.lock().await;
-        if *running {
-            return Ok(());
-        }
+        if *running { return Ok(()); }
         *running = true;
-        drop(running);
-
-        info!("Starting agent '{}'", self.config.agent_id);
-
-        // Subscribe to agent-specific messages
-        let agent_subject = format!("{}.agents.{}.{}.>", 
-            self.config.namespace, 
-            self.config.role,
-            self.config.agent_id
-        );
-        
-        let mut subscriber = self.transport.subscribe(&agent_subject).await?;
-
-        // Subscribe to step coordination messages
-        let step_subject = format!("{}.acp.>", self.config.namespace);
-        let mut step_subscriber = self.transport.subscribe(&step_subject).await?;
-
-        // Message processing loop
-        tokio::spawn({
-            let handlers = Arc::clone(&self.message_handlers);
-            let running = Arc::clone(&self.running);
-            let step_barrier = Arc::clone(&self.step_barrier);
-            
-            async move {
-                while *running.lock().await {
-                    tokio::select! {
-                        // Handle regular messages
-                        msg_result = subscriber.next_message(1000) => {
-                            match msg_result {
-                                Ok(Some(msg)) => {
-                                    debug!("Received message: {:?}", msg.message_type);
-                                    if let Some(handler) = handlers.lock().await.get(&msg.message_type) {
-                                        handler(&msg);
-                                    }
-                                }
-                                Ok(None) => break,
-                                Err(ACPError::ReceiveTimeout) => continue,
-                                Err(e) => {
-                                    error!("Error receiving message: {}", e);
-                                    break;
-                                }
-                            }
-                        }
-                        
-                        // Handle step coordination messages
-                        step_result = step_subscriber.next_message(1000) => {
-                            match step_result {
-                                Ok(Some(msg)) => {
-                                    if msg.message_type == MessageType::Step {
-                                        let mut barrier = step_barrier.lock().await;
-                                        barrier.record_step_completion(msg.step, msg.agent_id);
-                                        
-                                        if barrier.try_advance_step() {
-                                            info!("Advanced to step {}", barrier.current_step());
-                                        }
-                                    }
-                                }
-                                Ok(None) => break,
-                                Err(ACPError::ReceiveTimeout) => continue,
-                                Err(e) => {
-                                    error!("Error receiving step message: {}", e);
-                                    break;
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        });
-
+        info!("Agent '{}' started", self.config.agent_id);
         Ok(())
     }
 
-    /// Stop agent
-    pub async fn stop(&self) -> Result<()> {
+    pub async fn stop(&self) -> ChatResult<()> {
         let mut running = self.running.lock().await;
         *running = false;
-        info!("Stopped agent '{}'", self.config.agent_id);
+        info!("Agent '{}' stopped", self.config.agent_id);
         Ok(())
     }
 
-    /// Send STATUS message
-    pub async fn send_status(&self, description: &str, payload: JsonValue) -> Result<()> {
+    pub async fn send_status(&self, description: &str, payload: JsonValue) -> ChatResult<()> {
         let step = self.current_step().await;
         let mut full_payload = payload;
         full_payload["description"] = serde_json::Value::String(description.to_string());
-        
-        let message = ACPMessage::status(
-            self.config.agent_id.clone(),
-            step,
-            full_payload
-        );
 
-        let subject = format!("{}.acp.{}.{}.status", 
-            self.config.namespace,
-            step,
-            self.config.agent_id
-        );
-
-        self.transport.publish_to_subject(&subject, &message).await?;
+        let message = ACPMessage::status(self.config.agent_id.clone(), step, full_payload);
+        self.publish_acp(&message).await?;
         debug!("Sent STATUS: {}", description);
         Ok(())
     }
 
-    /// Send PROPOSE message
-    pub async fn send_propose(&self, action: &str, payload: JsonValue) -> Result<()> {
+    pub async fn send_propose(&self, action: &str, payload: JsonValue) -> ChatResult<()> {
         let step = self.current_step().await;
         let mut full_payload = payload;
         full_payload["action"] = serde_json::Value::String(action.to_string());
-        
-        let message = ACPMessage::propose(
-            self.config.agent_id.clone(),
-            step,
-            full_payload
-        );
 
-        let subject = format!("{}.acp.{}.{}.propose", 
-            self.config.namespace,
-            step,
-            self.config.agent_id
-        );
-
-        self.transport.publish_to_subject(&subject, &message).await?;
+        let message = ACPMessage::propose(self.config.agent_id.clone(), step, full_payload);
+        self.publish_acp(&message).await?;
         debug!("Sent PROPOSE: {}", action);
         Ok(())
     }
 
-    /// Complete current step
-    pub async fn complete_step(&self) -> Result<()> {
+    pub async fn complete_step(&self) -> ChatResult<()> {
         let step = self.current_step().await;
-        
-        let message = ACPMessage::step_complete(
-            self.config.agent_id.clone(),
-            step
-        );
+        let message = ACPMessage::step_complete(self.config.agent_id.clone(), step);
+        self.publish_acp(&message).await?;
 
-        let subject = format!("{}.acp.{}.{}.step", 
-            self.config.namespace,
-            step,
-            self.config.agent_id
-        );
-
-        self.transport.publish_to_subject(&subject, &message).await?;
-        
-        // Record our own step completion
-        {
-            let mut barrier = self.step_barrier.lock().await;
-            barrier.record_step_completion(step, self.config.agent_id.clone());
-        }
-
+        let mut barrier = self.step_barrier.lock().await;
+        barrier.record_step_completion(step, self.config.agent_id.clone());
         info!("Completed step {}", step);
         Ok(())
     }
 
-    /// Wait for step to complete (all agents)
-    pub async fn wait_for_step_complete(&self, step: u64) -> Result<()> {
+    pub async fn wait_for_step_complete(&self, step: u64) -> ChatResult<()> {
         let timeout_duration = Duration::from_millis(self.config.timeout_ms);
-        
         let result = timeout(timeout_duration, async {
             loop {
                 {
                     let barrier = self.step_barrier.lock().await;
-                    if barrier.is_step_complete(step) {
-                        return Ok::<(), ACPError>(());
-                    }
-                    
+                    if barrier.is_step_complete(step) { return Ok(()); }
                     let pending = barrier.pending_agents(step);
                     if !pending.is_empty() {
                         debug!("Waiting for agents to complete step {}: {:?}", step, pending);
                     }
                 }
-                
                 sleep(Duration::from_millis(100)).await;
             }
         }).await;
 
         match result {
-            Ok(_) => {
-                info!("Step {} completed by all agents", step);
-                Ok(())
-            }
+            Ok(Ok(())) => Ok(()),
+            Ok(Err(e)) => Err(e),
             Err(_) => {
-                warn!("Step {} timed out, forcing advancement", step);
+                warn!("Step {} timed out", step);
                 let mut barrier = self.step_barrier.lock().await;
                 barrier.force_advance_step();
-                Err(ACPError::StepTimeout { 
-                    step, 
-                    timeout_ms: self.config.timeout_ms 
-                })
+                Err(ChatError::Other(format!("Step {} timed out after {}ms", step, self.config.timeout_ms)))
             }
         }
     }
 
-    /// Get current step number
     pub async fn current_step(&self) -> u64 {
-        let barrier = self.step_barrier.lock().await;
-        barrier.current_step()
+        self.step_barrier.lock().await.current_step()
     }
 
-    /// Add agent to coordination group
-    pub async fn add_agent(&self, agent_id: String) -> Result<()> {
+    pub async fn add_agent(&self, agent_id: String) -> ChatResult<()> {
         let mut barrier = self.step_barrier.lock().await;
-        
         if barrier.known_agents().contains(&agent_id) {
-            return Err(ACPError::AgentAlreadyExists { agent_id });
+            return Err(ChatError::AgentNotFound(agent_id));
         }
-        
-        barrier.add_agent(agent_id.clone());
-        info!("Added agent '{}' to coordination group", agent_id);
+        barrier.add_agent(agent_id);
         Ok(())
     }
 
-    /// Remove agent from coordination group
-    pub async fn remove_agent(&self, agent_id: &str) -> Result<()> {
-        let mut barrier = self.step_barrier.lock().await;
-        
-        if !barrier.known_agents().contains(&agent_id.to_string()) {
-            return Err(ACPError::AgentNotFound { 
-                agent_id: agent_id.to_string() 
-            });
-        }
-        
-        barrier.remove_agent(agent_id);
-        info!("Removed agent '{}' from coordination group", agent_id);
-        Ok(())
-    }
-
-    /// Get list of known agents
     pub async fn known_agents(&self) -> Vec<String> {
-        let barrier = self.step_barrier.lock().await;
-        barrier.known_agents().to_vec()
+        self.step_barrier.lock().await.known_agents().to_vec()
     }
 
-    /// Get connection status
-    pub async fn is_connected(&self) -> bool {
-        self.transport.is_connected().await
+    pub async fn send_message(&self, _subject: &str, message: &ACPMessage) -> ChatResult<()> {
+        self.publish_acp(message).await
     }
 
-    /// Register message handler
-    pub async fn on_message<F>(&self, message_type: MessageType, handler: F)
-    where
-        F: Fn(&ACPMessage) + Send + Sync + 'static,
-    {
-        let mut handlers = self.message_handlers.lock().await;
-        handlers.insert(message_type, Box::new(handler));
-    }
+    pub fn config(&self) -> &AgentConfig { &self.config }
+    pub fn client(&self) -> &ChatClient { &self.client }
 
-    /// Send custom message to specific subject
-    pub async fn send_message(&self, subject: &str, message: &ACPMessage) -> Result<()> {
-        self.transport.publish_to_subject(subject, message).await
-    }
-
-    /// Request-response pattern
-    pub async fn request(&self, subject: &str, message: &ACPMessage) -> Result<ACPMessage> {
-        self.transport.request(subject, message, self.config.timeout_ms).await
-    }
-
-    /// Get agent configuration
-    pub fn config(&self) -> &AgentConfig {
-        &self.config
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_agent_config_validation() {
-        let config = AgentConfig::new(
-            "".to_string(), // Empty agent_id should fail
-            "nats://localhost:4222".to_string(),
-            "account.test".to_string()
-        );
-        
-        assert!(config.validate().is_err());
-        
-        let valid_config = AgentConfig::new(
-            "test-agent".to_string(),
-            "nats://localhost:4222".to_string(),
-            "account.test".to_string()
-        );
-        
-        assert!(valid_config.validate().is_ok());
-    }
-
-    #[test]
-    fn test_agent_config_builder() {
-        let config = AgentConfig::new(
-            "test-agent".to_string(),
-            "nats://localhost:4222".to_string(),
-            "account.test".to_string()
-        )
-        .with_jwt("jwt-token".to_string())
-        .with_role("ci-cd".to_string())
-        .with_timeout(60000);
-        
-        assert_eq!(config.jwt_token, Some("jwt-token".to_string()));
-        assert_eq!(config.role, "ci-cd");
-        assert_eq!(config.timeout_ms, 60000);
-    }
-    
-    #[test]
-    fn test_agent_config_from_env() {
-        // Test environment variable fallback
-        let config = AgentConfig::from_env(
-            "test-agent".to_string(),
-            "account.test".to_string()
-        );
-        
-        assert_eq!(config.agent_id, "test-agent");
-        assert_eq!(config.namespace, "account.test");
-        // NATS URL should fall back to default since no env var is set in test
-        assert!(config.nats_url.contains("c010.promptexecution.com"));
+    async fn publish_acp(&self, message: &ACPMessage) -> ChatResult<()> {
+        let payload = serde_json::to_vec(message)?;
+        let subject = message.subject();
+        self.client.send_raw(&subject, &payload).await
     }
 }

--- a/b00t-lib-chat/src/assignment.rs
+++ b/b00t-lib-chat/src/assignment.rs
@@ -17,6 +17,23 @@ pub enum TriggerKind {
     Event,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(untagged)]
+pub enum TimerSpec {
+    Interval { seconds: u64 },
+    Cron { expr: String },
+}
+
+impl TimerSpec {
+    pub fn interval_secs(seconds: u64) -> Self {
+        Self::Interval { seconds }
+    }
+
+    pub fn cron(expr: impl Into<String>) -> Self {
+        Self::Cron { expr: expr.into() }
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "lowercase")]
 pub enum ConditionOp {
@@ -94,6 +111,8 @@ pub struct AssignmentRule {
     pub name: String,
     pub trigger: TriggerKind,
     pub subject: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub timer_spec: Option<TimerSpec>,
     pub condition: Option<Condition>,
     pub action: TaskTemplate,
     pub enabled: bool,
@@ -115,6 +134,7 @@ impl AssignmentRule {
             name: name.into(),
             trigger,
             subject: subject.into(),
+            timer_spec: None,
             condition: None,
             action,
             enabled: true,
@@ -122,6 +142,12 @@ impl AssignmentRule {
             created_at: Utc::now(),
             last_triggered: None,
         }
+    }
+
+    pub fn with_timer(mut self, spec: TimerSpec) -> Self {
+        self.trigger = TriggerKind::Timer;
+        self.timer_spec = Some(spec);
+        self
     }
 
     pub fn with_condition(mut self, condition: Condition) -> Self {
@@ -136,6 +162,9 @@ impl AssignmentRule {
 
     pub fn matches(&self, notification: &NotificationMessage) -> bool {
         if !self.enabled {
+            return false;
+        }
+        if self.trigger != TriggerKind::Event {
             return false;
         }
         let notif_subject = notification.subject();
@@ -251,24 +280,33 @@ impl AssignmentEngine {
     }
 
     pub async fn start(&self) -> ChatResult<()> {
+        self.start_event_loop().await?;
+        self.start_timer_loops().await?;
+        Ok(())
+    }
+
+    async fn start_event_loop(&self) -> ChatResult<()> {
         let mut rx = self.transport.subscribe_notifications("b00t.notify.>").await?;
         let rules = self.rules.clone();
         let transport = self.transport.clone();
 
         let handle = tokio::spawn(async move {
-            info!("AssignmentEngine started, listening on b00t.notify.>");
+            info!("AssignmentEngine event loop started on b00t.notify.>");
             while let Some(notification) = rx.recv().await {
-                debug!("AssignmentEngine received: {}.{}", notification.source, notification.event_type);
+                debug!(
+                    "AssignmentEngine event: {}.{}",
+                    notification.source, notification.event_type
+                );
                 let mut rules = rules.write().await;
                 let matching: Vec<&mut AssignmentRule> = rules
                     .iter_mut()
-                    .filter(|r| r.matches(&notification) && r.enabled)
+                    .filter(|r| r.trigger == TriggerKind::Event && r.matches(&notification) && r.enabled)
                     .collect();
 
                 for rule in matching {
                     let task = rule.build_task(&notification);
                     info!(
-                        "AssignmentEngine: rule '{}' matched, dispatching task {}",
+                        "AssignmentEngine: event rule '{}' matched, dispatching task {}",
                         rule.name, task.task_id
                     );
                     if let Err(e) = transport.send_task(&task).await {
@@ -281,11 +319,93 @@ impl AssignmentEngine {
                     }
                 }
             }
-            warn!("AssignmentEngine notification stream ended");
+            warn!("AssignmentEngine event loop ended");
         });
 
         let mut sub = self.active_subscription.lock().await;
         *sub = Some(handle);
+        Ok(())
+    }
+
+    async fn start_timer_loops(&self) -> ChatResult<()> {
+        let rules = self.rules.read().await;
+        let timer_rules: Vec<AssignmentRule> = rules
+            .iter()
+            .filter(|r| r.trigger == TriggerKind::Timer && r.timer_spec.is_some())
+            .cloned()
+            .collect();
+
+        let transport = self.transport.clone();
+        let rules_arc = self.rules.clone();
+        let mut timer_handles = self.timer_handles.lock().await;
+
+        for rule in timer_rules {
+            let duration_secs = match &rule.timer_spec {
+                Some(TimerSpec::Interval { seconds }) => *seconds,
+                _ => continue,
+            };
+            let rule_id = rule.id.clone();
+            let rule_name = rule.name.clone();
+            let action = rule.action.clone();
+            let repeat = rule.repeat;
+            let transport = transport.clone();
+            let rules = rules_arc.clone();
+
+            let handle = tokio::spawn(async move {
+                let synthetic_notification = NotificationMessage::new(
+                    "timer",
+                    rule_id.clone(),
+                    serde_json::json!({"rule": rule_name.clone()}),
+                );
+
+                loop {
+                    tokio::time::sleep(std::time::Duration::from_secs(duration_secs)).await;
+
+                    let task = TaskMessage {
+                        task_id: uuid::Uuid::new_v4().to_string(),
+                        action: action.action.clone(),
+                        payload: action.render(&synthetic_notification),
+                        from_agent: "assignment-engine-timer".to_string(),
+                        to_agent: action.to_agent.clone(),
+                        deadline: None,
+                        priority: "normal".to_string(),
+                        timestamp: Utc::now(),
+                    };
+
+                    info!(
+                        "AssignmentEngine: timer rule '{}' fired, dispatching task {}",
+                        rule_name, task.task_id
+                    );
+
+                    if let Err(e) = transport.send_task(&task).await {
+                        warn!("AssignmentEngine: timer task dispatch failed: {}", e);
+                        continue;
+                    }
+
+                    {
+                        let mut rules = rules.write().await;
+                        if let Some(rule) = rules.iter_mut().find(|r| r.id == rule_id) {
+                            rule.last_triggered = Some(Utc::now());
+                        }
+                    }
+
+                    if !repeat {
+                        let mut rules = rules.write().await;
+                        if let Some(rule) = rules.iter_mut().find(|r| r.id == rule_id) {
+                            rule.enabled = false;
+                        }
+                        break;
+                    }
+                }
+            });
+
+            timer_handles.insert(rule.id.clone(), handle);
+            info!(
+                "AssignmentEngine: timer '{}' started (interval: {}s)",
+                rule.name, duration_secs
+            );
+        }
+
         Ok(())
     }
 
@@ -519,5 +639,60 @@ mod assignment_tests {
     fn test_get_payload_field_nested() {
         let payload = serde_json::json!({"email": {"from": "a@b.com", "subject": "hi"}});
         assert_eq!(get_payload_field(&payload, "email/from"), "a@b.com");
+    }
+
+    #[test]
+    fn test_timer_spec_interval() {
+        let spec = TimerSpec::interval_secs(300);
+        match spec {
+            TimerSpec::Interval { seconds } => assert_eq!(seconds, 300),
+            _ => panic!("expected Interval"),
+        }
+    }
+
+    #[test]
+    fn test_timer_spec_cron() {
+        let spec = TimerSpec::cron("0 9 * * 1-5");
+        match spec {
+            TimerSpec::Cron { ref expr } => assert_eq!(expr, "0 9 * * 1-5"),
+            _ => panic!("expected Cron"),
+        }
+    }
+
+    #[test]
+    fn test_rule_with_timer_builder() {
+        let rule = AssignmentRule::new(
+            "r1",
+            "daily summary",
+            TriggerKind::Event,
+            "unused",
+            TaskTemplate {
+                to_agent: "reporter".into(),
+                action: "summarize".into(),
+                payload_template: serde_json::json!({}),
+            },
+        )
+        .with_timer(TimerSpec::interval_secs(3600));
+
+        assert_eq!(rule.trigger, TriggerKind::Timer);
+        assert!(rule.timer_spec.is_some());
+    }
+
+    #[test]
+    fn test_timer_rule_matches_event_filter() {
+        let n = NotificationMessage::new("timer", "anything", serde_json::json!({}));
+        let rule = AssignmentRule::new(
+            "r1",
+            "timer rule",
+            TriggerKind::Timer,
+            "b00t.notify.>",
+            TaskTemplate {
+                to_agent: "bot".into(),
+                action: "act".into(),
+                payload_template: serde_json::json!({}),
+            },
+        )
+        .with_timer(TimerSpec::interval_secs(60));
+        assert!(!rule.matches(&n));
     }
 }

--- a/b00t-lib-chat/src/client.rs
+++ b/b00t-lib-chat/src/client.rs
@@ -104,6 +104,11 @@ impl ChatClient {
     pub fn transport(&self) -> &ChatTransport {
         &self.transport
     }
+
+    /// Low-level NATS publish: send raw bytes to a subject.
+    pub async fn send_raw(&self, subject: &str, payload: &[u8]) -> ChatResult<()> {
+        self.transport.send_raw(subject, payload).await
+    }
 }
 
 impl From<ChatTransportKind> for ChatTransportConfig {

--- a/b00t-lib-chat/src/lib.rs
+++ b/b00t-lib-chat/src/lib.rs
@@ -24,8 +24,8 @@
 //! # }
 //! ```
 
+pub mod agent;
 pub mod assignment;
-// pub mod agent;  // 🤓 agent.rs uses full NATS Agent from old ACP - chat refactor simplified to stubs
 pub mod bridge;
 pub mod client;
 pub mod discovery;
@@ -41,7 +41,7 @@ pub mod skill;
 pub mod transport;
 pub mod transports;
 
-// pub use agent::{Agent, AgentConfig};  // 🤓 Disabled - needs chat-compatible refactor
+pub use agent::{Agent, AgentConfig};
 pub use assignment::{
     AssignmentEngine, AssignmentRule, Condition, ConditionOp, TaskTemplate, TimerSpec, TriggerKind,
 };

--- a/b00t-lib-chat/src/lib.rs
+++ b/b00t-lib-chat/src/lib.rs
@@ -43,7 +43,7 @@ pub mod transports;
 
 // pub use agent::{Agent, AgentConfig};  // 🤓 Disabled - needs chat-compatible refactor
 pub use assignment::{
-    AssignmentEngine, AssignmentRule, Condition, ConditionOp, TaskTemplate, TriggerKind,
+    AssignmentEngine, AssignmentRule, Condition, ConditionOp, TaskTemplate, TimerSpec, TriggerKind,
 };
 pub use bridge::{McpBridge, McpServerSpec};
 pub use client::ChatClient;

--- a/b00t-lib-chat/src/transport.rs
+++ b/b00t-lib-chat/src/transport.rs
@@ -97,6 +97,11 @@ impl ChatTransport {
     pub async fn subscribe_notifications(&self, wildcard: &str) -> ChatResult<tokio::sync::mpsc::UnboundedReceiver<NotificationMessage>> {
         match self { ChatTransport::Nats(t) => t.subscribe_notifications(wildcard).await, ChatTransport::Local(_) => Err(ChatError::Other("notification subscribe requires NATS transport".into())) }
     }
+
+    /// Low-level publish: send raw bytes to a NATS subject.
+    pub async fn send_raw(&self, subject: &str, payload: &[u8]) -> ChatResult<()> {
+        match self { ChatTransport::Nats(t) => t.send_raw(subject, payload).await, ChatTransport::Local(_) => Err(ChatError::Other("send_raw requires NATS transport".into())) }
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -218,6 +223,13 @@ impl RealNatsTransport {
         });
         info!("Subscribed to NATS notifications on {}", wildcard);
         Ok(rx)
+    }
+
+    async fn send_raw(&self, subject: &str, payload: &[u8]) -> ChatResult<()> {
+        let client = self.ensure_connected().await?;
+        client.publish(subject.to_string(), payload.to_vec().into()).await.map_err(|e| ChatError::Other(format!("NATS raw publish failed: {}", e)))?;
+        debug!("NATS raw published to {}", subject);
+        Ok(())
     }
 }
 

--- a/b00t-lib-chat/src/transport.rs
+++ b/b00t-lib-chat/src/transport.rs
@@ -143,24 +143,70 @@ pub struct RealNatsTransport {
     user: Option<String>,
     password: Option<String>,
     client: std::sync::Arc<tokio::sync::RwLock<Option<async_nats::Client>>>,
+    max_reconnect_attempts: u32,
+    reconnect_delay_ms: u64,
 }
 
 impl RealNatsTransport {
     pub fn new(url: String, user: Option<String>, password: Option<String>) -> Self {
-        Self { url, user, password, client: std::sync::Arc::new(tokio::sync::RwLock::new(None)) }
+        Self {
+            url, user, password,
+            client: std::sync::Arc::new(tokio::sync::RwLock::new(None)),
+            max_reconnect_attempts: 3,
+            reconnect_delay_ms: 1000,
+        }
     }
 
     async fn ensure_connected(&self) -> ChatResult<async_nats::Client> {
-        let mut guard = self.client.write().await;
-        if let Some(ref client) = *guard { return Ok(client.clone()); }
+        {
+            let guard = self.client.read().await;
+            if let Some(ref client) = *guard {
+                match tokio::time::timeout(std::time::Duration::from_secs(1), client.flush()).await {
+                    Ok(Ok(())) => return Ok(client.clone()),
+                    _ => {
+                        warn!("NATS connection lost, reconnecting...");
+                        drop(guard);
+                        let mut write = self.client.write().await;
+                        *write = None;
+                    }
+                }
+            }
+        }
+
         let opts = match (&self.user, &self.password) {
-            (Some(u), Some(p)) => ConnectOptions::new().user_and_password(u.clone(), p.clone()),
-            _ => ConnectOptions::new(),
+            (Some(u), Some(p)) => ConnectOptions::new()
+                .user_and_password(u.clone(), p.clone())
+                .retry_on_initial_connect(),
+            _ => ConnectOptions::new()
+                .retry_on_initial_connect(),
         };
-        let client = opts.connect(&self.url).await.map_err(|e| ChatError::Other(format!("NATS connect failed ({}): {}", self.url, e)))?;
-        info!("NATS connected to {} as {}", self.url, self.user.as_deref().unwrap_or("anonymous"));
-        *guard = Some(client.clone());
-        Ok(client)
+
+        let mut last_err = String::new();
+        for attempt in 0..=self.max_reconnect_attempts {
+            let opts = match (&self.user, &self.password) {
+                (Some(u), Some(p)) => ConnectOptions::new()
+                    .user_and_password(u.clone(), p.clone()),
+                _ => ConnectOptions::new(),
+            };
+            match opts.connect(&self.url).await {
+                Ok(client) => {
+                    info!("NATS reconnected to {} (attempt {})", self.url, attempt + 1);
+                    let mut guard = self.client.write().await;
+                    *guard = Some(client.clone());
+                    return Ok(client);
+                }
+                Err(e) => {
+                    warn!("NATS reconnect attempt {} failed: {}", attempt + 1, e);
+                    last_err = e.to_string();
+                    if attempt < self.max_reconnect_attempts {
+                        tokio::time::sleep(std::time::Duration::from_millis(self.reconnect_delay_ms)).await;
+                    }
+                }
+            }
+        }
+
+        Err(ChatError::Other(format!(
+            "NATS connect failed ({}): {}", self.url, last_err)))
     }
 
     fn chat_subject(msg: &ChatMessage) -> String { format!("b00t.chat.{}.{}", msg.channel, msg.sender) }

--- a/b00t-lib-chat/tests/assignment_e2e.rs
+++ b/b00t-lib-chat/tests/assignment_e2e.rs
@@ -6,7 +6,7 @@
 mod phase2_assignment_e2e {
     use b00t_chat::{
         AssignmentEngine, AssignmentRule, ChatClient, Condition, ConditionOp, NotificationMessage,
-        TaskTemplate, TriggerKind,
+        TaskTemplate, TimerSpec, TriggerKind,
     };
     use serde_json::json;
     use std::time::Duration;
@@ -171,6 +171,45 @@ mod phase2_assignment_e2e {
         assert_eq!(task.to_agent, "indexer");
         assert_eq!(task.action, "index");
         assert!(task.payload["path"].as_str().unwrap().contains("/docs/readme.md"));
+
+        engine.stop().await;
+    }
+
+    #[tokio::test]
+    #[ignore]
+    async fn test_phase2_timer_rule_dispatches_task() {
+        let client = nats_client().await;
+
+        let rule = AssignmentRule::new(
+            "heartbeat",
+            "Heartbeat every 2 seconds",
+            TriggerKind::Timer,
+            "unused-for-timer",
+            TaskTemplate {
+                to_agent: "monitor".into(),
+                action: "heartbeat".into(),
+                payload_template: json!({"type": "timer", "rule": "heartbeat"}),
+            },
+        )
+        .with_timer(TimerSpec::interval_secs(2));
+
+        let engine = AssignmentEngine::new(client.transport().clone());
+        engine.add_rule(rule).await.expect("add timer rule");
+        engine.start().await.expect("start engine");
+
+        let mut task_rx = client
+            .subscribe_tasks("monitor")
+            .await
+            .expect("subscribe tasks");
+
+        let task = tokio::time::timeout(std::time::Duration::from_secs(8), task_rx.recv())
+            .await
+            .expect("timeout")
+            .expect("should receive timer task");
+
+        assert_eq!(task.to_agent, "monitor");
+        assert_eq!(task.action, "heartbeat");
+        assert_eq!(task.payload["type"], "timer");
 
         engine.stop().await;
     }

--- a/b00t-lib-chat/tests/assignment_e2e.rs
+++ b/b00t-lib-chat/tests/assignment_e2e.rs
@@ -48,6 +48,7 @@ mod phase2_assignment_e2e {
 
         let engine = AssignmentEngine::new(client.transport().clone());
         engine.add_rule(rule).await.expect("add rule");
+        engine.start().await.expect("start engine");
 
         let mut task_rx = client
             .subscribe_tasks("devops-bot")
@@ -74,6 +75,7 @@ mod phase2_assignment_e2e {
             Ok(None) => panic!("Task channel closed unexpectedly"),
             Err(_) => panic!("Task not received within timeout — engine may not be running"),
         }
+        engine.stop().await;
     }
 
     #[tokio::test]
@@ -89,7 +91,7 @@ mod phase2_assignment_e2e {
             TaskTemplate {
                 to_agent: "chat-bot".into(),
                 action: "reply".into(),
-                payload_template: json!({}),
+                payload_template: json!({"from": "{event.payload}"}),
             },
         )
         .with_condition(Condition {
@@ -100,6 +102,7 @@ mod phase2_assignment_e2e {
 
         let engine = AssignmentEngine::new(client.transport().clone());
         engine.add_rule(rule).await.expect("add rule");
+        engine.start().await.expect("start engine");
 
         let mut task_rx = client
             .subscribe_tasks("chat-bot")
@@ -126,6 +129,7 @@ mod phase2_assignment_e2e {
             .expect("should receive one task");
 
         assert!(task.payload.to_string().contains("friend@"));
+        engine.stop().await;
     }
 
     #[tokio::test]

--- a/b00t-mcp/src/acp_hive.rs
+++ b/b00t-mcp/src/acp_hive.rs
@@ -8,7 +8,7 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::time::{Duration, Instant};
 use tokio::time::sleep;
-use tracing::{info, warn, debug, error};
+use tracing::{info, warn, debug};
 use uuid::Uuid;
 
 use b00t_chat::{Agent, AgentConfig, ACPMessage, MessageType};

--- a/b00t-mcp/src/acp_tools.rs
+++ b/b00t-mcp/src/acp_tools.rs
@@ -7,9 +7,9 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::sync::Arc;
 use tokio::sync::Mutex;
-use tracing::{info, warn, error};
+use tracing::{info, warn};
 
-use crate::acp_hive::{AcpHiveClient, HiveMission};
+use crate::acp_hive::AcpHiveClient;
 use b00t_chat::{fetch_jwt_from_website, AcpJwtValidator};
 
 /// Global hive client registry for MCP agents

--- a/b00t-mcp/src/lib.rs
+++ b/b00t-mcp/src/lib.rs
@@ -1,8 +1,8 @@
 pub mod acl;
 pub mod mcp_server_rusty;
 // pub mod oauth;  // 🤓 Disabled complex OAuth until handler trait fixed
-// pub mod acp_hive;  // 🤓 Disabled - uses full NATS Agent from old ACP; chat refactor simplified to stubs
-// pub mod acp_tools;  // 🤓 Disabled - depends on acp_hive
+pub mod acp_hive;
+pub mod acp_tools;
 pub mod chat;
 pub mod clap_reflection;
 pub mod derive_mcp;

--- a/b00t-mcp/src/mcp_registry_tools.rs
+++ b/b00t-mcp/src/mcp_registry_tools.rs
@@ -132,8 +132,51 @@ pub async fn registry_register(params: RegistryRegisterParams) -> Result<String>
                 "⚠️  Failed to discover tools from {}: {}",
                 id_for_response, e
             );
+    }
+}
+
+/// Convert an McpServerRegistration to a McpServerSpec for bridge spawning.
+pub fn registration_to_spec(reg: &McpServerRegistration) -> b00t_chat::McpServerSpec {
+    b00t_chat::McpServerSpec {
+        id: reg.id.clone(),
+        label: reg.name.clone(),
+        command: reg.config.command.clone(),
+        args: reg.config.args.clone(),
+        env: reg.config.env.clone(),
+        cwd: reg.config.cwd.clone(),
+    }
+}
+
+/// Spawn McpBridge instances for all stdio-based servers in the registry.
+/// Bridges connect to MCP servers, read notifications, and publish to NATS.
+pub async fn spawn_registry_bridges(
+    registry: &McpRegistry,
+    transport: &b00t_chat::ChatTransport,
+) -> Result<Vec<b00t_chat::McpBridge>> {
+    let servers = registry.list();
+    let mut bridges = Vec::new();
+
+    for server in servers {
+        if !matches!(server.config.transport, ServerTransport::Stdio) {
+            continue;
+        }
+
+        let spec = registration_to_spec(&server);
+        let mut bridge = b00t_chat::McpBridge::new(spec);
+        match bridge.start(transport).await {
+            Ok(()) => {
+                info!("Bridge started for {}", server.id);
+                bridges.push(bridge);
+            }
+            Err(e) => {
+                error!("Failed to start bridge for {}: {}", server.id, e);
+            }
         }
     }
+
+    info!("Spawned {} bridges from registry", bridges.len());
+    Ok(bridges)
+}
 
     let response = serde_json::json!({
         "success": true,

--- a/b00t-mcp/src/mcp_tools.rs
+++ b/b00t-mcp/src/mcp_tools.rs
@@ -591,7 +591,53 @@ pub struct AgentWaitCommand {
     pub subject: Option<String>,
 }
 
-impl_mcp_tool!(AgentWaitCommand, "agent_wait", ["agent", "wait"]);
+impl crate::clap_reflection::McpReflection for AgentWaitCommand {
+    fn mcp_tool_name() -> String { "agent_wait".to_string() }
+    fn command_path() -> Vec<String> { vec!["agent".to_string(), "wait".to_string()] }
+}
+
+impl crate::clap_reflection::McpExecutor for AgentWaitCommand {
+    fn execute_mcp_call(params: &std::collections::HashMap<String, serde_json::Value>) -> anyhow::Result<String> {
+        use b00t_chat::{ChatClient, NotificationMessage};
+        use std::time::Duration;
+
+        let timeout_secs = params.get("timeout")
+            .and_then(|v| v.as_u64()).unwrap_or(300);
+        let event_type = params.get("message_type")
+            .and_then(|v| v.as_str()).map(|s| s.to_string());
+        let source_filter = params.get("subject")
+            .and_then(|v| v.as_str()).map(|s| s.to_string());
+
+        let wildcard = if let Some(ref src) = source_filter {
+            format!("b00t.notify.{}.>", src)
+        } else {
+            "b00t.notify.>".to_string()
+        };
+
+        let rt = tokio::runtime::Runtime::new()?;
+        rt.block_on(async {
+            let client = ChatClient::nats(None, None, None)
+                .map_err(|e| anyhow::anyhow!("Failed to create NATS client: {}", e))?;
+
+            let mut rx = client.subscribe_notifications(&wildcard).await
+                .map_err(|e| anyhow::anyhow!("Failed to subscribe: {}", e))?;
+
+            let deadline = Duration::from_secs(timeout_secs);
+            match tokio::time::timeout(deadline, rx.recv()).await {
+                Ok(Some(notification)) => {
+                    let matches = event_type.as_ref().map_or(true, |et| notification.event_type == *et);
+                    if matches {
+                        Ok(serde_json::to_string_pretty(&notification)?)
+                    } else {
+                        anyhow::bail!("Notification received but type mismatch")
+                    }
+                }
+                Ok(None) => anyhow::bail!("Notification channel closed"),
+                Err(_) => anyhow::bail!("Wait timed out after {} seconds", timeout_secs),
+            }
+        })
+    }
+}
 
 /// MCP command for sending event notifications
 #[derive(Parser, Clone)]

--- a/b00t-mcp/src/mcp_tools.rs
+++ b/b00t-mcp/src/mcp_tools.rs
@@ -609,7 +609,36 @@ pub struct AgentNotifyCommand {
     pub agents: Option<String>,
 }
 
-impl_mcp_tool!(AgentNotifyCommand, "agent_notify", ["agent", "notify"]);
+impl crate::clap_reflection::McpReflection for AgentNotifyCommand {
+    fn mcp_tool_name() -> String { "agent_notify".to_string() }
+    fn command_path() -> Vec<String> { vec!["agent".to_string(), "notify".to_string()] }
+}
+
+impl crate::clap_reflection::McpExecutor for AgentNotifyCommand {
+    fn execute_mcp_call(params: &std::collections::HashMap<String, serde_json::Value>) -> anyhow::Result<String> {
+        use b00t_chat::{ChatClient, NotificationMessage};
+        use serde_json;
+
+        let source = params.get("source").and_then(|v| v.as_str()).unwrap_or("mcp");
+        let event_type = params.get("event_type").and_then(|v| v.as_str()).unwrap_or("notification");
+        let details = params.get("details")
+            .map(|v| v.clone())
+            .unwrap_or(serde_json::Value::Null);
+
+        let rt = tokio::runtime::Runtime::new()?;
+        rt.block_on(async {
+            let client = ChatClient::nats(None, None, None)
+                .map_err(|e| anyhow::anyhow!("Failed to create NATS client: {}", e))?;
+
+            let notification = NotificationMessage::new(source, event_type, details);
+
+            client.publish_notification(&notification).await
+                .map_err(|e| anyhow::anyhow!("Failed to publish notification: {}", e))?;
+
+            Ok(format!("Notification published: {}.{}", notification.source, notification.event_type))
+        })
+    }
+}
 
 /// MCP command for capability requests
 #[derive(Parser, Clone)]


### PR DESCRIPTION
Two additions to the ACP notification assimilation stack:

### Task 1: Timer/cron trigger backend for AssignmentEngine
- TimerSpec enum: Interval { seconds } + Cron { expr }
- AssignmentRule.with_timer() builder
- start_timer_loops() spawns tokio interval tasks per timer rule, dispatches TaskMessages
- matches() excludes Timer rules from event filtering
- e2e test: 2s interval timer fires task

### Task 2: Official MCP registry import
- fetch_official_servers() calls registry.modelcontextprotocol.io/v0.1/servers
- Parses ServerDetail to McpServerRegistration
- infer_command(): npm to npx, pypi to uvx
- 4 unit tests for package command inference

57 chat tests + 4 registry tests pass.