### PR TITLE
docs(ufo-types): reframe module docs as b00t-ecosystem-generic, not Tax-Lawyer-only

### DIFF
--- a/crates/ufo-types/src/lib.rs
+++ b/crates/ufo-types/src/lib.rs
@@ -1,15 +1,35 @@
-//! # ufo-types — UFO-grounded domain types for the Tax-Lawyer platform
+//! # ufo-types — UFO-grounded domain types for the b00t ecosystem
 //!
-//! This crate provides the ontological foundation for the Tax-Lawyer
-//! (#510 EPIC) by defining:
+//! This crate provides a domain-generic ontological foundation — grounded in
+//! Guizzardi's Unified Foundational Ontology — for any b00t-ecosystem project
+//! that wants ontologically-grounded types with deterministic, audit-ready
+//! constraint evaluation. It defines:
 //!
 //! - **UFO stereotypes** (`stereotype`): `UfoStereotype` enum grounding
 //!   every domain type in Guizzardi's Unified Foundational Ontology.
+//!   Domain-generic — nothing here is specific to any one consumer.
 //! - **Satisfies<C> trait** (`satisfies`): The core constraint evaluation
-//!   pattern — every domain type implements `Satisfies<Constraint>` with
-//!   deterministic, audit-ready results.
-//! - **ISO standard wrappers** (`iso`): `Lei` (ISO 17442), `Iso4217`
-//!   currency codes, and `Ifrs9Classification` financial instrument types.
+//!   pattern — any domain type can implement `Satisfies<Constraint>` with
+//!   deterministic, audit-ready results. Domain-generic.
+//! - **Capability types** (`capability`): `Task`, `Attempt`, `ActionRecord`,
+//!   `Episode`, `ReviewVerdict`, `Solution`, `TrainingCorpus`,
+//!   `EnergyBudget`, etc. — generic agent-capability/OODA types extracted
+//!   from AgentSea skillpacks. Domain-generic.
+//! - **DARED proposal types** (`dare`): `Decision`, `Alternative`, `Risk`,
+//!   `ExecutiveDecision`, `OodaStateMachine` — a generic OODA state-change
+//!   proposal framework codified as Rust generics. Domain-generic.
+//! - **ISO standard wrappers** (`iso`): `Lei` (ISO 17442 Legal Entity
+//!   Identifier), `Iso4217` currency codes, and `Ifrs9Classification`
+//!   financial-instrument types. These ARE domain-specific — they encode
+//!   financial/legal-entity accounting standards and are only meaningful to
+//!   consumers working in that space (e.g. Tax-Lawyer). Not intended as a
+//!   generic building block for unrelated domains.
+//!
+//! **Tax-Lawyer** (#510 EPIC) is this crate's first consumer, not its only
+//! intended one — any b00t-ecosystem project needing UFO-grounded domain
+//! types and the `Satisfies<T>` pattern (e.g. `stereotype`, `satisfies`,
+//! `capability`, `dare`) can depend on it directly. Only `iso` carries
+//! genuinely finance/tax-domain-specific types.
 //!
 //! ## Architecture
 //!
@@ -19,6 +39,10 @@
 //! │ (traits)  │     │ (domain impls)│     │ (thin wrappers)│
 //! └──────────┘     └───────────────┘     └────────────────┘
 //! ```
+//!
+//! (The above pipeline is Tax-Lawyer's own consumption path; other
+//! consumers wire `ufo-types` into their own domain-impl layer instead of
+//! `ledger-core`.)
 //!
 //! ## Integration with evidence layer (NS-9, NS-10)
 //!
@@ -35,9 +59,13 @@
 //!
 //! - Guizzardi, G. (2005). _Ontological Foundations for Structural
 //!   Conceptual Models_. PhD Thesis, University of Twente.
-//! - ISO 17442:2012 — Legal Entity Identifier (LEI)
-//! - ISO 4217:2015 — Codes for the representation of currencies
-//! - IFRS 9 — Financial Instruments (IASB, 2014)
+//! - ISO 17442:2012 — Legal Entity Identifier (LEI) (`iso` module only)
+//! - ISO 4217:2015 — Codes for the representation of currencies (`iso` module only)
+//! - IFRS 9 — Financial Instruments (IASB, 2014) (`iso` module only)
+//!
+//! The following references are specific to the Tax-Lawyer consumer and its
+//! use of the domain-generic types above — they are not properties of this
+//! crate itself:
 //! - ITAA 1997 Division 355 — AU R&D Tax Incentive
 //! - IRC Sec 41 — US R&D Tax Credit
 //! - IRS Rev. Proc. 2024-28 — Crypto cost basis safe harbor


### PR DESCRIPTION
## Summary

Cargo.toml's description already said "for the Tax-Lawyer platform + b00t governance"
but lib.rs's module docs still framed the whole crate as Tax-Lawyer-specific. This
mismatch matters because a second consumer is about to depend on this crate directly
(app4dog's photo-critter-generation pipeline — see the companion cross-repo plan at
`_b00t_/PIPELINE-DATUM-UFO-FOUNDATION.tomllmd`), and the stale docs would mislead that
integration.

Verified by reading `stereotype.rs`/`satisfies.rs`/`capability.rs`/`dare.rs` in full:
none contain tax-domain-specific types — only `iso.rs` (LEI/ISO4217/IFRS9) is genuinely
finance/legal-entity-specific. Reframes the crate as domain-generic UFO-grounded types +
the `Satisfies<T>` pattern, with Tax-Lawyer named as the first consumer, not the only
intended one.

Doc-only change — no type or logic modifications.

## Test plan
- [x] `cargo test -p ufo-types`: 92 passed, 0 failed, no regressions
- [x] `cargo test --package b00t-cli --lib` (pre-push hook): passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)