### PR TITLE
feat(chat): b00t.hive.mesh — NATS intra-hive gossip discovery + UFO-grounded hive types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -347,21 +347,83 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f02882884d3e1bc524fb12c79f107f6ad0e1cfd498c536ffb494301740995dfe"
 
 [[package]]
+name = "arrow"
+version = "55.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3f15b4c6b148206ff3a2b35002e08929c2462467b62b9c02036d9c34f9ef994"
+dependencies = [
+ "arrow-arith",
+ "arrow-array 55.2.0",
+ "arrow-buffer 55.2.0",
+ "arrow-cast",
+ "arrow-csv",
+ "arrow-data 55.2.0",
+ "arrow-ipc 55.2.0",
+ "arrow-json",
+ "arrow-ord",
+ "arrow-row",
+ "arrow-schema 55.2.0",
+ "arrow-select 55.2.0",
+ "arrow-string",
+]
+
+[[package]]
+name = "arrow-arith"
+version = "55.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30feb679425110209ae35c3fbf82404a39a4c0436bb3ec36164d8bffed2a4ce4"
+dependencies = [
+ "arrow-array 55.2.0",
+ "arrow-buffer 55.2.0",
+ "arrow-data 55.2.0",
+ "arrow-schema 55.2.0",
+ "chrono",
+ "num",
+]
+
+[[package]]
+name = "arrow-array"
+version = "55.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70732f04d285d49054a48b72c54f791bb3424abae92d27aafdf776c98af161c8"
+dependencies = [
+ "ahash",
+ "arrow-buffer 55.2.0",
+ "arrow-data 55.2.0",
+ "arrow-schema 55.2.0",
+ "chrono",
+ "half",
+ "hashbrown 0.15.5",
+ "num",
+]
+
+[[package]]
 name = "arrow-array"
 version = "58.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfd33d3e92f207444098c75b42de99d329562be0cf686b307b097cc52b4e999e"
 dependencies = [
  "ahash",
- "arrow-buffer",
- "arrow-data",
- "arrow-schema",
+ "arrow-buffer 58.3.0",
+ "arrow-data 58.3.0",
+ "arrow-schema 58.3.0",
  "chrono",
  "half",
  "hashbrown 0.17.1",
  "num-complex",
  "num-integer",
  "num-traits",
+]
+
+[[package]]
+name = "arrow-buffer"
+version = "55.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "169b1d5d6cb390dd92ce582b06b23815c7953e9dfaaea75556e89d890d19993d"
+dependencies = [
+ "bytes",
+ "half",
+ "num",
 ]
 
 [[package]]
@@ -377,16 +439,76 @@ dependencies = [
 ]
 
 [[package]]
+name = "arrow-cast"
+version = "55.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4f12eccc3e1c05a766cafb31f6a60a46c2f8efec9b74c6e0648766d30686af8"
+dependencies = [
+ "arrow-array 55.2.0",
+ "arrow-buffer 55.2.0",
+ "arrow-data 55.2.0",
+ "arrow-schema 55.2.0",
+ "arrow-select 55.2.0",
+ "atoi",
+ "base64 0.22.1",
+ "chrono",
+ "half",
+ "lexical-core",
+ "num",
+ "ryu",
+]
+
+[[package]]
+name = "arrow-csv"
+version = "55.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "012c9fef3f4a11573b2c74aec53712ff9fdae4a95f4ce452d1bbf088ee00f06b"
+dependencies = [
+ "arrow-array 55.2.0",
+ "arrow-cast",
+ "arrow-schema 55.2.0",
+ "chrono",
+ "csv",
+ "csv-core",
+ "regex",
+]
+
+[[package]]
+name = "arrow-data"
+version = "55.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8de1ce212d803199684b658fc4ba55fb2d7e87b213de5af415308d2fee3619c2"
+dependencies = [
+ "arrow-buffer 55.2.0",
+ "arrow-schema 55.2.0",
+ "half",
+ "num",
+]
+
+[[package]]
 name = "arrow-data"
 version = "58.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c88210023a2bfee1896af366309a3028fc3bcbd6515fa29a7990ee1baa08ee0"
 dependencies = [
- "arrow-buffer",
- "arrow-schema",
+ "arrow-buffer 58.3.0",
+ "arrow-schema 58.3.0",
  "half",
  "num-integer",
  "num-traits",
+]
+
+[[package]]
+name = "arrow-ipc"
+version = "55.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9ea5967e8b2af39aff5d9de2197df16e305f47f404781d3230b2dc672da5d92"
+dependencies = [
+ "arrow-array 55.2.0",
+ "arrow-buffer 55.2.0",
+ "arrow-data 55.2.0",
+ "arrow-schema 55.2.0",
+ "flatbuffers",
 ]
 
 [[package]]
@@ -395,13 +517,67 @@ version = "58.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "238438f0834483703d88896db6fe5a7138b2230debc31b34c0336c2996e3c64f"
 dependencies = [
- "arrow-array",
- "arrow-buffer",
- "arrow-data",
- "arrow-schema",
- "arrow-select",
+ "arrow-array 58.3.0",
+ "arrow-buffer 58.3.0",
+ "arrow-data 58.3.0",
+ "arrow-schema 58.3.0",
+ "arrow-select 58.3.0",
  "flatbuffers",
 ]
+
+[[package]]
+name = "arrow-json"
+version = "55.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5709d974c4ea5be96d900c01576c7c0b99705f4a3eec343648cb1ca863988a9c"
+dependencies = [
+ "arrow-array 55.2.0",
+ "arrow-buffer 55.2.0",
+ "arrow-cast",
+ "arrow-data 55.2.0",
+ "arrow-schema 55.2.0",
+ "chrono",
+ "half",
+ "indexmap 2.14.0",
+ "lexical-core",
+ "memchr",
+ "num",
+ "serde",
+ "serde_json",
+ "simdutf8",
+]
+
+[[package]]
+name = "arrow-ord"
+version = "55.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6506e3a059e3be23023f587f79c82ef0bcf6d293587e3272d20f2d30b969b5a7"
+dependencies = [
+ "arrow-array 55.2.0",
+ "arrow-buffer 55.2.0",
+ "arrow-data 55.2.0",
+ "arrow-schema 55.2.0",
+ "arrow-select 55.2.0",
+]
+
+[[package]]
+name = "arrow-row"
+version = "55.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52bf7393166beaf79b4bed9bfdf19e97472af32ce5b6b48169d321518a08cae2"
+dependencies = [
+ "arrow-array 55.2.0",
+ "arrow-buffer 55.2.0",
+ "arrow-data 55.2.0",
+ "arrow-schema 55.2.0",
+ "half",
+]
+
+[[package]]
+name = "arrow-schema"
+version = "55.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af7686986a3bf2254c9fb130c623cdcb2f8e1f15763e7c71c310f0834da3d292"
 
 [[package]]
 name = "arrow-schema"
@@ -411,16 +587,47 @@ checksum = "f633dbfdf39c039ada1bf9e34c694816eb71fbb7dc78f613993b7245e078a1ed"
 
 [[package]]
 name = "arrow-select"
+version = "55.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd2b45757d6a2373faa3352d02ff5b54b098f5e21dccebc45a21806bc34501e5"
+dependencies = [
+ "ahash",
+ "arrow-array 55.2.0",
+ "arrow-buffer 55.2.0",
+ "arrow-data 55.2.0",
+ "arrow-schema 55.2.0",
+ "num",
+]
+
+[[package]]
+name = "arrow-select"
 version = "58.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8cd065c54172ac787cf3f2f8d4107e0d3fdc26edba76fdf4f4cc170258942222"
 dependencies = [
  "ahash",
- "arrow-array",
- "arrow-buffer",
- "arrow-data",
- "arrow-schema",
+ "arrow-array 58.3.0",
+ "arrow-buffer 58.3.0",
+ "arrow-data 58.3.0",
+ "arrow-schema 58.3.0",
  "num-traits",
+]
+
+[[package]]
+name = "arrow-string"
+version = "55.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0377d532850babb4d927a06294314b316e23311503ed580ec6ce6a0158f49d40"
+dependencies = [
+ "arrow-array 55.2.0",
+ "arrow-buffer 55.2.0",
+ "arrow-data 55.2.0",
+ "arrow-schema 55.2.0",
+ "arrow-select 55.2.0",
+ "memchr",
+ "num",
+ "regex",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -1338,6 +1545,7 @@ name = "b00t-chat"
 version = "0.9.5"
 dependencies = [
  "anyhow",
+ "arrow",
  "async-nats",
  "async-stream",
  "async-trait",
@@ -3000,6 +3208,27 @@ checksum = "13b588ba4ac1a99f7f2964d24b3d896ddc6bf847ee3855dbd4366f058cfcd331"
 dependencies = [
  "quote",
  "syn 2.0.118",
+]
+
+[[package]]
+name = "csv"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52cd9d68cf7efc6ddfaaee42e7288d3a99d613d4b50f76ce9827ae0c6e14f938"
+dependencies = [
+ "csv-core",
+ "itoa",
+ "ryu",
+ "serde_core",
+]
+
+[[package]]
+name = "csv-core"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704a3c26996a80471189265814dbc2c257598b96b8a7feae2d31ace646bb9782"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -5414,9 +5643,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ede967e6b0a16396c91752febdf037ab04ca69b851f6fb43565ee5f30586ee0d"
 dependencies = [
  "arcstr",
- "arrow-array",
- "arrow-ipc",
- "arrow-schema",
+ "arrow-array 58.3.0",
+ "arrow-ipc 58.3.0",
+ "arrow-schema 58.3.0",
  "bincode 2.0.1",
  "bytes",
  "crc32fast",
@@ -6859,6 +7088,63 @@ name = "lebe"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a79a3332a6609480d7d0c9eab957bca6b455b91bb84e66d19f5ff66294b85b8"
+
+[[package]]
+name = "lexical-core"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d8d125a277f807e55a77304455eb7b1cb52f2b18c143b60e766c120bd64a594"
+dependencies = [
+ "lexical-parse-float",
+ "lexical-parse-integer",
+ "lexical-util",
+ "lexical-write-float",
+ "lexical-write-integer",
+]
+
+[[package]]
+name = "lexical-parse-float"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52a9f232fbd6f550bc0137dcb5f99ab674071ac2d690ac69704593cb4abbea56"
+dependencies = [
+ "lexical-parse-integer",
+ "lexical-util",
+]
+
+[[package]]
+name = "lexical-parse-integer"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a7a039f8fb9c19c996cd7b2fcce303c1b2874fe1aca544edc85c4a5f8489b34"
+dependencies = [
+ "lexical-util",
+]
+
+[[package]]
+name = "lexical-util"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2604dd126bb14f13fb5d1bd6a66155079cb9fa655b37f875b3a742c705dbed17"
+
+[[package]]
+name = "lexical-write-float"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50c438c87c013188d415fbabbb1dceb44249ab81664efbd31b14ae55dabb6361"
+dependencies = [
+ "lexical-util",
+ "lexical-write-integer",
+]
+
+[[package]]
+name = "lexical-write-integer"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "409851a618475d2d5796377cad353802345cba92c867d9fbcde9cf4eac4e14df"
+dependencies = [
+ "lexical-util",
+]
 
 [[package]]
 name = "libc"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1576,6 +1576,7 @@ dependencies = [
  "tokio-stream",
  "tracing",
  "tracing-subscriber",
+ "ufo-types",
  "uuid",
  "wasm-bindgen",
  "web-sys",

--- a/_b00t_/NATS-MESH-GOSSIP-DISCOVERY.tomllmd
+++ b/_b00t_/NATS-MESH-GOSSIP-DISCOVERY.tomllmd
@@ -1,0 +1,98 @@
+# b00t:datum v1
+# kind: proposal
+# status: draft
+# summary: gossip-based discovery advertising for the b00t-comms NATS intra-agent mesh, with a path to iroh/QUIC for broker-free P2P
+# tags: nats, mesh, gossip, discovery, iroh, quic, finops, ledgrrr
+# tier: frontier
+# author: yei (b00t operator)
+# date: 2026-07-11
+
+[proposal]
+title = "Gossip-based discovery advertising for the b00t-comms NATS intra-agent mesh"
+problem = """
+Discovery in the b00t-comms mesh currently rides NATS subject broadcast
+(`b00t.mesh.discovery` presence + `b00t.mesh.gossip` Gossip frame). That works
+for any deployment with a reachable NATS broker, but it is broker-bound: no
+broker, no discovery, and no NAT traversal for true peer-to-peer agents.
+
+We want membership advertising that (a) keeps working on NATS today, (b) is
+transport-agnostic so it can run over a broker-free substrate later, and
+(c) terminates membership churn via bounded epidemic fanout rather than O(N)
+heartbeat storms.
+"""
+
+[implemented]
+summary = """
+`GossipTable` (src/gossip.rs) is a transport-agnostic epidemic membership
+primitive: `ingest`/`insert_local`/`next_seq`/`live_endpoints`/`peer_count`,
+with a `max_hops` hop-budget so a single advertisement dies after a bounded
+number of relays. `NatsMeshNode` now backs its `peers` table with `GossipTable`:
+`announce()` publishes a `MeshFrame::Gossip { presence, seq, hops }` on
+`b00t.mesh.gossip`; receivers ingest newer-endpoint ads, re-gossip with
+`hops-1`, and ignore stale/over-budget ads. This is the "advertise by gossip"
+behavior requested, realized on NATS without a Redis broker.
+"""
+
+[options]
+gossiper = """
+github.com/thehydroimpulse/gossiper — Rust epidemic gossip with a pluggable
+transport and peer-scoring/anti-entropy. Mature pattern, would let us swap
+`GossipTable`'s transport for its peer-management later. Larger opinion surface
+than our ~250-line primitive; adopt only if we need its scoring/partial-view
+features.
+"""
+iroh_gossip = """
+crates.io/crates/iroh-gossip — topic-based gossip built on iroh (QUIC + relay),
+with NodeId (ed25519) addressing and NAT traversal out of the box. Strongest
+candidate for the *broker-free* future: drop the NATS broker entirely and let
+nodes discover each other over an iroh gossip topic. Cost: pulls the iroh stack
+into the binary. Strategic, not urgent.
+"""
+gwyh = """
+github.com/brndnmtthws/gwyh ("get what you have") — minimal Rust gossip /
+anti-entropy library, tiny dependency footprint. The closest drop-in to the
+epidemic membership we already wrote: it would back `GossipTable`'s transport
+without dragging in a whole P2P toolkit. Best near-term broker-free option if
+we want to shed NATS for discovery while staying lightweight.
+"""
+iroh = """
+github.com/n0-computer/iroh — distributed-systems toolkit: NodeId ed25519
+dialing, `noq` QUIC (iroh.computer/blog/noq-announcement) for reliable NAT
+traversal, direct P2P. This is the substrate iroh-gossip sits on. Long-term
+play: iroh becomes the transport under BOTH the mesh and ledgrrr — NodeId
+addressing replaces NATS subjects, and receipt exchange (finops usage codes)
+flows peer-to-peer instead of through a broker.
+"""
+
+[recommendation]
+decision = """
+1. Keep `GossipTable` as the transport-agnostic membership primitive (already
+   landed) — it is intentionally substrate-neutral.
+2. For broker-free deployments NOW, back `GossipTable`'s transport with `gwyh`
+   (lightest footprint, matches our epidemic model). Leave the NATS transport as
+   the default/broker-backed path.
+3. Treat `iroh-gossip` + `iroh` as the strategic substrate: when we cut the
+   NATS broker, the mesh dials peers by iroh NodeId over noq QUIC, and iroh is
+   added as a transport behind `ledgrrr` so finops receipts are exchanged P2P.
+4. ledgrrr stays mocked for this PR (`MockLedgrrr` / `MOCK-FINOPS-*`); real
+   ledgerr-mcp + iroh backing deferred.
+"""
+
+[ledgrrr]
+now = "MockLedgrrr in src/ledgrrr.rs — synthetic MOCK-FINOPS-* codes, in-memory, no server."
+later = "McpLedgrrr bridges real ledgerr-mcp via LEDGERR_MCP_CMD; iroh transport added behind the Ledgrrr trait for P2P receipt exchange."
+
+[acceptance]
+criteria = [
+  "cargo test -p b00t-chat (default + --features dataframe) green",
+  "NatsMeshNode membership converges via gossip with bounded hops on NATS",
+  "gossip.rs + mesh.rs gossip backing have unit/integration coverage",
+  "proposal reviewed by operator/yEI before iroh work begins",
+]
+
+# b00t:map v1
+# summary: gossip discovery for b00t-comms mesh; gwyh near-term, iroh/QUIC strategic; ledgrrr mocked now
+# tags: nats, mesh, gossip, iroh, quic, discovery, ledgrrr, finops
+# tier: frontier
+# cmds: cargo test -p b00t-chat, cargo run -p b00t-chat --example mesh_cli
+# complexity: 7

--- a/_b00t_/NATS-MESH-GOSSIP-DISCOVERY.tomllmd
+++ b/_b00t_/NATS-MESH-GOSSIP-DISCOVERY.tomllmd
@@ -1,19 +1,21 @@
 # b00t:datum v1
 # kind: proposal
 # status: draft
-# summary: gossip-based discovery advertising for the b00t-comms NATS intra-agent mesh, with a path to iroh/QUIC for broker-free P2P
-# tags: nats, mesh, gossip, discovery, iroh, quic, finops, ledgrrr
+# summary: gossip-based discovery advertising for the b00t-comms NATS intra-hive mesh (b00t.hive.mesh), with a broker-free path via iroh/gwyh
+# tags: nats, hive, gossip, discovery, iroh, quic, finops, ledgrrr
 # tier: frontier
 # author: yei (b00t operator)
 # date: 2026-07-11
 
 [proposal]
-title = "Gossip-based discovery advertising for the b00t-comms NATS intra-agent mesh"
+title = "Gossip-based discovery advertising for the b00t-comms NATS intra-hive mesh"
 problem = """
-Discovery in the b00t-comms mesh currently rides NATS subject broadcast
-(`b00t.mesh.discovery` presence + `b00t.mesh.gossip` Gossip frame). That works
-for any deployment with a reachable NATS broker, but it is broker-bound: no
-broker, no discovery, and no NAT traversal for true peer-to-peer agents.
+Discovery in the b00t-comms hive currently rides NATS subject broadcast
+(`b00t.hive.mesh.discovery.presence` heartbeat + `b00t.hive.mesh.gossip` Gossip frame). That
+works for any deployment with a reachable NATS broker, but it is broker-bound:
+no broker, no discovery. The hive is always intra-hive (same logical network),
+so cross-network NAT traversal is out of scope — the goal is broker-free
+discovery *within* the hive.
 
 We want membership advertising that (a) keeps working on NATS today, (b) is
 transport-agnostic so it can run over a broker-free substrate later, and
@@ -28,7 +30,7 @@ primitive: `ingest`/`insert_local`/`next_seq`/`live_endpoints`/`peer_count`,
 with a `max_hops` hop-budget so a single advertisement dies after a bounded
 number of relays. `NatsMeshNode` now backs its `peers` table with `GossipTable`:
 `announce()` publishes a `MeshFrame::Gossip { presence, seq, hops }` on
-`b00t.mesh.gossip`; receivers ingest newer-endpoint ads, re-gossip with
+`b00t.hive.mesh.gossip`; receivers ingest newer-endpoint ads, re-gossip with
 `hops-1`, and ignore stale/over-budget ads. This is the "advertise by gossip"
 behavior requested, realized on NATS without a Redis broker.
 """
@@ -43,25 +45,27 @@ features.
 """
 iroh_gossip = """
 crates.io/crates/iroh-gossip — topic-based gossip built on iroh (QUIC + relay),
-with NodeId (ed25519) addressing and NAT traversal out of the box. Strongest
-candidate for the *broker-free* future: drop the NATS broker entirely and let
-nodes discover each other over an iroh gossip topic. Cost: pulls the iroh stack
-into the binary. Strategic, not urgent.
+with NodeId (ed25519) addressing. Strongest candidate for the *broker-free*
+future: drop the NATS broker entirely and let nodes discover each other over an
+iroh gossip topic — still intra-hive (same logical network), just without a
+central relay. Cost: pulls the iroh stack into the binary. Strategic, not urgent.
 """
 gwyh = """
 github.com/brndnmtthws/gwyh ("get what you have") — minimal Rust gossip /
 anti-entropy library, tiny dependency footprint. The closest drop-in to the
 epidemic membership we already wrote: it would back `GossipTable`'s transport
 without dragging in a whole P2P toolkit. Best near-term broker-free option if
-we want to shed NATS for discovery while staying lightweight.
+we want to shed NATS for discovery while staying lightweight and intra-hive.
 """
 iroh = """
 github.com/n0-computer/iroh — distributed-systems toolkit: NodeId ed25519
-dialing, `noq` QUIC (iroh.computer/blog/noq-announcement) for reliable NAT
-traversal, direct P2P. This is the substrate iroh-gossip sits on. Long-term
-play: iroh becomes the transport under BOTH the mesh and ledgrrr — NodeId
-addressing replaces NATS subjects, and receipt exchange (finops usage codes)
-flows peer-to-peer instead of through a broker.
+dialing, `noq` QUIC (iroh.computer/blog/noq-announcement) for reliable transport,
+direct P2P. This is the substrate iroh-gossip sits on. Because the hive is always
+intra-hive (same network), there is no cross-network NAT-traversal requirement;
+iroh's value here is a broker-free intra-hive transport. Long-term play: iroh
+becomes the transport under BOTH the hive mesh and ledgrrr — NodeId addressing
+replaces NATS subjects, and receipt exchange (finops usage codes) flows
+peer-to-peer instead of through a broker.
 """
 
 [recommendation]
@@ -72,8 +76,9 @@ decision = """
    (lightest footprint, matches our epidemic model). Leave the NATS transport as
    the default/broker-backed path.
 3. Treat `iroh-gossip` + `iroh` as the strategic substrate: when we cut the
-   NATS broker, the mesh dials peers by iroh NodeId over noq QUIC, and iroh is
-   added as a transport behind `ledgrrr` so finops receipts are exchanged P2P.
+   NATS broker, the hive dials peers by iroh NodeId over noq QUIC — still
+   intra-hive (no NAT traversal needed) — and iroh is added as a transport
+   behind `ledgrrr` so finops receipts are exchanged P2P.
 4. ledgrrr stays mocked for this PR (`MockLedgrrr` / `MOCK-FINOPS-*`); real
    ledgerr-mcp + iroh backing deferred.
 """
@@ -109,13 +114,13 @@ how_to_test = """
 """
 
 how_to_contact = """
-Every node is addressable on NATS under the `b00t.mesh.*` subject tree:
+Every node is addressable on NATS under the `b00t.hive.mesh.*` subject tree:
 
-  b00t.mesh.node.{agent_id}        -> a node's direct inbox (point-to-point target)
-  b00t.mesh.discovery.query        -> broadcast "who is online?"; reply goes to the
-                                     querier's own inbox (b00t.mesh.node.{querier})
-  b00t.mesh.gossip                 -> epidemic membership ads (MeshFrame::Gossip)
-  b00t.mesh.channel.{channel}      -> pub/sub broadcast channel
+  b00t.hive.mesh.node.{agent_id}        -> a node's direct inbox (point-to-point target)
+  b00t.hive.mesh.discovery.query        -> broadcast "who is online?"; reply goes to the
+                                     querier's own inbox (b00t.hive.mesh.node.{querier})
+  b00t.hive.mesh.gossip                 -> epidemic membership ads (MeshFrame::Gossip)
+  b00t.hive.mesh.channel.{channel}      -> pub/sub broadcast channel
 
 Bring up a contactable node without writing Rust:
 
@@ -127,15 +132,15 @@ Bring up a contactable node without writing Rust:
   cargo run -p b00t-chat --example mesh_cli -- node_b nats://localhost:4222 send node_a "ping"
 
 `discover` prints the live peer set learned via gossip; `send node_a ...`
-publishes a Direct frame to b00t.mesh.node.node_a, which prints on terminal 1.
+publishes a Direct frame to b00t.hive.mesh.node.node_a, which prints on terminal 1.
 Set B00T_LEDGER=/path/to/finops.jsonl for a persisted ledger — by default the
 node uses the in-memory MockLedgrrr (MOCK-FINOPS-* codes), so no ledgerr-mcp
 server is required to test/contact it.
 """
 
 # b00t:map v1
-# summary: gossip discovery for b00t-comms mesh; gwyh near-term, iroh/QUIC strategic; ledgrrr mocked now
-# tags: nats, mesh, gossip, iroh, quic, discovery, ledgrrr, finops
+# summary: gossip discovery for b00t-comms intra-hive mesh (b00t.hive.mesh); gwyh near-term, iroh/QUIC strategic; ledgrrr mocked now
+# tags: nats, hive, gossip, iroh, quic, discovery, ledgrrr, finops
 # tier: frontier
 # cmds: cargo test -p b00t-chat, cargo run -p b00t-chat --example mesh_cli
 # complexity: 7

--- a/_b00t_/NATS-MESH-GOSSIP-DISCOVERY.tomllmd
+++ b/_b00t_/NATS-MESH-GOSSIP-DISCOVERY.tomllmd
@@ -90,6 +90,49 @@ criteria = [
   "proposal reviewed by operator/yEI before iroh work begins",
 ]
 
+# 🔎 Reviewer-facing: how to verify and how to reach a node (no prior context needed).
+[reviewer]
+how_to_test = """
+1. Unit/doctests, no server required (run both):
+     cargo test -p b00t-chat
+     cargo test -p b00t-chat --features dataframe
+   Both must be green. gossip.rs has dedicated unit tests:
+   newer_advertisement_is_accepted_and_forwarded, stale_advertisement_not_forwarded,
+   hop_budget_terminates_epidemic.
+2. Live two-node test (requires a reachable NATS server):
+     export NATS_URL=nats://localhost:4222
+     cargo test -p b00t-chat --test nats_mesh_integration
+   Without NATS_URL the test self-skips, so CI stays green offline.
+3. Manual smoke (see how_to_contact): bring up two mesh_cli nodes, run
+   `discover` on one, confirm the other appears in the live peer list, then
+   `send` a Direct frame and confirm it prints on the receiver.
+"""
+
+how_to_contact = """
+Every node is addressable on NATS under the `b00t.mesh.*` subject tree:
+
+  b00t.mesh.node.{agent_id}        -> a node's direct inbox (point-to-point target)
+  b00t.mesh.discovery.query        -> broadcast "who is online?"; reply goes to the
+                                     querier's own inbox (b00t.mesh.node.{querier})
+  b00t.mesh.gossip                 -> epidemic membership ads (MeshFrame::Gossip)
+  b00t.mesh.channel.{channel}      -> pub/sub broadcast channel
+
+Bring up a contactable node without writing Rust:
+
+  # terminal 1 — the node under test
+  cargo run -p b00t-chat --example mesh_cli -- node_a nats://localhost:4222 listen
+
+  # terminal 2 — a peer that discovers and contacts it
+  cargo run -p b00t-chat --example mesh_cli -- node_b nats://localhost:4222 discover
+  cargo run -p b00t-chat --example mesh_cli -- node_b nats://localhost:4222 send node_a "ping"
+
+`discover` prints the live peer set learned via gossip; `send node_a ...`
+publishes a Direct frame to b00t.mesh.node.node_a, which prints on terminal 1.
+Set B00T_LEDGER=/path/to/finops.jsonl for a persisted ledger — by default the
+node uses the in-memory MockLedgrrr (MOCK-FINOPS-* codes), so no ledgerr-mcp
+server is required to test/contact it.
+"""
+
 # b00t:map v1
 # summary: gossip discovery for b00t-comms mesh; gwyh near-term, iroh/QUIC strategic; ledgrrr mocked now
 # tags: nats, mesh, gossip, iroh, quic, discovery, ledgrrr, finops

--- a/_b00t_/b00t-comms.agent.toml
+++ b/_b00t_/b00t-comms.agent.toml
@@ -1,0 +1,66 @@
+# b00t Agent Datum — b00t-comms
+# 🤓 b00t-comms is the hive's intra-agent communication node. It owns the
+#    `--skill=nats` NATS mesh (b00t-lib-chat/src/mesh.rs) and the finops
+#    accounting seam: every capability it executes registers a dataframe-typed
+#    receipt with ledgrrr (b00t-lib-chat/src/ledgrrr.rs) and mints a finops code.
+#    Receipts implement DataframeReceipt (b00t-lib-chat/src/dataframe_receipt.rs)
+#    so they materialize to Apache Arrow (feature `dataframe`).
+#
+# 🔗参 _b00t_/nats.skill.toml — the nats skill this agent realizes
+# 🔗参 _b00t_/datums/AGENT-REGISTRY.tomllmd — registry protocol
+
+[b00t]
+name = "b00t-comms"
+type = "agent"
+hint = "b00t-comms — NATS intra-agent mesh node; Redis-free discovery, direct send, broadcast, presence, and finops receipt accounting via ledgrrr"
+
+[[b00t.agent.inherits]]
+from = "++abstract.agent"
+
+[b00t.agent]
+pid = "b00t-comms-001"
+model = "b00t-comms"
+skills = [
+  "nats",
+  "ledgrrr",
+]
+personality = "neutral"
+humor = "low"
+role = "b00t-comms"
+
+# 🤓 The mesh speaks async_nats directly (per-agent inbox + NATS reply-to),
+#    not the channel-based NatsTransport. Subjects live under `b00t.mesh.*`.
+[b00t.agent.ipc]
+transport = "nats"
+nats_url = "nats://localhost:4222"
+mesh = true
+pubsub = true
+protocol = "nats-mesh"
+subject_prefix = "b00t.mesh"
+
+[b00t.agent.mesh]
+discovery_query = "b00t.mesh.discovery.query"
+discovery_presence = "b00t.mesh.discovery.presence"
+inbox = "b00t.mesh.node.{agent_id}"
+channel = "b00t.mesh.channel.{channel}"
+presence_interval_secs = 10
+presence_ttl_secs = 30
+
+# 🤓 Collaborative-autonomy finops: every capability execution (nats.send,
+#    nats.broadcast, nats.discover, nats.presence) registers a UsageReceipt
+#    with ledgrrr, which mints a FINOPS-<project>-<seq> code. The same receipt
+#    is a DataframeReceipt, so it lands in Arrow/Parquet for audit.
+[b00t.agent.finops]
+ledger = "local"                       # "local" (LocalLedgrrr/JSONL) or "ledgerr-mcp"
+ledger_path = ".b00t/finops.jsonl"
+project = "b00t-comms"
+receipt = "dataframe"                  # DataframeReceipt -> Arrow (feature `dataframe`)
+focus_record = "experiment"            # FOCUS record is the reference dataframe receipt
+
+[b00t.agent.crew]
+role = "b00t-comms"
+captain = false
+
+[b00t.agent.mcp]
+enabled = true
+transport = ["stdio"]

--- a/_b00t_/b00t-comms.agent.toml
+++ b/_b00t_/b00t-comms.agent.toml
@@ -41,17 +41,21 @@ subject_prefix = "b00t.mesh"
 [b00t.agent.mesh]
 discovery_query = "b00t.mesh.discovery.query"
 discovery_presence = "b00t.mesh.discovery.presence"
+gossip = "b00t.mesh.gossip"            # epidemic membership advertising (bounded hop budget)
 inbox = "b00t.mesh.node.{agent_id}"
 channel = "b00t.mesh.channel.{channel}"
 presence_interval_secs = 10
 presence_ttl_secs = 30
+gossip_max_hops = 5                    # hop budget so a single ad dies after bounded relays
 
 # 🤓 Collaborative-autonomy finops: every capability execution (nats.send,
 #    nats.broadcast, nats.discover, nats.presence) registers a UsageReceipt
-#    with ledgrrr, which mints a FINOPS-<project>-<seq> code. The same receipt
-#    is a DataframeReceipt, so it lands in Arrow/Parquet for audit.
+#    with ledgrrr. For the nats-focused PR this defaults to MockLedgrrr
+#    (synthetic MOCK-FINOPS-* codes, in-memory); the same receipt is a
+#    DataframeReceipt, so it lands in Arrow/Parquet for audit. ledgerr-mcp + iroh
+#    backing is deferred (see _b00t_/NATS-MESH-GOSSIP-DISCOVERY.tomllmd).
 [b00t.agent.finops]
-ledger = "local"                       # "local" (LocalLedgrrr/JSONL) or "ledgerr-mcp"
+ledger = "mock"                        # "mock" (MockLedgrrr/in-memory) | "local" (LocalLedgrrr/JSONL) | "ledgerr-mcp"
 ledger_path = ".b00t/finops.jsonl"
 project = "b00t-comms"
 receipt = "dataframe"                  # DataframeReceipt -> Arrow (feature `dataframe`)

--- a/_b00t_/b00t-comms.agent.toml
+++ b/_b00t_/b00t-comms.agent.toml
@@ -1,6 +1,6 @@
 # b00t Agent Datum — b00t-comms
-# 🤓 b00t-comms is the hive's intra-agent communication node. It owns the
-#    `--skill=nats` NATS mesh (b00t-lib-chat/src/mesh.rs) and the finops
+# 🤓 b00t-comms is the hive's intra-hive communication node. It owns the
+#    `--skill=nats` NATS hive mesh (b00t-lib-chat/src/mesh.rs) and the finops
 #    accounting seam: every capability it executes registers a dataframe-typed
 #    receipt with ledgrrr (b00t-lib-chat/src/ledgrrr.rs) and mints a finops code.
 #    Receipts implement DataframeReceipt (b00t-lib-chat/src/dataframe_receipt.rs)
@@ -12,7 +12,7 @@
 [b00t]
 name = "b00t-comms"
 type = "agent"
-hint = "b00t-comms — NATS intra-agent mesh node; Redis-free discovery, direct send, broadcast, presence, and finops receipt accounting via ledgrrr"
+hint = "b00t-comms — NATS intra-hive mesh node; Redis-free discovery, direct send, broadcast, presence, and finops receipt accounting via ledgrrr"
 
 [[b00t.agent.inherits]]
 from = "++abstract.agent"
@@ -28,22 +28,24 @@ personality = "neutral"
 humor = "low"
 role = "b00t-comms"
 
-# 🤓 The mesh speaks async_nats directly (per-agent inbox + NATS reply-to),
-#    not the channel-based NatsTransport. Subjects live under `b00t.mesh.*`.
+# 🤓 The hive speaks async_nats directly (per-agent inbox + NATS reply-to),
+#    not the channel-based NatsTransport. Subjects live under `b00t.hive.mesh.*`
+#    and are always intra-hive (same logical network).
 [b00t.agent.ipc]
 transport = "nats"
 nats_url = "nats://localhost:4222"
 mesh = true
 pubsub = true
-protocol = "nats-mesh"
-subject_prefix = "b00t.mesh"
+protocol = "nats-hive"
+subject_prefix = "b00t.hive.mesh"
 
-[b00t.agent.mesh]
-discovery_query = "b00t.mesh.discovery.query"
-discovery_presence = "b00t.mesh.discovery.presence"
-gossip = "b00t.mesh.gossip"            # epidemic membership advertising (bounded hop budget)
-inbox = "b00t.mesh.node.{agent_id}"
-channel = "b00t.mesh.channel.{channel}"
+[b00t.agent.hive]
+intra_hive = true                      # same logical network; no cross-network path
+discovery_query = "b00t.hive.mesh.discovery.query"
+discovery_presence = "b00t.hive.mesh.discovery.presence"
+gossip = "b00t.hive.mesh.gossip"       # epidemic membership advertising (bounded hop budget)
+inbox = "b00t.hive.mesh.node.{agent_id}"
+channel = "b00t.hive.mesh.channel.{channel}"
 presence_interval_secs = 10
 presence_ttl_secs = 30
 gossip_max_hops = 5                    # hop budget so a single ad dies after bounded relays

--- a/_b00t_/hooks/pre-push
+++ b/_b00t_/hooks/pre-push
@@ -1,7 +1,21 @@
 #!/usr/bin/env bash
 # pre-push hook for b00t repo — runs tests before allowing push to remote.
+#
+# Selection model (per operator fast-fix-forward):
+#   changed files -> owning packages -> transitive workspace reverse-dependant
+#   closure (via `cargo metadata`) -> ONE `cargo test --lib -p ... -p ...`
+#   invocation (Cargo dedups compilation across selected packages).
+#
+# A package's own tests do NOT prove its API changes haven't broken consumers,
+# so the reverse-dependant closure is always included (e.g. b00t-lib-chat change
+# pulls in b00t-cli).
+#
+# Conservative invalidation (full b00t-cli gate) when workspace/toolchain/
+# dependency configuration changes: Cargo.lock, root Cargo.toml, .cargo/**,
+# rust-toolchain*, build.rs, vendor/**, _b00t_/hooks/**.
+#
 # Install: cp _b00t_/hooks/pre-push .git/hooks/pre-push && chmod +x .git/hooks/pre-push
-# Or: just install-pre-push-hook
+#   (or: just install-pre-push-hook)
 set -euo pipefail
 
 REMOTE="$1"
@@ -13,17 +27,128 @@ if [[ "$URL" == *"fork"* ]]; then
   exit 0
 fi
 
-# Gate: never force-push to main
+export PATH="$HOME/.cargo/bin:$PATH"
+
+# Capture the remote's current tip for this ref (incremental-push base) and
+# block force-delete of main.
+REMOTE_TIP=""
 while read LOCAL_REF LOCAL_SHA REMOTE_REF REMOTE_SHA; do
   if [[ "$REMOTE_REF" == "refs/heads/main" && "$LOCAL_SHA" == "0000000000000000000000000000000000000000" ]]; then
     echo "🚫 pre-push: force-delete of main is BLOCKED" >&2
     exit 1
   fi
+  REMOTE_TIP="$REMOTE_SHA"
 done
 
-# Run Rust tests for b00t-cli (fast — lib tests only, no integration)
-echo "[pre-push] running cargo test --package b00t-cli --lib ..."
-if ! cargo test --package b00t-cli --lib --quiet 2>&1; then
+# Base = remote tip when pushing an existing branch (only new commits tested);
+# for a brand-new branch fall back to merge-base with origin/main so the whole
+# branch is still gated once.
+if [ -n "${REMOTE_TIP:-}" ] && [ "$REMOTE_TIP" != "0000000000000000000000000000000000000000" ]; then
+  BASE="$REMOTE_TIP"
+else
+  BASE_REF="origin/main"
+  git rev-parse --verify --quiet "refs/remotes/$BASE_REF" >/dev/null 2>&1 || BASE_REF="main"
+  BASE=$(git merge-base HEAD "$BASE_REF" 2>/dev/null) || BASE=$(git rev-parse HEAD~1)
+fi
+CHANGED=$(git diff --name-only "$BASE"..HEAD)
+
+# No Rust-affecting files (docs/datums only) -> skip the gate.
+if [ -z "$CHANGED" ]; then
+  echo "[pre-push] no changes on branch — skipping test gate"
+  exit 0
+fi
+
+# Conservative invalidation: workspace/toolchain/dependency configuration.
+CONSERVATIVE=0
+while IFS= read -r f; do
+  case "$f" in
+    Cargo.lock|.cargo/*|rust-toolchain*|rust-toolchain.toml|build.rs|vendor/*|_b00t_/hooks/*) CONSERVATIVE=1 ;;
+    Cargo.toml) CONSERVATIVE=1 ;;   # any Cargo.toml (incl. root members list)
+  esac
+  [ "$CONSERVATIVE" -eq 1 ] && break
+done <<< "$CHANGED"
+
+if [ "$CONSERVATIVE" -eq 1 ]; then
+  echo "[pre-push] dependency/toolchain/config change — running full b00t-cli gate"
+  git submodule update --init vendor/ledgrrr 2>/dev/null || true
+  if ! cargo test -p b00t-cli --lib --quiet 2>&1; then
+    echo "🚫 pre-push: tests failed — push blocked" >&2
+    exit 1
+  fi
+  echo "✅ pre-push: tests pass"
+  exit 0
+fi
+
+# Precise selection via cargo metadata reverse-dependant closure.
+if ! command -v jq >/dev/null 2>&1; then
+  echo "[pre-push] jq not found — falling back to full b00t-cli gate"
+  git submodule update --init vendor/ledgrrr 2>/dev/null || true
+  if ! cargo test -p b00t-cli --lib --quiet 2>&1; then
+    echo "🚫 pre-push: tests failed — push blocked" >&2
+    exit 1
+  fi
+  echo "✅ pre-push: tests pass"
+  exit 0
+fi
+
+META=$(cargo metadata --format-version 1 --no-deps --quiet)
+# Reverse-dependency map: dep package name -> [dependent package names].
+REV=$(jq -c 'reduce .packages[] as $p ({}; reduce ($p.dependencies // [])[] as $d (.; .[$d.name] += [$p.name]))' <<<"$META")
+
+owning_package() {
+  local f="$1" d mp
+  d=$(dirname "$f")
+  while [ -n "$d" ] && [ "$d" != "." ] && [ "$d" != "/" ]; do
+    if [ -f "$d/Cargo.toml" ]; then
+      mp=$(realpath "$d/Cargo.toml")
+      jq -r --arg mp "$mp" '.packages[] | select(.manifest_path == $mp) | .name' <<<"$META"
+      return 0
+    fi
+    d=$(dirname "$d")
+  done
+  return 1
+}
+
+# Seed closure with packages that own changed files.
+declare -A SEEN=()
+SELECTED=()
+QUEUE=()
+while IFS= read -r f; do
+  [ -z "$f" ] && continue
+  pkg=$(owning_package "$f" || true)
+  [ -z "$pkg" ] && continue
+  if [ -z "${SEEN[$pkg]:-}" ]; then
+    SEEN[$pkg]=1
+    QUEUE+=("$pkg")
+  fi
+done <<< "$CHANGED"
+
+# BFS over the reverse-dependency closure.
+while [ "${#QUEUE[@]}" -gt 0 ]; do
+  cur="${QUEUE[0]}"; QUEUE=("${QUEUE[@]:1}")
+  SELECTED+=("$cur")
+  while IFS= read -r dep; do
+    [ -z "$dep" ] && continue
+    if [ -z "${SEEN[$dep]:-}" ]; then
+      SEEN[$dep]=1
+      QUEUE+=("$dep")
+    fi
+  done < <(jq -r --arg p "$cur" '.[$p] // [] | .[]' <<<"$REV")
+done
+
+if [ "${#SELECTED[@]}" -eq 0 ]; then
+  echo "[pre-push] no Rust packages affected — skipping test gate"
+  exit 0
+fi
+
+echo "[pre-push] selected packages (changed ∪ reverse dependants): ${SELECTED[*]}"
+# b00t-cli tests may need the ledgrrr submodule.
+for p in "${SELECTED[@]}"; do
+  [ "$p" = "b00t-cli" ] && { git submodule update --init vendor/ledgrrr 2>/dev/null || true; break; }
+done
+
+# Single invocation: Cargo dedups compilation across selected packages.
+if ! cargo test --lib --quiet $(printf -- '-p %s ' "${SELECTED[@]}") 2>&1; then
   echo "🚫 pre-push: tests failed — push blocked" >&2
   exit 1
 fi

--- a/_b00t_/nats.skill.toml
+++ b/_b00t_/nats.skill.toml
@@ -33,6 +33,7 @@ Subject hierarchy (all under `b00t.mesh.*`):
 | `b00t.mesh.channel.{channel}` | pub/sub broadcast channel |
 | `b00t.mesh.discovery.query` | broadcast "who is online?" with a NATS reply inbox |
 | `b00t.mesh.discovery.presence` | periodic heartbeat announcing a live node |
+| `b00t.mesh.gossip` | epidemic membership advertising (`MeshFrame::Gossip`); bounded hop-budget re-gossip so discovery converges without a central registry |
 
 The four primitives:
 
@@ -100,7 +101,7 @@ The mesh is the accounting seam for collaborative autonomy. Every capability a
 attributable and auditable:
 
 ```rust
-let ledger = Arc::new(LocalLedgrrr::file(".b00t/finops.jsonl")?);
+let ledger = Arc::new(MockLedgrrr::mock());
 let node = NatsMeshNode::new(
     MeshNodeConfig::new("alpha", "nats://localhost:4222")
         .with_project("app4dog")
@@ -112,9 +113,12 @@ node.record_usage("app4dog", "nats.broadcast", 1).await?;
 let codes = ledger.codes_for("app4dog"); // roll up finops for the project
 ```
 
-`LocalLedgrrr` is the default (persistent JSONL, no server). `McpLedgrrr`
-bridges to the running `ledgerr-mcp` server via `LEDGERR_MCP_CMD`, mirroring
-`b00t-mcp`'s existing stdio bridge.
+`LocalLedgrrr` is the persistent default (JSONL, no server). For this
+broker-free / nats-focused PR the mesh defaults to `MockLedgrrr`
+(`LocalLedgrrr::mock()`), which mints synthetic `MOCK-FINOPS-*` codes in-memory
+so the nats work is not blocked on a running `ledgerr-mcp`. `McpLedgrrr` bridges
+to the real server via `LEDGERR_MCP_CMD`, mirroring `b00t-mcp`'s stdio bridge;
+iroh-backed receipt exchange is deferred (see NATS-MESH-GOSSIP-DISCOVERY).
 
 ### Dataframe-typed receipts → Apache Arrow
 

--- a/_b00t_/nats.skill.toml
+++ b/_b00t_/nats.skill.toml
@@ -1,52 +1,52 @@
 ---
 name: nats
 type: skill
-hint: NATS intra-agent mesh — Redis-free b00t hive discovery, direct send, broadcast, and presence over NATS subjects
+hint: NATS intra-hive mesh — Redis-free b00t hive discovery, direct send, broadcast, and presence over NATS subjects
 version: 1.0.0
-tags: [nats, mesh, a2a, discovery, ipc, b00t-comms, pubsub, intra-agent]
+tags: [nats, mesh, a2a, discovery, ipc, b00t-comms, pubsub, intra-hive]
 tier: ch0nky
 complexity: 5
 description: |-
   Provides the `--skill=nats` capability for the `b00t-comms` agent: a fully
-  realized NATS intra-agent mesh in `b00t-lib-chat` (src/mesh.rs). Every b00t
+  realized NATS intra-hive mesh in `b00t-lib-chat` (src/mesh.rs). Every b00t
   agent process becomes a first-class mesh node keyed by a stable agent id.
   The mesh needs only a reachable NATS server (no Redis, no central registry),
   so agent discovery works even when the Redis broker is down.
-applies_to: [agent discovery, A2A messaging, hive coordination, intra-agent mesh, offline discovery]
+applies_to: [agent discovery, A2A messaging, hive coordination, intra-hive mesh, offline discovery]
 output_types: [.rs, .toml]
 allowed-tools: Read, Write, Edit, Grep, Glob, Bash, Task
 ---
 
 ## What
 
-`nats` realizes the b00t intra-agent mesh. It is implemented in
+`nats` realizes the b00t intra-hive mesh. It is implemented in
 `b00t-lib-chat/src/mesh.rs` as `NatsMeshNode` and is the canonical
 `--skill=nats` for the `b00t-comms` agent. The mesh speaks `async_nats`
 directly (the channel-based `NatsTransport` cannot express per-agent inboxes
 or NATS reply-to, so the mesh does not reuse it).
 
-Subject hierarchy (all under `b00t.mesh.*`):
+Subject hierarchy (all under `b00t.hive.mesh.*`):
 
 | Subject | Purpose |
 |---------|---------|
-| `b00t.mesh.node.{agent_id}` | a node's direct inbox (point-to-point + discovery reply target) |
-| `b00t.mesh.channel.{channel}` | pub/sub broadcast channel |
-| `b00t.mesh.discovery.query` | broadcast "who is online?" with a NATS reply inbox |
-| `b00t.mesh.discovery.presence` | periodic heartbeat announcing a live node |
-| `b00t.mesh.gossip` | epidemic membership advertising (`MeshFrame::Gossip`); bounded hop-budget re-gossip so discovery converges without a central registry |
+| `b00t.hive.mesh.node.{agent_id}` | a node's direct inbox (point-to-point + discovery reply target) |
+| `b00t.hive.mesh.channel.{channel}` | pub/sub broadcast channel |
+| `b00t.hive.mesh.discovery.query` | broadcast "who is online?" with a NATS reply inbox |
+| `b00t.hive.mesh.discovery.presence` | periodic heartbeat announcing a live node |
+| `b00t.hive.mesh.gossip` | epidemic membership advertising (`MeshFrame::Gossip`); bounded hop-budget re-gossip so discovery converges without a central registry |
 
 The four primitives:
 
 1. **Presence** — `announce()` / `start_presence()` publish heartbeats on the
    presence subject. Peers learn each other with no central registry.
 2. **Discovery** — `discover()` publishes a `DiscoveryQuery` to
-   `b00t.mesh.discovery.query` with the node's own inbox as the NATS reply
+   `b00t.hive.mesh.discovery.query` with the node's own inbox as the NATS reply
    inbox. Live nodes answer with a `DiscoveryReply` carrying their
    `AgentEndpoint`. Already-known peers are returned immediately.
 3. **Direct send** — `send(to_agent, msg)` publishes a `Direct` frame to
-   `b00t.mesh.node.{to_agent}`.
+   `b00t.hive.mesh.node.{to_agent}`.
 4. **Broadcast** — `publish(channel, msg)` publishes a `Broadcast` frame to
-   `b00t.mesh.channel.{channel}`.
+   `b00t.hive.mesh.channel.{channel}`.
 
 `NatsMeshNode` implements `DiscoverableTransport`, so it slots into the
 existing `b00t agent discover` plumbing as a Redis-free transport.
@@ -133,9 +133,26 @@ implementation; `UsageReceipt` also implements `DataframeReceipt`.
 let batch = focus_record.to_dataframe().to_arrow()?; // feature `dataframe`
 ```
 
+### Ontology — UFO grounding
+
+The hive types are classified against the `ufo-types` crate (#511) via the
+`Stereotyped` trait, so they carry a `UfoStereotype` for evidence/audit
+(`record_is_a`):
+
+| Type | UFO stereotype |
+|------|----------------|
+| `AgentEndpoint` | `Kind("AgentEndpoint")` — material endpoint realizing an agent |
+| `AgentPresence` | `Kind("AgentPresence")` — live reachability snapshot |
+| `GossipMember` | `Kind("GossipMember")` — membership entry |
+| `MeshFrame` | `Relator("hive-mesh-frame")` — binds sender↔recipient |
+| `NatsMeshNode` | `Role("hive-node")` — plays the intra-hive comms role |
+
+This aligns the mesh with the existing b00t hive UFO stereotypes and the
+`b00t.hive.*` namespace (intra-hive, same network).
+
 <!-- b00t:map v1
-summary: nats — Redis-free NATS intra-agent mesh (discovery, direct, broadcast, presence) + ledgrrr finops receipts + Arrow dataframe for b00t-comms
-tags: nats, mesh, a2a, discovery, ipc, b00t-comms, intra-agent, finops, ledgrrr, arrow, dataframe
+summary: nats — Redis-free NATS intra-hive mesh (discovery, direct, broadcast, presence) + ledgrrr finops receipts + Arrow dataframe for b00t-comms
+tags: nats, mesh, a2a, discovery, ipc, b00t-comms, intra-hive, finops, ledgrrr, arrow, dataframe
 tier: ch0nky
 cmds: cargo run -p b00t-chat --example mesh_cli -- node1 nats://localhost:4222 listen
 complexity: 5

--- a/_b00t_/nats.skill.toml
+++ b/_b00t_/nats.skill.toml
@@ -1,0 +1,138 @@
+---
+name: nats
+type: skill
+hint: NATS intra-agent mesh — Redis-free b00t hive discovery, direct send, broadcast, and presence over NATS subjects
+version: 1.0.0
+tags: [nats, mesh, a2a, discovery, ipc, b00t-comms, pubsub, intra-agent]
+tier: ch0nky
+complexity: 5
+description: |-
+  Provides the `--skill=nats` capability for the `b00t-comms` agent: a fully
+  realized NATS intra-agent mesh in `b00t-lib-chat` (src/mesh.rs). Every b00t
+  agent process becomes a first-class mesh node keyed by a stable agent id.
+  The mesh needs only a reachable NATS server (no Redis, no central registry),
+  so agent discovery works even when the Redis broker is down.
+applies_to: [agent discovery, A2A messaging, hive coordination, intra-agent mesh, offline discovery]
+output_types: [.rs, .toml]
+allowed-tools: Read, Write, Edit, Grep, Glob, Bash, Task
+---
+
+## What
+
+`nats` realizes the b00t intra-agent mesh. It is implemented in
+`b00t-lib-chat/src/mesh.rs` as `NatsMeshNode` and is the canonical
+`--skill=nats` for the `b00t-comms` agent. The mesh speaks `async_nats`
+directly (the channel-based `NatsTransport` cannot express per-agent inboxes
+or NATS reply-to, so the mesh does not reuse it).
+
+Subject hierarchy (all under `b00t.mesh.*`):
+
+| Subject | Purpose |
+|---------|---------|
+| `b00t.mesh.node.{agent_id}` | a node's direct inbox (point-to-point + discovery reply target) |
+| `b00t.mesh.channel.{channel}` | pub/sub broadcast channel |
+| `b00t.mesh.discovery.query` | broadcast "who is online?" with a NATS reply inbox |
+| `b00t.mesh.discovery.presence` | periodic heartbeat announcing a live node |
+
+The four primitives:
+
+1. **Presence** — `announce()` / `start_presence()` publish heartbeats on the
+   presence subject. Peers learn each other with no central registry.
+2. **Discovery** — `discover()` publishes a `DiscoveryQuery` to
+   `b00t.mesh.discovery.query` with the node's own inbox as the NATS reply
+   inbox. Live nodes answer with a `DiscoveryReply` carrying their
+   `AgentEndpoint`. Already-known peers are returned immediately.
+3. **Direct send** — `send(to_agent, msg)` publishes a `Direct` frame to
+   `b00t.mesh.node.{to_agent}`.
+4. **Broadcast** — `publish(channel, msg)` publishes a `Broadcast` frame to
+   `b00t.mesh.channel.{channel}`.
+
+`NatsMeshNode` implements `DiscoverableTransport`, so it slots into the
+existing `b00t agent discover` plumbing as a Redis-free transport.
+
+## When to Use
+
+Use `nats` whenever hive coordination must survive a down Redis broker, or when
+agents run across hosts/regions where a single Unix-socket registry is not
+enough. Prefer the mesh over `discover`'s local-filesystem fallback when a NATS
+server is reachable, because it also carries live messaging (not just discovery).
+
+## How
+
+```rust
+use b00t_chat::mesh::{MeshNodeConfig, NatsMeshNode};
+use b00t_chat::message::ChatMessage;
+
+let node = NatsMeshNode::new(
+    MeshNodeConfig::new("alpha", "nats://localhost:4222")
+        .with_role("b00t-comms")
+        .with_skills(vec!["nats".to_string()]),
+);
+node.connect().await?;
+node.start_presence().await;            // heartbeat + discoverable
+let peers = node.discover().await?;     // request/reply discovery
+node.join("mission.alpha").await?;
+node.publish("mission.alpha", &ChatMessage::new("mission.alpha", "alpha", "go"))
+    .await?;
+while let Some(frame) = node.recv().await? { /* handle */ }
+```
+
+Run the reference `b00t-comms` node without writing Rust:
+
+```text
+cargo run -p b00t-chat --example mesh_cli -- node1 nats://localhost:4222 listen
+cargo run -p b00t-chat --example mesh_cli -- node2 nats://localhost:4222 discover
+```
+
+## Tests
+
+`cargo test -p b00t-chat` runs unit tests (subject shape, presence TTL, frame
+JSON round-trip, self/stale peer exclusion) with no server. A full two-node
+integration test is env-gated on `NATS_URL`; when unset it is skipped so CI
+stays green without a broker.
+
+## Finops / Collaborative Autonomy
+
+The mesh is the accounting seam for collaborative autonomy. Every capability a
+`b00t-comms` node executes registers a `UsageReceipt` with **ledgrrr**
+(`b00t-lib-chat/src/ledgrrr.rs`) and mints a finops code
+(`FINOPS-<project>-<seq>`). This makes each project/capability an agent runs
+attributable and auditable:
+
+```rust
+let ledger = Arc::new(LocalLedgrrr::file(".b00t/finops.jsonl")?);
+let node = NatsMeshNode::new(
+    MeshNodeConfig::new("alpha", "nats://localhost:4222")
+        .with_project("app4dog")
+        .with_ledgrrr(ledger.clone()),
+);
+node.connect().await?;
+node.send("beta", &msg).await?;          // auto-registers a nats.send receipt
+node.record_usage("app4dog", "nats.broadcast", 1).await?;
+let codes = ledger.codes_for("app4dog"); // roll up finops for the project
+```
+
+`LocalLedgrrr` is the default (persistent JSONL, no server). `McpLedgrrr`
+bridges to the running `ledgerr-mcp` server via `LEDGERR_MCP_CMD`, mirroring
+`b00t-mcp`'s existing stdio bridge.
+
+### Dataframe-typed receipts → Apache Arrow
+
+Every receipt is also a `DataframeReceipt` (`b00t-lib-chat/src/dataframe_receipt.rs`):
+it yields an Arrow-shaped `Dataframe` (named columns + Arrow datatypes). With
+the `dataframe` feature, `Dataframe::to_arrow()` materializes a real
+`arrow::record_batch::RecordBatch` — the concrete columnar implementation the
+operator requires. The **FOCUS record** (`FocusRecord`) is the reference
+implementation; `UsageReceipt` also implements `DataframeReceipt`.
+
+```rust
+let batch = focus_record.to_dataframe().to_arrow()?; // feature `dataframe`
+```
+
+<!-- b00t:map v1
+summary: nats — Redis-free NATS intra-agent mesh (discovery, direct, broadcast, presence) + ledgrrr finops receipts + Arrow dataframe for b00t-comms
+tags: nats, mesh, a2a, discovery, ipc, b00t-comms, intra-agent, finops, ledgrrr, arrow, dataframe
+tier: ch0nky
+cmds: cargo run -p b00t-chat --example mesh_cli -- node1 nats://localhost:4222 listen
+complexity: 5
+-->

--- a/b00t-cli/src/commands/agent.rs
+++ b/b00t-cli/src/commands/agent.rs
@@ -365,7 +365,12 @@ async fn handle_workers(json: bool) -> Result<()> {
     };
 
     let coordinator = AgentCoordinator::new(redis, metadata);
-    let agents = coordinator.discover_agents().await?;
+    let mut agents = coordinator.discover_agents().await?;
+
+    // Kaizen: Redis empty → surface locally-defined agents.
+    if agents.is_empty() {
+        agents = discover_local_agents();
+    }
 
     if json {
         println!("{}", serde_json::to_string_pretty(&agents)?);
@@ -385,6 +390,93 @@ async fn handle_workers(json: bool) -> Result<()> {
         }
     }
     Ok(())
+}
+
+/// Fallback agent discovery from the local filesystem when the Redis-backed
+/// registry is unavailable (no broker, or no agents registered).
+///
+/// Scans `_b00t_/*.agent.toml` in the current dir and `~/.b00t/_b00t_/*.agent.toml`,
+/// parsing each `[b00t]`/`[b00t.agent]` table into an `AgentMetadata`. This makes
+/// `b00t agent discover` useful offline instead of silently returning zero agents.
+fn discover_local_agents() -> Vec<AgentMetadata> {
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0);
+
+    let dirs: Vec<_> = [
+        std::env::current_dir().ok().map(|d| d.join("_b00t_")),
+        dirs::home_dir().map(|d| d.join(".b00t").join("_b00t_")),
+    ]
+    .into_iter()
+    .flatten()
+    .filter(|p| p.is_dir())
+    .collect();
+
+    let mut out = Vec::new();
+    for dir in &dirs {
+        let Ok(entries) = std::fs::read_dir(dir) else {
+            continue;
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.extension().and_then(|e| e.to_str()) != Some("toml") {
+                continue;
+            }
+            let file_name = path.file_name().and_then(|s| s.to_str()).unwrap_or("");
+            if !file_name.ends_with(".agent.toml") {
+                continue;
+            }
+            let Ok(content) = std::fs::read_to_string(&path) else {
+                continue;
+            };
+            let Ok(value) = toml::from_str::<toml::Value>(&content) else {
+                continue;
+            };
+            let b00t = match value.get("b00t") {
+                Some(v) => v,
+                None => continue,
+            };
+            let agent_id = b00t
+                .get("name")
+                .and_then(|n| n.as_str())
+                .unwrap_or(file_name)
+                .to_string();
+            let agent_tbl = b00t.get("agent");
+            let agent_role = agent_tbl
+                .and_then(|a| a.get("role"))
+                .and_then(|r| r.as_str())
+                .unwrap_or("unknown")
+                .to_string();
+            let capabilities = agent_tbl
+                .and_then(|a| a.get("skills"))
+                .and_then(|s| s.as_array())
+                .map(|arr| {
+                    arr.iter()
+                        .filter_map(|v| v.as_str().map(|s| s.to_string()))
+                        .collect::<Vec<_>>()
+                })
+                .unwrap_or_default();
+            let crew = agent_tbl
+                .and_then(|a| a.get("crew"))
+                .and_then(|c| c.get("role"))
+                .and_then(|r| r.as_str())
+                .map(|s| s.to_string());
+
+            out.push(AgentMetadata {
+                agent_id,
+                agent_role,
+                capabilities,
+                crew,
+                status: AgentStatus::Online,
+                last_seen: now,
+                load: 0.0,
+                specializations: HashMap::new(),
+                subtype: Default::default(),
+            });
+        }
+    }
+    out
 }
 
 async fn handle_discover(
@@ -410,6 +502,19 @@ async fn handle_discover(
 
     let coordinator = AgentCoordinator::new(redis, metadata);
     let mut agents = coordinator.discover_agents().await?;
+    let from_redis = !agents.is_empty();
+
+    // Kaizen: Redis registry empty/unavailable → fall back to locally-defined
+    // agents so `discover` is useful offline instead of returning zero.
+    if agents.is_empty() {
+        agents = discover_local_agents();
+        if !agents.is_empty() {
+            eprintln!(
+                "⚠️  Redis agent registry empty/unavailable — discovered {} local agent(s) from _b00t_/*.agent.toml",
+                agents.len()
+            );
+        }
+    }
 
     // Apply filters
     if let Some(role_filter) = role {
@@ -432,7 +537,8 @@ async fn handle_discover(
     if json {
         println!("{}", serde_json::to_string_pretty(&agents)?);
     } else {
-        println!("📡 Discovered {} agents:\n", agents.len());
+        let source = if from_redis { "" } else { "local " };
+        println!("📡 Discovered {} {}agent(s):\n", agents.len(), source);
         for agent in agents {
             let subtype_label = if agent.subtype.is_known() {
                 format!(" [{}]", agent.subtype.label())
@@ -677,11 +783,28 @@ async fn handle_capability(capabilities: &str, description: &str, urgency_str: &
     println!("Task: {}", description);
 
     let agents = coordinator
-        .request_capability(required_caps, description, urgency)
+        .request_capability(required_caps.clone(), description, urgency)
         .await?;
 
     if agents.is_empty() {
-        println!("No agents responded (Redis may be unavailable)");
+        // Kaizen: Redis unavailable → fall back to locally-defined agents.
+        let local = discover_local_agents();
+        let matched: Vec<_> = local
+            .iter()
+            .filter(|a| {
+                required_caps
+                    .iter()
+                    .all(|c| a.capabilities.contains(c))
+            })
+            .collect();
+        if matched.is_empty() {
+            println!("No agents responded (Redis may be unavailable; no local match)");
+        } else {
+            println!("Capable local agents found: {}", matched.len());
+            for a in &matched {
+                println!("  {} - {:?}", a.agent_id, a.capabilities);
+            }
+        }
     } else {
         println!("Capable agents found: {}", agents.len());
         for (agent_id, skills) in &agents {

--- a/b00t-lib-chat/Cargo.toml
+++ b/b00t-lib-chat/Cargo.toml
@@ -39,6 +39,7 @@ async-trait = "0.1"
 async-stream = "0.3"
 regex = "1.0"
 cron = "0.15"
+arrow = { version = "55", optional = true }
 
 # OpenTelemetry observability — workspace version + extra features for chat runtime
 opentelemetry = { workspace = true, features = ["metrics"] }
@@ -63,6 +64,8 @@ tempfile = "3.0"
 default = []
 python = ["pyo3"]
 wasm = ["wasm-bindgen", "js-sys", "web-sys", "serde-wasm-bindgen"]
+# Concrete Apache Arrow materialization for dataframe-typed receipts.
+dataframe = ["arrow"]
 
 # 🤓 Profile configuration moved to workspace root to avoid warnings
 # Examples are in examples/ directory, not as bins

--- a/b00t-lib-chat/Cargo.toml
+++ b/b00t-lib-chat/Cargo.toml
@@ -40,6 +40,9 @@ async-stream = "0.3"
 regex = "1.0"
 cron = "0.15"
 arrow = { version = "55", optional = true }
+# UFO-grounded domain stereotypes (crate #511) — hive types declare their
+# ontological classification via `Stereotyped`.
+ufo-types = { path = "../crates/ufo-types" }
 
 # OpenTelemetry observability — workspace version + extra features for chat runtime
 opentelemetry = { workspace = true, features = ["metrics"] }

--- a/b00t-lib-chat/examples/mesh_cli.rs
+++ b/b00t-lib-chat/examples/mesh_cli.rs
@@ -14,7 +14,7 @@
 //! default `b00t-comms` channel, announces presence, and prints every frame it
 //! receives (including auto-replies to discovery queries from other nodes).
 
-use b00t_chat::ledgrrr::{LocalLedgrrr, Ledgrrr};
+use b00t_chat::ledgrrr::{Ledgrrr, MockLedgrrr};
 use b00t_chat::mesh::{MeshFrame, MeshNodeConfig, NatsMeshNode};
 use b00t_chat::message::ChatMessage;
 use std::sync::Arc;
@@ -26,11 +26,12 @@ async fn main() -> anyhow::Result<()> {
     let nats_url = args.next().unwrap_or_else(|| "nats://localhost:4222".to_string());
     let command = args.next().unwrap_or_else(|| "discover".to_string());
 
-    // Optional local finops ledger (collaborative-autonomy receipts).
-    let ledger: Option<Arc<LocalLedgrrr>> =
+    // Finops ledger (collaborative-autonomy receipts). Defaults to an in-memory
+    // mock; point B00T_LEDGER at a path for a persisted local ledger.
+    let ledger: Option<Arc<dyn Ledgrrr>> =
         match std::env::var("B00T_LEDGER").ok().filter(|s| !s.is_empty()) {
-            Some(path) => Some(Arc::new(LocalLedgrrr::file(&path)?)),
-            None => None,
+            Some(path) => Some(Arc::new(MockLedgrrr::file(&path)?)),
+            None => Some(Arc::new(MockLedgrrr::mock())),
         };
     let project = std::env::var("B00T_PROJECT").unwrap_or_else(|_| "b00t-comms".to_string());
 
@@ -71,6 +72,9 @@ async fn main() -> anyhow::Result<()> {
                     MeshFrame::DiscoveryQuery { from, .. } => {
                         println!("[discovery-query] from {from}")
                     }
+                    // Gossip frames are internal mesh plumbing (membership
+                    // advertising) and are not surfaced to the app channel.
+                    MeshFrame::Gossip { .. } => {}
                 }
             }
         }

--- a/b00t-lib-chat/examples/mesh_cli.rs
+++ b/b00t-lib-chat/examples/mesh_cli.rs
@@ -1,0 +1,106 @@
+//! `b00t-comms` mesh CLI — realizes `--agent=b00t-comms --skill=nats`.
+//!
+//! Run two terminals against a reachable NATS server:
+//!
+//! ```text
+//! # terminal 1
+//! cargo run -p b00t-chat --example mesh_cli -- node1 nats://localhost:4222 listen
+//! # terminal 2
+//! cargo run -p b00t-chat --example mesh_cli -- node2 nats://localhost:4222 discover
+//! cargo run -p b00t-chat --example mesh_cli -- node2 nats://localhost:4222 send node1 "hello mesh"
+//! ```
+//!
+//! `discover` publishes a query and prints live peers. `listen` joins the
+//! default `b00t-comms` channel, announces presence, and prints every frame it
+//! receives (including auto-replies to discovery queries from other nodes).
+
+use b00t_chat::ledgrrr::{LocalLedgrrr, Ledgrrr};
+use b00t_chat::mesh::{MeshFrame, MeshNodeConfig, NatsMeshNode};
+use b00t_chat::message::ChatMessage;
+use std::sync::Arc;
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let mut args = std::env::args().skip(1);
+    let agent_id = args.next().unwrap_or_else(|| "b00t-comms".to_string());
+    let nats_url = args.next().unwrap_or_else(|| "nats://localhost:4222".to_string());
+    let command = args.next().unwrap_or_else(|| "discover".to_string());
+
+    // Optional local finops ledger (collaborative-autonomy receipts).
+    let ledger: Option<Arc<LocalLedgrrr>> =
+        match std::env::var("B00T_LEDGER").ok().filter(|s| !s.is_empty()) {
+            Some(path) => Some(Arc::new(LocalLedgrrr::file(&path)?)),
+            None => None,
+        };
+    let project = std::env::var("B00T_PROJECT").unwrap_or_else(|_| "b00t-comms".to_string());
+
+    let mut config = MeshNodeConfig::new(agent_id.clone(), nats_url)
+        .with_role("b00t-comms")
+        .with_skills(vec!["nats".to_string()])
+        .with_project(project.clone());
+    if let Some(l) = &ledger {
+        config = config.with_ledgrrr(l.clone() as Arc<dyn Ledgrrr>);
+    }
+
+    let node = NatsMeshNode::new(config);
+    node.connect().await?;
+    node.announce().await?;
+
+    match command.as_str() {
+        "discover" => {
+            let peers = node.discover().await?;
+            println!("discovered {} peer(s):", peers.len());
+            for p in &peers {
+                println!("  - {} ({})", p.agent_id, p.endpoint_uri);
+            }
+        }
+        "listen" => {
+            node.join("b00t-comms").await?;
+            node.start_presence().await;
+            println!("{agent_id} listening on mesh channel 'b00t-comms' (ctrl-c to stop)");
+            while let Some(frame) = node.recv().await? {
+                match frame {
+                    MeshFrame::Direct(m) => println!("[direct] {}: {}", m.sender, m.body),
+                    MeshFrame::Broadcast { channel, message } => {
+                        println!("[broadcast:{channel}] {}: {}", message.sender, message.body)
+                    }
+                    MeshFrame::Presence(p) => println!("[presence] {} role={}", p.agent_id, p.role),
+                    MeshFrame::DiscoveryReply { endpoint, .. } => {
+                        println!("[discovery-reply] {}", endpoint.agent_id)
+                    }
+                    MeshFrame::DiscoveryQuery { from, .. } => {
+                        println!("[discovery-query] from {from}")
+                    }
+                }
+            }
+        }
+        "send" => {
+            let to = args.next().expect("send requires <to-agent>");
+            let body = args.next().unwrap_or_else(|| "ping".to_string());
+            let msg = ChatMessage::new("b00t-comms", &agent_id, body);
+            node.send(&to, &msg).await?;
+            println!("sent direct message to {to}");
+        }
+        "broadcast" => {
+            let body = args.next().unwrap_or_else(|| "hello mesh".to_string());
+            let msg = ChatMessage::new("b00t-comms", &agent_id, body);
+            node.publish("b00t-comms", &msg).await?;
+            println!("broadcast on channel 'b00t-comms'");
+        }
+        other => {
+            eprintln!("unknown command: {other} (discover|listen|send|broadcast)");
+            std::process::exit(2);
+        }
+    }
+
+    if let Some(l) = &ledger {
+        let codes = l.codes_for(&project);
+        println!("finops: {project} -> {} receipt(s) minted", codes.len());
+        for c in &codes {
+            println!("  - {c}");
+        }
+    }
+
+    node.close().await?;
+    Ok(())
+}

--- a/b00t-lib-chat/src/dataframe_receipt.rs
+++ b/b00t-lib-chat/src/dataframe_receipt.rs
@@ -1,0 +1,315 @@
+//! Dataframe-typed receipts → Apache Arrow.
+//!
+//! Every subsystem that executes billable/auditable work emits a *typed
+//! receipt*. The [`DataframeReceipt`] trait is the contract each subsystem
+//! implements: given a receipt, produce a columnar [`Dataframe`]. The dataframe
+//! is Arrow-shaped (named columns + Arrow-compatible datatypes), so the same
+//! receipt can be dumped to Parquet, queried with DataFusion, or streamed to a
+//! finops warehouse.
+//!
+//! The local [`Dataframe`] type compiles with **no** external dependency, so
+//! the trait is always available. When the `dataframe` feature is enabled,
+//! `Dataframe::to_arrow()` materializes a real `arrow::record_batch::RecordBatch`
+//! — the concrete Arrow implementation the operator requires. The FOCUS record
+//! (ledgrr's experiment/finops record) is the reference [`DataframeReceipt`]
+//! implementation.
+
+use serde::{Deserialize, Serialize};
+
+/// Arrow-compatible logical datatype for a receipt column.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Datatype {
+    Null,
+    Bool,
+    Int64,
+    Float64,
+    Utf8,
+    /// Milliseconds since the Unix epoch.
+    TimestampMs,
+}
+
+impl Datatype {
+    /// Map to the corresponding `arrow` datatype (feature `dataframe`).
+    #[cfg(feature = "dataframe")]
+    pub fn to_arrow(&self) -> arrow::datatypes::DataType {
+        use arrow::datatypes::DataType;
+        match self {
+            Datatype::Null => DataType::Null,
+            Datatype::Bool => DataType::Boolean,
+            Datatype::Int64 => DataType::Int64,
+            Datatype::Float64 => DataType::Float64,
+            Datatype::Utf8 => DataType::Utf8,
+            Datatype::TimestampMs => {
+                DataType::Timestamp(arrow::datatypes::TimeUnit::Millisecond, None)
+            }
+        }
+    }
+}
+
+/// A single typed column value (Arrow-compatible).
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub enum ColumnValue {
+    Null,
+    Bool(bool),
+    Int64(i64),
+    Float64(f64),
+    Utf8(String),
+    TimestampMs(i64),
+}
+
+impl ColumnValue {
+    pub fn as_bool(&self) -> bool {
+        matches!(self, ColumnValue::Bool(true))
+    }
+    pub fn as_i64(&self) -> i64 {
+        match self {
+            ColumnValue::Int64(v) => *v,
+            ColumnValue::TimestampMs(v) => *v,
+            _ => 0,
+        }
+    }
+    pub fn as_f64(&self) -> f64 {
+        match self {
+            ColumnValue::Float64(v) => *v,
+            ColumnValue::Int64(v) => *v as f64,
+            _ => 0.0,
+        }
+    }
+    pub fn as_str(&self) -> &str {
+        match self {
+            ColumnValue::Utf8(s) => s,
+            _ => "",
+        }
+    }
+}
+
+/// A columnar, Arrow-shaped receipt dataframe (one or more rows).
+#[derive(Debug, Clone)]
+pub struct Dataframe {
+    pub fields: Vec<Field>,
+    pub columns: Vec<Vec<ColumnValue>>,
+}
+
+/// A named, typed column descriptor.
+#[derive(Debug, Clone)]
+pub struct Field {
+    pub name: String,
+    pub datatype: Datatype,
+    pub nullable: bool,
+}
+
+impl Dataframe {
+    /// New dataframe with the given field schema; columns are empty.
+    pub fn new(fields: Vec<Field>) -> Self {
+        let columns = vec![Vec::new(); fields.len()];
+        Self { fields, columns }
+    }
+
+    /// Append one row. `values` must align 1:1 with `fields`.
+    pub fn push_row(&mut self, values: Vec<ColumnValue>) {
+        debug_assert_eq!(values.len(), self.fields.len());
+        for (col, v) in self.columns.iter_mut().zip(values.into_iter()) {
+            col.push(v);
+        }
+    }
+
+    pub fn row_count(&self) -> usize {
+        self.columns.first().map(|c| c.len()).unwrap_or(0)
+    }
+
+    /// Materialize a real Apache Arrow `RecordBatch` from this dataframe.
+    #[cfg(feature = "dataframe")]
+    pub fn to_arrow(&self) -> arrow::error::Result<arrow::record_batch::RecordBatch> {
+        use arrow::array::*;
+        use arrow::datatypes::{Field as AField, Schema};
+        use arrow::record_batch::RecordBatch;
+        use std::sync::Arc;
+
+        let a_fields: Vec<Arc<AField>> = self
+            .fields
+            .iter()
+            .map(|f| Arc::new(AField::new(&f.name, f.datatype.to_arrow(), f.nullable)))
+            .collect();
+        let schema = Arc::new(Schema::new(a_fields));
+
+        let mut arrays: Vec<ArrayRef> = Vec::with_capacity(self.fields.len());
+        for (field, col) in self.fields.iter().zip(self.columns.iter()) {
+            let arr: ArrayRef = match field.datatype {
+                Datatype::Null => Arc::new(NullArray::new(col.len())),
+                Datatype::Bool => {
+                    let mut b = BooleanBuilder::new();
+                    for v in col {
+                        b.append_value(v.as_bool());
+                    }
+                    Arc::new(b.finish())
+                }
+                Datatype::Int64 => {
+                    let mut b = Int64Builder::new();
+                    for v in col {
+                        b.append_value(v.as_i64());
+                    }
+                    Arc::new(b.finish())
+                }
+                Datatype::Float64 => {
+                    let mut b = Float64Builder::new();
+                    for v in col {
+                        b.append_value(v.as_f64());
+                    }
+                    Arc::new(b.finish())
+                }
+                Datatype::Utf8 => {
+                    let mut b = StringBuilder::new();
+                    for v in col {
+                        b.append_value(v.as_str());
+                    }
+                    Arc::new(b.finish())
+                }
+                Datatype::TimestampMs => {
+                    let mut b = TimestampMillisecondBuilder::new();
+                    for v in col {
+                        b.append_value(v.as_i64());
+                    }
+                    Arc::new(b.finish())
+                }
+            };
+            arrays.push(arr);
+        }
+        RecordBatch::try_new(schema, arrays)
+    }
+}
+
+/// Contract every subsystem implements for its typed receipt.
+///
+/// `to_dataframe()` returns a single-row (or multi-row) Arrow-shaped dataframe
+/// describing the receipt. Subsystems call this to feed finops/audit pipelines.
+pub trait DataframeReceipt {
+    /// Logical schema (column names + datatypes).
+    fn fields(&self) -> Vec<Field>;
+    /// The receipt's rows as columnar values.
+    fn rows(&self) -> Vec<Vec<ColumnValue>>;
+    /// Convenience: build the dataframe (schema + rows).
+    fn to_dataframe(&self) -> Dataframe {
+        let mut df = Dataframe::new(self.fields());
+        for row in self.rows() {
+            df.push_row(row);
+        }
+        df
+    }
+}
+
+// ── Reference implementation: FOCUS record ─────────────────────────────────
+//
+// FOCUS is ledgrr's experiment/finops record (see b00t-cli datum_schema.rs:
+// x_ExperimentId, x_Variant, x_Personality, x_ExperimentScore, x_AgentId,
+// x_ReasoningReview). Any subsystem running an experiment emits one.
+
+/// A FOCUS record — the canonical dataframe-typed finops receipt.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FocusRecord {
+    pub experiment_id: String,
+    pub variant: String,
+    pub personality: String,
+    pub score: f64,
+    pub agent_id: String,
+    pub reasoning_review: String,
+    pub occurred_at_ms: i64,
+}
+
+impl DataframeReceipt for FocusRecord {
+    fn fields(&self) -> Vec<Field> {
+        use Datatype::*;
+        vec![
+            Field { name: "experiment_id".into(), datatype: Utf8, nullable: false },
+            Field { name: "variant".into(), datatype: Utf8, nullable: false },
+            Field { name: "personality".into(), datatype: Utf8, nullable: true },
+            Field { name: "score".into(), datatype: Float64, nullable: false },
+            Field { name: "agent_id".into(), datatype: Utf8, nullable: false },
+            Field { name: "reasoning_review".into(), datatype: Utf8, nullable: true },
+            Field { name: "occurred_at_ms".into(), datatype: TimestampMs, nullable: false },
+        ]
+    }
+
+    fn rows(&self) -> Vec<Vec<ColumnValue>> {
+        vec![vec![
+            ColumnValue::Utf8(self.experiment_id.clone()),
+            ColumnValue::Utf8(self.variant.clone()),
+            ColumnValue::Utf8(self.personality.clone()),
+            ColumnValue::Float64(self.score),
+            ColumnValue::Utf8(self.agent_id.clone()),
+            ColumnValue::Utf8(self.reasoning_review.clone()),
+            ColumnValue::TimestampMs(self.occurred_at_ms),
+        ]]
+    }
+}
+
+// ── ledgrrr UsageReceipt is also a dataframe-typed receipt ──────────────────
+
+impl DataframeReceipt for crate::ledgrrr::UsageReceipt {
+    fn fields(&self) -> Vec<Field> {
+        use Datatype::*;
+        vec![
+            Field { name: "receipt_id".into(), datatype: Utf8, nullable: false },
+            Field { name: "agent_id".into(), datatype: Utf8, nullable: false },
+            Field { name: "project".into(), datatype: Utf8, nullable: false },
+            Field { name: "capability".into(), datatype: Utf8, nullable: false },
+            Field { name: "units".into(), datatype: Int64, nullable: false },
+            Field { name: "occurred_at".into(), datatype: TimestampMs, nullable: false },
+            Field { name: "finops_code".into(), datatype: Utf8, nullable: true },
+            Field { name: "constraint_satisfied".into(), datatype: Bool, nullable: false },
+        ]
+    }
+
+    fn rows(&self) -> Vec<Vec<ColumnValue>> {
+        vec![vec![
+            ColumnValue::Utf8(self.receipt_id.clone()),
+            ColumnValue::Utf8(self.agent_id.clone()),
+            ColumnValue::Utf8(self.project.clone()),
+            ColumnValue::Utf8(self.capability.clone()),
+            ColumnValue::Int64(self.units as i64),
+            ColumnValue::TimestampMs(self.occurred_at as i64),
+            ColumnValue::Utf8(self.finops_code.clone().unwrap_or_default()),
+            ColumnValue::Bool(self.constraint_satisfied),
+        ]]
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn focus_record_builds_a_dataframe_row() {
+        let f = FocusRecord {
+            experiment_id: "exp-1".into(),
+            variant: "treatment".into(),
+            personality: "meticulous".into(),
+            score: 0.87,
+            agent_id: "alpha".into(),
+            reasoning_review: "accepted".into(),
+            occurred_at_ms: 1_700_000_000_000,
+        };
+        let df = f.to_dataframe();
+        assert_eq!(df.row_count(), 1);
+        assert_eq!(df.fields.len(), 7);
+        assert_eq!(df.columns[4][0].as_str(), "alpha");
+        assert_eq!(df.columns[3][0].as_f64(), 0.87);
+    }
+
+    #[cfg(feature = "dataframe")]
+    #[test]
+    fn focus_record_materializes_arrow() {
+        let f = FocusRecord {
+            experiment_id: "exp-2".into(),
+            variant: "control".into(),
+            personality: "low".into(),
+            score: 0.42,
+            agent_id: "beta".into(),
+            reasoning_review: "rejected".into(),
+            occurred_at_ms: 1_700_000_000_123,
+        };
+        let batch = f.to_dataframe().to_arrow().unwrap();
+        assert_eq!(batch.num_rows(), 1);
+        assert_eq!(batch.num_columns(), 7);
+        assert_eq!(batch.schema().field(0).name(), "experiment_id");
+    }
+}

--- a/b00t-lib-chat/src/error.rs
+++ b/b00t-lib-chat/src/error.rs
@@ -32,6 +32,10 @@ pub enum ChatError {
     /// Generic error for miscellaneous cases.
     #[error("{0}")]
     Other(String),
+
+    /// Underlying NATS client failure.
+    #[error("nats error: {0}")]
+    Nats(String),
 }
 
 /// Convenience result type used across the chat crate.
@@ -41,5 +45,14 @@ impl ChatError {
     /// Build an [`ChatError::Other`] from any displayable value.
     pub fn other(msg: impl Into<String>) -> Self {
         ChatError::Other(msg.into())
+    }
+}
+
+impl<E> From<async_nats::error::Error<E>> for ChatError
+where
+    E: std::fmt::Debug + Clone + PartialEq + std::fmt::Display,
+{
+    fn from(e: async_nats::error::Error<E>) -> Self {
+        ChatError::Nats(format!("{e:?}"))
     }
 }

--- a/b00t-lib-chat/src/gossip.rs
+++ b/b00t-lib-chat/src/gossip.rs
@@ -1,0 +1,174 @@
+//! Epidemic (gossip) membership for the b00t mesh.
+//!
+//! Gossip-based discovery advertising: when a node announces, it *gossips* its
+//! presence to the mesh. Every node that receives a newer advertisement
+//! re-gossips it (with a decremented hop budget) until the budget hits zero.
+//! This is the advertisement primitive the operator asked for — nodes learn
+//! each other not by a central registry or a single query/response, but by
+//! epidemic propagation of signed presence advertisements.
+//!
+//! The table is **transport-agnostic**: the mesh wires it to a NATS subject
+//! today, but the same logic drives a future P2P transport (Iroh/gossip) where
+//! there is no central broker to fan out for you. See
+//! `_b00t_/NATS-MESH-GOSSIP-DISCOVERY.tomllmd`.
+
+use crate::ipc_transport::{AgentEndpoint, TransportKind};
+use crate::mesh::AgentPresence;
+use std::collections::HashMap;
+use std::time::{Duration, SystemTime};
+
+/// A single membership entry: the presence plus the monotonically increasing
+/// sequence the advertiser assigned it.
+#[derive(Debug, Clone)]
+pub struct GossipMember {
+    pub presence: AgentPresence,
+    pub seq: u64,
+}
+
+/// Transport-agnostic epidemic membership table.
+///
+/// `ingest` is the core decision: accept a received advertisement only if it is
+/// newer than what we hold, and return the remaining hop budget so the caller
+/// can re-advertise (bounded epidemic). `hops == 0` means "accept but do not
+/// forward" — this is what stops the gossip from looping forever.
+#[derive(Debug, Clone)]
+pub struct GossipTable {
+    max_hops: u8,
+    members: HashMap<String, GossipMember>,
+}
+
+impl GossipTable {
+    pub fn new(max_hops: u8) -> Self {
+        Self {
+            max_hops,
+            members: HashMap::new(),
+        }
+    }
+
+    pub fn max_hops(&self) -> u8 {
+        self.max_hops
+    }
+
+    /// Ingest an incoming advertisement. Returns `Some(remaining_hops)` when the
+    /// member was accepted as newer and should be re-gossiped, or `None` when it
+    /// was a stale/duplicate (do not forward).
+    pub fn ingest(&mut self, presence: AgentPresence, seq: u64, hops: u8) -> Option<u8> {
+        match self.members.get(&presence.agent_id) {
+            Some(existing) if existing.seq >= seq => return None,
+            _ => {}
+        }
+        self.members.insert(
+            presence.agent_id.clone(),
+            GossipMember {
+                presence: presence.clone(),
+                seq,
+            },
+        );
+        if hops == 0 {
+            None
+        } else {
+            Some(hops - 1)
+        }
+    }
+
+    /// Record a local (self-originated or non-propagating) presence update.
+    pub fn insert_local(&mut self, presence: AgentPresence, seq: u64) {
+        self.members.insert(
+            presence.agent_id.clone(),
+            GossipMember {
+                presence,
+                seq,
+            },
+        );
+    }
+
+    /// Next sequence number for `agent_id` (previous + 1, or 1 if unseen).
+    pub fn next_seq(&self, agent_id: &str) -> u64 {
+        self.members
+            .get(agent_id)
+            .map(|m| m.seq + 1)
+            .unwrap_or(1)
+    }
+
+    /// All live endpoints (excluding self, excluding stale by TTL).
+    pub fn live_endpoints(&self, self_id: &str, _ttl: Duration) -> Vec<AgentEndpoint> {
+        let now = SystemTime::now();
+        self.members
+            .values()
+            .filter(|m| m.presence.agent_id != self_id && !m.presence.is_stale(now))
+            .map(|m| AgentEndpoint {
+                agent_id: m.presence.agent_id.clone(),
+                endpoint_uri: m.presence.endpoint_uri.clone(),
+                transport_kind: TransportKind::Nats,
+                last_seen: m.presence.last_seen,
+                metadata: Some(serde_json::json!({
+                    "role": m.presence.role,
+                    "skills": m.presence.skills,
+                    "seq": m.seq,
+                })),
+            })
+            .collect()
+    }
+
+    pub fn peer_count(&self, self_id: &str, _ttl: Duration) -> usize {
+        let now = SystemTime::now();
+        self.members
+            .values()
+            .filter(|m| m.presence.agent_id != self_id && !m.presence.is_stale(now))
+            .count()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::{Duration, SystemTime};
+
+    fn presence(id: &str, _seq: u64) -> AgentPresence {
+        AgentPresence {
+            agent_id: id.into(),
+            role: "r".into(),
+            skills: vec![],
+            endpoint_uri: format!("b00t.mesh.node.{id}"),
+            last_seen: SystemTime::now(),
+            ttl: Duration::from_secs(30),
+        }
+    }
+
+    #[test]
+    fn newer_advertisement_is_accepted_and_forwarded() {
+        let mut t = GossipTable::new(5);
+        assert_eq!(t.ingest(presence("a", 1), 1, 5), Some(4));
+        // same seq -> stale, not forwarded
+        assert_eq!(t.ingest(presence("a", 1), 1, 5), None);
+        // older seq -> stale
+        assert_eq!(t.ingest(presence("a", 1), 1, 5), None);
+        // newer seq -> accepted, forwarded with decremented hops
+        assert_eq!(t.ingest(presence("a", 2), 2, 3), Some(2));
+    }
+
+    #[test]
+    fn hop_budget_terminates_propagation() {
+        let mut t = GossipTable::new(5);
+        // hops==0 means accept but never forward
+        assert_eq!(t.ingest(presence("b", 1), 1, 0), None);
+        assert_eq!(t.peer_count("self", Duration::from_secs(30)), 1);
+    }
+
+    #[test]
+    fn self_and_stale_are_excluded_from_endpoints() {
+        let mut t = GossipTable::new(5);
+        t.insert_local(presence("self", 1), 1);
+        t.insert_local(presence("live", 1), 1);
+        let stale = presence("ghost", 1);
+        t.insert_local(stale, 1);
+        // age the ghost
+        t.members.get_mut("ghost").unwrap().presence.last_seen =
+            SystemTime::now() - Duration::from_secs(120);
+        let eps = t.live_endpoints("self", Duration::from_secs(30));
+        let ids: Vec<&str> = eps.iter().map(|e| e.agent_id.as_str()).collect();
+        assert!(ids.contains(&"live"));
+        assert!(!ids.contains(&"self"));
+        assert!(!ids.contains(&"ghost"));
+    }
+}

--- a/b00t-lib-chat/src/gossip.rs
+++ b/b00t-lib-chat/src/gossip.rs
@@ -16,6 +16,7 @@ use crate::ipc_transport::{AgentEndpoint, TransportKind};
 use crate::mesh::AgentPresence;
 use std::collections::HashMap;
 use std::time::{Duration, SystemTime};
+use ufo_types::{Stereotyped, UfoStereotype};
 
 /// A single membership entry: the presence plus the monotonically increasing
 /// sequence the advertiser assigned it.
@@ -23,6 +24,12 @@ use std::time::{Duration, SystemTime};
 pub struct GossipMember {
     pub presence: AgentPresence,
     pub seq: u64,
+}
+
+impl Stereotyped for GossipMember {
+    fn ufo_stereotype(&self) -> UfoStereotype {
+        UfoStereotype::Kind("GossipMember".into())
+    }
 }
 
 /// Transport-agnostic epidemic membership table.
@@ -129,7 +136,7 @@ mod tests {
             agent_id: id.into(),
             role: "r".into(),
             skills: vec![],
-            endpoint_uri: format!("b00t.mesh.node.{id}"),
+            endpoint_uri: format!("b00t.hive.mesh.node.{id}"),
             last_seen: SystemTime::now(),
             ttl: Duration::from_secs(30),
         }
@@ -170,5 +177,14 @@ mod tests {
         assert!(ids.contains(&"live"));
         assert!(!ids.contains(&"self"));
         assert!(!ids.contains(&"ghost"));
+    }
+
+    #[test]
+    fn gossip_member_is_ufo_grounded() {
+        let m = GossipMember {
+            presence: presence("a", 1),
+            seq: 1,
+        };
+        assert_eq!(m.ufo_stereotype().to_string(), "Kind:GossipMember");
     }
 }

--- a/b00t-lib-chat/src/ipc_transport.rs
+++ b/b00t-lib-chat/src/ipc_transport.rs
@@ -8,6 +8,7 @@ use crate::error::ChatResult;
 use crate::message::ChatMessage;
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
+use ufo_types::{Stereotyped, UfoStereotype};
 use std::fmt::Debug;
 
 /// Core transport trait for sending/receiving messages.
@@ -78,6 +79,14 @@ pub struct AgentEndpoint {
     pub transport_kind: TransportKind,
     pub last_seen: std::time::SystemTime,
     pub metadata: Option<serde_json::Value>,
+}
+
+impl Stereotyped for AgentEndpoint {
+    fn ufo_stereotype(&self) -> UfoStereotype {
+        // The material network endpoint that realizes a hive agent's
+        // communicative capacity — a domain Kind (endpoint of an agent).
+        UfoStereotype::Kind("AgentEndpoint".into())
+    }
 }
 
 /// Agent watcher for monitoring agent availability.

--- a/b00t-lib-chat/src/ledgrrr.rs
+++ b/b00t-lib-chat/src/ledgrrr.rs
@@ -139,15 +139,29 @@ pub struct LocalLedgrrr {
     constraint: ReceiptConstraint,
     by_project: Mutex<HashMap<String, Vec<UsageReceipt>>>,
     path: Option<PathBuf>,
+    code_prefix: String,
 }
 
 impl LocalLedgrrr {
-    /// In-memory ledger (no persistence).
+    /// In-memory ledger (no persistence), prefix `FINOPS`.
     pub fn memory() -> Self {
         Self {
             constraint: ReceiptConstraint::strict(),
             by_project: Mutex::new(HashMap::new()),
             path: None,
+            code_prefix: "FINOPS".to_string(),
+        }
+    }
+
+    /// Mock ledger used while real ledgerr integration is pending: synthetic
+    /// `MOCK-FINOPS-*` codes, in-memory only. Keeps the nats mesh focus
+    /// unblocked from a running `ledgerr-mcp` server.
+    pub fn mock() -> Self {
+        Self {
+            constraint: ReceiptConstraint::strict(),
+            by_project: Mutex::new(HashMap::new()),
+            path: None,
+            code_prefix: "MOCK-FINOPS".to_string(),
         }
     }
 
@@ -169,12 +183,13 @@ impl LocalLedgrrr {
             constraint: ReceiptConstraint::strict(),
             by_project: Mutex::new(by_project),
             path: Some(path),
+            code_prefix: "FINOPS".to_string(),
         })
     }
 
     fn next_code(&self, project: &str, map: &HashMap<String, Vec<UsageReceipt>>) -> FinopsCode {
         let seq = map.get(project).map(|v| v.len() as u64 + 1).unwrap_or(1);
-        FinopsCode(format!("FINOPS-{}-{:06}", slug(project), seq))
+        FinopsCode(format!("{}-{}-{:06}", self.code_prefix, slug(project), seq))
     }
 
     fn append_line(&self, receipt: &UsageReceipt) -> ChatResult<()> {
@@ -228,6 +243,11 @@ impl Ledgrrr for LocalLedgrrr {
             .unwrap_or(0)
     }
 }
+
+/// Mock ledger alias (see [`LocalLedgrrr::mock`]); synthetic `MOCK-FINOPS-*`
+/// codes, no external server. Used by the nats-focused mesh work until real
+/// ledgerr integration (and iroh backing) lands.
+pub type MockLedgrrr = LocalLedgrrr;
 
 /// MCP bridge to the `ledgerr-mcp` server (production seam).
 ///

--- a/b00t-lib-chat/src/ledgrrr.rs
+++ b/b00t-lib-chat/src/ledgrrr.rs
@@ -1,0 +1,386 @@
+//! ledgrrr — finops usage ledger for collaborative autonomy.
+//!
+//! Every capability a b00t agent executes on behalf of a project is a
+//! billable/auditable event. This module makes that explicit: the agent
+//! creates a **receipt of data** ([`UsageReceipt`]) for each execution and
+//! registers it with `ledgrrr`, which mints a **finops usage code**
+//! ([`FinopsCode`]). Multiple collaborating agents share one ledger
+//! (local-first JSONL, or the `ledgerr-mcp` server) so usage is attributable
+//! per agent / project / capability — the accounting backbone of
+//! collaborative autonomy.
+//!
+//! Two implementations:
+//! - [`LocalLedgrrr`] — persistent JSONL ledger, milled codes, constraint
+//!   validation. Fully realized, no external server; the default.
+//! - [`McpLedgrrr`] — bridges to the running `ledgerr-mcp` server over stdio
+//!   (mirrors `b00t-mcp`'s existing `call_ledgerr_mcp_stdio` bridge, driven by
+//!   `LEDGERR_MCP_CMD`). The production seam when a server is available.
+
+use crate::error::{ChatError, ChatResult};
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::io::{BufRead, BufReader, Write};
+use std::path::{Path, PathBuf};
+use std::sync::Mutex;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+/// A finops usage code minted by ledgrrr on receipt registration.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct FinopsCode(pub String);
+
+impl FinopsCode {
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl std::fmt::Display for FinopsCode {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+/// Constraint a [`UsageReceipt`] must satisfy before a code is minted.
+/// Aligns with the Tax-Lawyer `Satisfies<Constraint>` pattern used across
+/// `ledgerr_tax` / `ufo-types`.
+#[derive(Debug, Clone, Default)]
+pub struct ReceiptConstraint {
+    pub require_project: bool,
+    pub require_capability: bool,
+    pub nonneg_units: bool,
+}
+
+impl ReceiptConstraint {
+    pub fn strict() -> Self {
+        Self {
+            require_project: true,
+            require_capability: true,
+            nonneg_units: true,
+        }
+    }
+}
+
+/// A data receipt describing one agent capability execution.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct UsageReceipt {
+    pub receipt_id: String,
+    pub agent_id: String,
+    pub project: String,
+    pub capability: String,
+    /// Quantified usage (messages, tokens, requests…). Drives finops cost.
+    pub units: u64,
+    /// Epoch milliseconds when the capability executed.
+    pub occurred_at: u64,
+    /// Whether the receipt passed [`ReceiptConstraint`] validation.
+    pub constraint_satisfied: bool,
+    /// Finops code assigned by ledgrrr on registration (None until registered).
+    pub finops_code: Option<String>,
+    #[serde(default, skip_serializing_if = "serde_json::Value::is_null")]
+    pub metadata: serde_json::Value,
+}
+
+impl UsageReceipt {
+    pub fn new(
+        agent_id: impl Into<String>,
+        project: impl Into<String>,
+        capability: impl Into<String>,
+        units: u64,
+    ) -> Self {
+        let occurred_at = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|d| d.as_millis() as u64)
+            .unwrap_or(0);
+        Self {
+            receipt_id: uuid::Uuid::new_v4().to_string(),
+            agent_id: agent_id.into(),
+            project: project.into(),
+            capability: capability.into(),
+            units,
+            occurred_at,
+            constraint_satisfied: false,
+            finops_code: None,
+            metadata: serde_json::Value::Null,
+        }
+    }
+
+    /// Evaluate the receipt against a constraint (Tax-Lawyer `Satisfies`).
+    pub fn check(&mut self, c: &ReceiptConstraint) -> bool {
+        let ok = (!c.require_project || !self.project.is_empty())
+            && (!c.require_capability || !self.capability.is_empty())
+            && (!c.nonneg_units || self.units > 0);
+        self.constraint_satisfied = ok;
+        ok
+    }
+}
+
+/// The ledgrrr ledger contract. Implemented by local and MCP backends.
+pub trait Ledgrrr: Send + Sync {
+    /// Register a receipt; mint and return its finops usage code.
+    fn register(&self, receipt: &UsageReceipt) -> ChatResult<FinopsCode>;
+    /// All finops codes recorded for a project.
+    fn codes_for(&self, project: &str) -> Vec<FinopsCode>;
+    /// Total units recorded for a project (collaborative cost rollup).
+    fn units_for(&self, project: &str) -> u64;
+}
+
+fn slug(project: &str) -> String {
+    project
+        .chars()
+        .map(|c| if c.is_ascii_alphanumeric() { c.to_ascii_lowercase() } else { '-' })
+        .collect::<String>()
+        .trim_matches('-')
+        .to_string()
+}
+
+/// Local-first persistent ledger. Append-only JSONL; milled, monotonic finops
+/// codes per project. Safe for multiple collaborating agents on one host when
+/// they point at the same `path` (each append is a single line write).
+pub struct LocalLedgrrr {
+    constraint: ReceiptConstraint,
+    by_project: Mutex<HashMap<String, Vec<UsageReceipt>>>,
+    path: Option<PathBuf>,
+}
+
+impl LocalLedgrrr {
+    /// In-memory ledger (no persistence).
+    pub fn memory() -> Self {
+        Self {
+            constraint: ReceiptConstraint::strict(),
+            by_project: Mutex::new(HashMap::new()),
+            path: None,
+        }
+    }
+
+    /// Persistent ledger backed by a JSONL file. Existing lines are replayed to
+    /// continue the per-project code sequence.
+    pub fn file(path: impl AsRef<Path>) -> ChatResult<Self> {
+        let path = path.as_ref().to_path_buf();
+        let mut by_project: HashMap<String, Vec<UsageReceipt>> = HashMap::new();
+        if path.exists() {
+            let file = std::fs::File::open(&path)
+                .map_err(|e| ChatError::Other(format!("ledgrrr open {path:?}: {e}")))?;
+            for line in BufReader::new(file).lines().flatten() {
+                if let Ok(r) = serde_json::from_str::<UsageReceipt>(&line) {
+                    by_project.entry(r.project.clone()).or_default().push(r);
+                }
+            }
+        }
+        Ok(Self {
+            constraint: ReceiptConstraint::strict(),
+            by_project: Mutex::new(by_project),
+            path: Some(path),
+        })
+    }
+
+    fn next_code(&self, project: &str, map: &HashMap<String, Vec<UsageReceipt>>) -> FinopsCode {
+        let seq = map.get(project).map(|v| v.len() as u64 + 1).unwrap_or(1);
+        FinopsCode(format!("FINOPS-{}-{:06}", slug(project), seq))
+    }
+
+    fn append_line(&self, receipt: &UsageReceipt) -> ChatResult<()> {
+        let Some(path) = &self.path else {
+            return Ok(());
+        };
+        let mut file = std::fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(path)
+            .map_err(|e| ChatError::Other(format!("ledgrrr append {path:?}: {e}")))?;
+        let line = serde_json::to_string(receipt)?;
+        writeln!(file, "{line}")
+            .map_err(|e| ChatError::Other(format!("ledgrrr write {path:?}: {e}")))?;
+        Ok(())
+    }
+}
+
+impl Ledgrrr for LocalLedgrrr {
+    fn register(&self, receipt: &UsageReceipt) -> ChatResult<FinopsCode> {
+        let mut receipt = receipt.clone();
+        if !receipt.check(&self.constraint) {
+            return Err(ChatError::Other(format!(
+                "ledgrrr: receipt {} failed constraint",
+                receipt.receipt_id
+            )));
+        }
+        let mut map = self.by_project.lock().unwrap();
+        let code = self.next_code(&receipt.project, &map);
+        receipt.finops_code = Some(code.0.clone());
+        self.append_line(&receipt)?;
+        map.entry(receipt.project.clone()).or_default().push(receipt);
+        Ok(code)
+    }
+
+    fn codes_for(&self, project: &str) -> Vec<FinopsCode> {
+        self.by_project
+            .lock()
+            .unwrap()
+            .get(project)
+            .map(|v| v.iter().filter_map(|r| r.finops_code.clone().map(FinopsCode)).collect())
+            .unwrap_or_default()
+    }
+
+    fn units_for(&self, project: &str) -> u64 {
+        self.by_project
+            .lock()
+            .unwrap()
+            .get(project)
+            .map(|v| v.iter().map(|r| r.units).sum())
+            .unwrap_or(0)
+    }
+}
+
+/// MCP bridge to the `ledgerr-mcp` server (production seam).
+///
+/// Mirrors `b00t-mcp`'s `call_ledgerr_mcp_stdio`: spawns the binary named by
+/// `LEDGERR_MCP_CMD` as a stdio subprocess, performs the MCP `initialize`
+/// handshake, then issues `tools/call` for `ledgerr_register_receipt`. The
+/// returned finops code is parsed from the tool result.
+///
+/// ⚠️ The exact register-tool name/shape should be confirmed against the
+/// deployed `ledgerr-mcp`; it is the integration surface, not a local default.
+pub struct McpLedgrrr {
+    command: String,
+    register_tool: String,
+}
+
+impl McpLedgrrr {
+    pub fn from_env() -> ChatResult<Self> {
+        let command = std::env::var("LEDGERR_MCP_CMD")
+            .map_err(|_| ChatError::Other("LEDGERR_MCP_CMD not set".into()))?;
+        Ok(Self {
+            command,
+            register_tool: "ledgerr_register_receipt".to_string(),
+        })
+    }
+
+    pub fn with_command(command: impl Into<String>) -> Self {
+        Self {
+            command: command.into(),
+            register_tool: "ledgerr_register_receipt".to_string(),
+        }
+    }
+}
+
+impl Ledgrrr for McpLedgrrr {
+    fn register(&self, receipt: &UsageReceipt) -> ChatResult<FinopsCode> {
+        let payload = serde_json::json!({
+            "name": self.register_tool,
+            "arguments": { "receipt": receipt }
+        });
+        let result = call_ledgerr_stdio(&self.command, &payload)
+            .map_err(|e| ChatError::Other(format!("ledgrrr-mcp: {e}")))?;
+        let code = result
+            .get("finops_code")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| ChatError::Other("ledgrrr-mcp: no finops_code in response".into()))?;
+        Ok(FinopsCode(code.to_string()))
+    }
+
+    fn codes_for(&self, _project: &str) -> Vec<FinopsCode> {
+        // Remote ledger: not enumerated locally by the bridge.
+        Vec::new()
+    }
+
+    fn units_for(&self, _project: &str) -> u64 {
+        0
+    }
+}
+
+/// Spawn `ledgerr-mcp` as a stdio subprocess, handshake, call one tool.
+/// Returns the parsed `result` object from the tool response.
+fn call_ledgerr_stdio(cmd: &str, payload: &serde_json::Value) -> anyhow::Result<serde_json::Value> {
+    use std::io::{BufRead, Write};
+    use std::process::{Command, Stdio};
+
+    let mut child = Command::new(cmd)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .map_err(|e| anyhow::anyhow!("spawn ledgerr-mcp failed: {e}"))?;
+
+    let mut stdin = child.stdin.take().ok_or_else(|| anyhow::anyhow!("no stdin"))?;
+    let stdout = child.stdout.take().ok_or_else(|| anyhow::anyhow!("no stdout"))?;
+
+    let initialize = serde_json::json!({
+        "jsonrpc": "2.0", "id": 1,
+        "method": "initialize",
+        "params": { "protocolVersion": "2024-11-05", "capabilities": {} }
+    });
+    writeln!(stdin, "{initialize}").ok();
+    stdin.flush().ok();
+
+    let initialized = serde_json::json!({
+        "jsonrpc": "2.0", "method": "notifications/initialized", "params": {}
+    });
+    writeln!(stdin, "{initialized}").ok();
+    stdin.flush().ok();
+
+    let call = serde_json::json!({
+        "jsonrpc": "2.0", "id": 2,
+        "method": "tools/call",
+        "params": payload
+    });
+    writeln!(stdin, "{call}").ok();
+    stdin.flush().ok();
+
+    let reader = std::io::BufReader::new(stdout);
+    for line in reader.lines() {
+        let line = match line {
+            Ok(l) => l,
+            Err(_) => break,
+        };
+        if let Ok(v) = serde_json::from_str::<serde_json::Value>(&line) {
+            if v.get("id").and_then(|i| i.as_i64()) == Some(2) {
+                return Ok(v
+                    .get("result")
+                    .and_then(|r| r.get("content"))
+                    .and_then(|c| c.as_array())
+                    .and_then(|a| a.first())
+                    .and_then(|c| c.get("text"))
+                    .and_then(|t| t.as_str())
+                    .and_then(|t| serde_json::from_str::<serde_json::Value>(t).ok())
+                    .unwrap_or_else(|| serde_json::json!({})));
+            }
+        }
+    }
+    Err(anyhow::anyhow!("no response from ledgerr-mcp"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn local_ledger_mints_monotonic_codes() {
+        let ledger = LocalLedgrrr::memory();
+        let r1 = UsageReceipt::new("alpha", "app4dog", "nats.send", 1);
+        let r2 = UsageReceipt::new("beta", "app4dog", "nats.broadcast", 3);
+        let c1 = ledger.register(&r1).unwrap();
+        let c2 = ledger.register(&r2).unwrap();
+        assert_eq!(c1.as_str(), "FINOPS-app4dog-000001");
+        assert_eq!(c2.as_str(), "FINOPS-app4dog-000002");
+        assert_eq!(ledger.codes_for("app4dog").len(), 2);
+        assert_eq!(ledger.units_for("app4dog"), 4);
+    }
+
+    #[test]
+    fn constraint_rejects_empty_project() {
+        let ledger = LocalLedgrrr::memory();
+        let bad = UsageReceipt::new("alpha", "", "nats.send", 1);
+        assert!(ledger.register(&bad).is_err());
+    }
+
+    #[test]
+    fn slugifies_project_names() {
+        assert_eq!(slug("App4.Dog"), "app4-dog");
+    }
+
+    #[test]
+    fn receipt_check_validates_units() {
+        let mut r = UsageReceipt::new("a", "p", "c", 0);
+        assert!(!r.check(&ReceiptConstraint::strict()));
+        let mut r2 = UsageReceipt::new("a", "p", "c", 5);
+        assert!(r2.check(&ReceiptConstraint::strict()));
+    }
+}

--- a/b00t-lib-chat/src/lib.rs
+++ b/b00t-lib-chat/src/lib.rs
@@ -31,6 +31,7 @@ pub mod client;
 pub mod discovery;
 pub mod dataframe_receipt;
 pub mod error;
+pub mod gossip;
 pub mod ipc_transport;
 pub mod ledgrrr;
 pub mod mesh;
@@ -61,7 +62,8 @@ pub use mesh::{
     AgentPresence, MeshFrame, MeshNodeConfig, NatsMeshNode, DEFAULT_DISCOVER_TIMEOUT,
     DEFAULT_PRESENCE_INTERVAL, DEFAULT_PRESENCE_TTL,
 };
-pub use ledgrrr::{FinopsCode, Ledgrrr, LocalLedgrrr, McpLedgrrr, ReceiptConstraint, UsageReceipt};
+pub use ledgrrr::{FinopsCode, Ledgrrr, LocalLedgrrr, McpLedgrrr, MockLedgrrr, ReceiptConstraint, UsageReceipt};
+pub use gossip::{GossipTable, GossipMember};
 pub use dataframe_receipt::{
     ColumnValue, Dataframe, DataframeReceipt, Datatype, Field, FocusRecord,
 };

--- a/b00t-lib-chat/src/lib.rs
+++ b/b00t-lib-chat/src/lib.rs
@@ -29,8 +29,11 @@ pub mod assignment;
 pub mod bridge;
 pub mod client;
 pub mod discovery;
+pub mod dataframe_receipt;
 pub mod error;
 pub mod ipc_transport;
+pub mod ledgrrr;
+pub mod mesh;
 pub mod message;
 pub mod metrics;
 pub mod protocol;
@@ -54,6 +57,14 @@ pub use ipc_transport::{
     DiscoverableTransport, IpcTransport, TransportKind,
 };
 pub use message::{ChatMessage, NotificationMessage, TaskMessage};
+pub use mesh::{
+    AgentPresence, MeshFrame, MeshNodeConfig, NatsMeshNode, DEFAULT_DISCOVER_TIMEOUT,
+    DEFAULT_PRESENCE_INTERVAL, DEFAULT_PRESENCE_TTL,
+};
+pub use ledgrrr::{FinopsCode, Ledgrrr, LocalLedgrrr, McpLedgrrr, ReceiptConstraint, UsageReceipt};
+pub use dataframe_receipt::{
+    ColumnValue, Dataframe, DataframeReceipt, Datatype, Field, FocusRecord,
+};
 pub use metrics::{ChatMetrics, LatencyTimer};
 pub use protocol::{ACPMessage, MessageType, StepBarrier};
 pub use router::{Destination, MessageRouter, MessageRouterBuilder};

--- a/b00t-lib-chat/src/mesh.rs
+++ b/b00t-lib-chat/src/mesh.rs
@@ -1,0 +1,760 @@
+//! NATS intra-agent mesh for b00t hive coordination.
+//!
+//! Realizes the `--agent=b00t-comms --skill=nats` capability: every b00t agent
+//! process is a first-class node in a subject-routed mesh over NATS. The mesh
+//! provides four primitives:
+//!
+//! 1. **Presence** — nodes announce heartbeats on `b00t.mesh.discovery.presence`
+//!    so peers learn each other without a central registry (Redis-free
+//!    discovery, works offline once a NATS server is reachable).
+//! 2. **Discovery** — `discover()` publishes a query to `b00t.mesh.discovery.query`
+//!    with a NATS reply inbox; live nodes answer with their [`AgentEndpoint`].
+//! 3. **Direct send** — point-to-point frames to `b00t.mesh.node.{agent_id}`.
+//! 4. **Broadcast** — pub/sub frames to `b00t.mesh.channel.{channel}`.
+//!
+//! The channel-based [`crate::transports::NatsTransport`] cannot express
+//! per-agent inboxes or NATS reply-to semantics, so the mesh speaks `async_nats`
+//! directly. It is fully compatible with the existing
+//! [`crate::ipc_transport::DiscoverableTransport`] trait so it can slot into
+//! `b00t agent discover` plumbing.
+
+use crate::error::{ChatError, ChatResult};
+use crate::ipc_transport::{
+    AgentEndpoint, AgentEvent, AgentWatcher, DiscoverableTransport, TransportKind,
+};
+use crate::ledgrrr::{FinopsCode, Ledgrrr, UsageReceipt};
+use crate::message::ChatMessage;
+use async_nats::Subscriber;
+use async_trait::async_trait;
+use futures::StreamExt;
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::{Duration, SystemTime};
+use tokio::sync::{mpsc, RwLock, RwLockWriteGuard};
+use tokio_stream::wrappers::ReceiverStream;
+use tracing::{info, warn};
+
+/// Subject prefix for a node's direct inbox.
+const NODE_PREFIX: &str = "b00t.mesh.node.";
+/// Subject prefix for a pub/sub channel.
+const CHANNEL_PREFIX: &str = "b00t.mesh.channel.";
+/// Subject all nodes listen on to answer discovery queries.
+const DISCOVERY_QUERY: &str = "b00t.mesh.discovery.query";
+/// Subject all nodes publish presence heartbeats to.
+const DISCOVERY_PRESENCE: &str = "b00t.mesh.discovery.presence";
+
+/// Default time a node waits for discovery replies before returning.
+pub const DEFAULT_DISCOVER_TIMEOUT: Duration = Duration::from_millis(1500);
+/// Default presence heartbeat interval.
+pub const DEFAULT_PRESENCE_INTERVAL: Duration = Duration::from_secs(10);
+/// Default time-to-live for a presence record before it is considered stale.
+pub const DEFAULT_PRESENCE_TTL: Duration = Duration::from_secs(30);
+
+/// Direct inbox subject for a given agent id.
+pub fn node_subject(agent_id: &str) -> String {
+    format!("{NODE_PREFIX}{agent_id}")
+}
+
+/// Pub/sub subject for a given channel name.
+pub fn channel_subject(channel: &str) -> String {
+    format!("{CHANNEL_PREFIX}{channel}")
+}
+
+/// Wire envelope exchanged between mesh nodes.
+///
+/// The NATS subject carries routing intent; this frame carries the typed
+/// payload so a single fused inbound stream can demultiplex every primitive.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum MeshFrame {
+    /// Point-to-point message addressed to this node's inbox.
+    Direct(ChatMessage),
+    /// Pub/sub broadcast on a channel.
+    Broadcast {
+        channel: String,
+        message: ChatMessage,
+    },
+    /// A peer asking "who is online?" — answered on the NATS reply inbox.
+    DiscoveryQuery {
+        from: String,
+        role: String,
+        skills: Vec<String>,
+    },
+    /// A node's self-description in response to a query or presence tick.
+    DiscoveryReply {
+        endpoint: AgentEndpoint,
+        role: String,
+        skills: Vec<String>,
+    },
+    /// Periodic heartbeat announcing a node is alive.
+    Presence(AgentPresence),
+}
+
+/// Live presence record for a mesh node.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AgentPresence {
+    pub agent_id: String,
+    pub role: String,
+    pub skills: Vec<String>,
+    pub endpoint_uri: String,
+    pub last_seen: SystemTime,
+    pub ttl: Duration,
+}
+
+impl AgentPresence {
+    /// True when this record has not been refreshed within its TTL.
+    pub fn is_stale(&self, now: SystemTime) -> bool {
+        match now.duration_since(self.last_seen) {
+            Ok(age) => age > self.ttl,
+            Err(_) => false,
+        }
+    }
+}
+
+/// Builder/configuration for a [`NatsMeshNode`].
+#[derive(Clone)]
+pub struct MeshNodeConfig {
+    pub agent_id: String,
+    pub role: String,
+    pub skills: Vec<String>,
+    pub nats_url: String,
+    pub discover_timeout: Duration,
+    pub presence_interval: Duration,
+    pub presence_ttl: Duration,
+    /// Project attributed to this node's finops receipts (collaborative-autonomy).
+    pub project: String,
+    /// Optional ledgrrr ledger; when set, every capability execution registers
+    /// a usage receipt and mints a finops code.
+    pub ledgrrr: Option<Arc<dyn Ledgrrr>>,
+}
+
+impl MeshNodeConfig {
+    pub fn new(agent_id: impl Into<String>, nats_url: impl Into<String>) -> Self {
+        Self {
+            agent_id: agent_id.into(),
+            role: "b00t-comms".to_string(),
+            skills: vec!["nats".to_string()],
+            nats_url: nats_url.into(),
+            discover_timeout: DEFAULT_DISCOVER_TIMEOUT,
+            presence_interval: DEFAULT_PRESENCE_INTERVAL,
+            presence_ttl: DEFAULT_PRESENCE_TTL,
+            project: "b00t-comms".to_string(),
+            ledgrrr: None,
+        }
+    }
+
+    pub fn with_role(mut self, role: impl Into<String>) -> Self {
+        self.role = role.into();
+        self
+    }
+
+    pub fn with_skills(mut self, skills: Vec<String>) -> Self {
+        self.skills = skills;
+        self
+    }
+
+    pub fn with_project(mut self, project: impl Into<String>) -> Self {
+        self.project = project.into();
+        self
+    }
+
+    pub fn with_ledgrrr(mut self, ledgrrr: Arc<dyn Ledgrrr>) -> Self {
+        self.ledgrrr = Some(ledgrrr);
+        self
+    }
+}
+
+impl std::fmt::Debug for MeshNodeConfig {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("MeshNodeConfig")
+            .field("agent_id", &self.agent_id)
+            .field("role", &self.role)
+            .field("project", &self.project)
+            .field("nats_url", &self.nats_url)
+            .field("ledgrrr", &self.ledgrrr.is_some())
+            .finish()
+    }
+}
+
+/// A node in the b00t NATS intra-agent mesh.
+///
+/// Connect, join channels, announce presence, then `recv()` frames. Discovery
+/// is request/reply over NATS; presence heartbeats keep the peer table fresh
+/// so `discover()` returns instantly for already-known nodes.
+#[derive(Clone)]
+pub struct NatsMeshNode {
+    config: MeshNodeConfig,
+    client: Arc<RwLock<Option<async_nats::Client>>>,
+    /// Known peers keyed by agent id (presence + discovery replies).
+    peers: Arc<RwLock<HashMap<String, AgentPresence>>>,
+    /// Application-facing inbound frames.
+    inbox_tx: mpsc::Sender<MeshFrame>,
+    inbox_rx: Arc<RwLock<Option<mpsc::Receiver<MeshFrame>>>>,
+    /// Forwarding task handles, aborted on close.
+    forwards: Arc<RwLock<Vec<tokio::task::JoinHandle<()>>>>,
+    presence_task: Arc<RwLock<Option<tokio::task::JoinHandle<()>>>>,
+    ledgrrr: Option<Arc<dyn Ledgrrr>>,
+}
+
+impl std::fmt::Debug for NatsMeshNode {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("NatsMeshNode")
+            .field("agent_id", &self.config.agent_id)
+            .field("role", &self.config.role)
+            .finish()
+    }
+}
+
+impl NatsMeshNode {
+    pub fn new(config: MeshNodeConfig) -> Self {
+        let ledgrrr = config.ledgrrr.clone();
+        let (inbox_tx, inbox_rx) = mpsc::channel(256);
+        Self {
+            config,
+            client: Arc::new(RwLock::new(None)),
+            peers: Arc::new(RwLock::new(HashMap::new())),
+            inbox_tx,
+            inbox_rx: Arc::new(RwLock::new(Some(inbox_rx))),
+            forwards: Arc::new(RwLock::new(Vec::new())),
+            presence_task: Arc::new(RwLock::new(None)),
+            ledgrrr,
+        }
+    }
+
+    /// Register a finops usage receipt for a capability execution, if a ledger
+    /// is configured. Returns the minted code (or `None` when no ledger is set).
+    ///
+    /// This is the collaborative-autonomy accounting seam: every project/
+    /// capability an agent executes is attributable via a ledgrrr finops code.
+    pub async fn record_usage(
+        &self,
+        project: &str,
+        capability: &str,
+        units: u64,
+    ) -> ChatResult<Option<FinopsCode>> {
+        let Some(ledger) = &self.ledgrrr else {
+            return Ok(None);
+        };
+        let receipt = UsageReceipt::new(&self.config.agent_id, project, capability, units);
+        let code = ledger.register(&receipt)?;
+        Ok(Some(code))
+    }
+
+    /// Connect to NATS and start the inbound forwarding task.
+    pub async fn connect(&self) -> ChatResult<()> {
+        let mut guard = self.client.write().await;
+        if guard.is_some() {
+            return Ok(());
+        }
+        let client = async_nats::ConnectOptions::new()
+            .connect(&self.config.nats_url)
+            .await
+            .map_err(|e| {
+                ChatError::Other(format!(
+                    "NATS mesh connect failed ({}): {}",
+                    self.config.nats_url, e
+                ))
+            })?;
+        *guard = Some(client);
+        drop(guard);
+
+        self.spawn_inbound().await?;
+        info!("NATS mesh node connected: {}", self.config.agent_id);
+        Ok(())
+    }
+
+    async fn client(&self) -> ChatResult<async_nats::Client> {
+        self.client
+            .read()
+            .await
+            .clone()
+            .ok_or(ChatError::NotConnected)
+    }
+
+    /// Subscribe to the inbox, presence, discovery-query, and any joined
+    /// channels; forward every frame into the application inbox.
+    async fn spawn_inbound(&self) -> ChatResult<()> {
+        let client = self.client().await?;
+
+        let mut handles = self.forwards.write().await;
+
+        // Own inbox (direct messages + discovery reply target).
+        let inbox_sub = client
+            .subscribe(node_subject(&self.config.agent_id))
+            .await
+            .map_err(|e| ChatError::Nats(e.to_string()))?;
+        handles.push(self.forward(client.clone(), inbox_sub));
+
+        // Presence heartbeats.
+        let presence_sub = client
+            .subscribe(DISCOVERY_PRESENCE)
+            .await
+            .map_err(|e| ChatError::Nats(e.to_string()))?;
+        handles.push(self.forward(client.clone(), presence_sub));
+
+        // Discovery queries.
+        let query_sub = client
+            .subscribe(DISCOVERY_QUERY)
+            .await
+            .map_err(|e| ChatError::Nats(e.to_string()))?;
+        handles.push(self.forward(client.clone(), query_sub));
+
+        Ok(())
+    }
+
+    fn forward(
+        &self,
+        client: async_nats::Client,
+        mut sub: Subscriber,
+    ) -> tokio::task::JoinHandle<()> {
+        let inbox_tx = self.inbox_tx.clone();
+        let agent_id = self.config.agent_id.clone();
+        let peers = self.peers.clone();
+        let this_role = self.config.role.clone();
+        let this_skills = self.config.skills.clone();
+        let endpoint_uri = node_subject(&agent_id);
+        let ttl = self.config.presence_ttl;
+        tokio::spawn(async move {
+            while let Some(msg) = sub.next().await {
+                let frame: MeshFrame = match serde_json::from_slice(&msg.payload) {
+                    Ok(f) => f,
+                    Err(e) => {
+                        warn!("mesh: dropping undecodable frame: {}", e);
+                        continue;
+                    }
+                };
+                // Auto-learn peers from presence / discovery traffic.
+                match &frame {
+                    MeshFrame::Presence(p) => {
+                        upsert_presence(&peers, p.clone()).await;
+                    }
+                    MeshFrame::DiscoveryReply { endpoint, role, skills } => {
+                        if endpoint.agent_id != agent_id {
+                            upsert_presence(
+                                &peers,
+                                AgentPresence {
+                                    agent_id: endpoint.agent_id.clone(),
+                                    role: role.clone(),
+                                    skills: skills.clone(),
+                                    endpoint_uri: endpoint.endpoint_uri.clone(),
+                                    last_seen: SystemTime::now(),
+                                    ttl,
+                                },
+                            )
+                            .await;
+                        }
+                    }
+                    MeshFrame::DiscoveryQuery { from, role, skills } => {
+                        if from != &agent_id {
+                            upsert_presence(
+                                &peers,
+                                AgentPresence {
+                                    agent_id: from.clone(),
+                                    role: role.clone(),
+                                    skills: skills.clone(),
+                                    endpoint_uri: node_subject(from),
+                                    last_seen: SystemTime::now(),
+                                    ttl,
+                                },
+                            )
+                            .await;
+                            // Answer the query on its NATS reply inbox.
+                            if let Some(reply) = &msg.reply {
+                                let reply_frame = MeshFrame::DiscoveryReply {
+                                    endpoint: AgentEndpoint {
+                                        agent_id: agent_id.clone(),
+                                        endpoint_uri: endpoint_uri.clone(),
+                                        transport_kind: TransportKind::Nats,
+                                        last_seen: SystemTime::now(),
+                                        metadata: None,
+                                    },
+                                    role: this_role.clone(),
+                                    skills: this_skills.clone(),
+                                };
+                                let payload = match serde_json::to_vec(&reply_frame) {
+                                    Ok(p) => p,
+                                    Err(_) => continue,
+                                };
+                                if let Err(e) = client.publish(reply.clone(), payload.into()).await {
+                                    warn!("mesh: discovery reply failed: {}", e);
+                                }
+                            }
+                        }
+                    }
+                    _ => {}
+                }
+                if inbox_tx.send(frame).await.is_err() {
+                    break; // application dropped the node
+                }
+            }
+        })
+    }
+
+    /// Join a pub/sub channel (start receiving broadcasts on it).
+    pub async fn join(&self, channel: &str) -> ChatResult<()> {
+        let client = self.client().await?;
+        let sub = client
+            .subscribe(channel_subject(channel))
+            .await
+            .map_err(|e| ChatError::Nats(e.to_string()))?;
+        self.forwards.write().await.push(self.forward(client, sub));
+        Ok(())
+    }
+
+    /// Announce presence to the mesh (also answers future discovery queries).
+    pub async fn announce(&self) -> ChatResult<()> {
+        let client = self.client().await?;
+        let presence = AgentPresence {
+            agent_id: self.config.agent_id.clone(),
+            role: self.config.role.clone(),
+            skills: self.config.skills.clone(),
+            endpoint_uri: node_subject(&self.config.agent_id),
+            last_seen: SystemTime::now(),
+            ttl: self.config.presence_ttl,
+        };
+        let frame = MeshFrame::Presence(presence.clone());
+        let payload = serde_json::to_vec(&frame)?;
+        client
+            .publish(DISCOVERY_PRESENCE, payload.into())
+            .await
+            .map_err(|e| ChatError::Nats(e.to_string()))?;
+        upsert_presence(&self.peers, presence).await;
+        self.record_usage(&self.config.project, "nats.presence", 1)
+            .await
+            .ok();
+        Ok(())
+    }
+
+    /// Start a background heartbeat that announces presence every interval.
+    pub async fn start_presence(&self) {
+        let node = self.clone();
+        let interval = self.config.presence_interval;
+        let task = tokio::spawn(async move {
+            loop {
+                if let Err(e) = node.announce().await {
+                    warn!("mesh: presence announce failed: {}", e);
+                }
+                tokio::time::sleep(interval).await;
+            }
+        });
+        *self.presence_task.write().await = Some(task);
+    }
+
+    /// Discover peers: publish a query with the local inbox as reply target,
+    /// then collect replies for the configured timeout. Already-known peers
+    /// are included.
+    pub async fn discover(&self) -> ChatResult<Vec<AgentEndpoint>> {
+        self.discover_with_timeout(self.config.discover_timeout).await
+    }
+
+    /// Discover peers, waiting up to `timeout` for fresh replies.
+    pub async fn discover_with_timeout(&self, timeout: Duration) -> ChatResult<Vec<AgentEndpoint>> {
+        let client = self.client().await?;
+        let query = MeshFrame::DiscoveryQuery {
+            from: self.config.agent_id.clone(),
+            role: self.config.role.clone(),
+            skills: self.config.skills.clone(),
+        };
+        let payload = serde_json::to_vec(&query)?;
+        // NATS reply inbox = our own inbox subject.
+        let reply = node_subject(&self.config.agent_id);
+        client
+            .publish_with_reply(DISCOVERY_QUERY, reply, payload.into())
+            .await
+            .map_err(|e| ChatError::Nats(e.to_string()))?;
+        // Also announce so peers learn us even if they miss the reply window.
+        self.announce().await.ok();
+        self.record_usage(&self.config.project, "nats.discover", 1).await.ok();
+
+        // Collect inbound DiscoveryReply frames for `timeout`.
+        let deadline = tokio::time::Instant::now() + timeout;
+        let mut rx_guard = self.inbox_rx.write().await;
+        let rx = match rx_guard.take() {
+            Some(rx) => rx,
+            None => return Ok(self.endpoints_locked().await),
+        };
+        drop(rx_guard);
+        let mut rx = rx;
+        while tokio::time::Instant::now() < deadline {
+            let remaining = (deadline - tokio::time::Instant::now()).as_millis() as u64;
+            match tokio::time::timeout(Duration::from_millis(remaining.max(1)), rx.recv()).await {
+                Ok(Some(MeshFrame::DiscoveryReply { endpoint, .. })) => {
+                    if endpoint.agent_id != self.config.agent_id {
+                        let mut peers = self.peers.write().await;
+                        upsert_endpoint(&mut peers, &endpoint, self.config.presence_ttl);
+                    }
+                }
+                Ok(Some(_)) => { /* non-reply frame; ignore during discovery */ }
+                Ok(None) => break,
+                Err(_) => break,
+            }
+        }
+        // Return the inbox so future recv() calls keep working.
+        *self.inbox_rx.write().await = Some(rx);
+        Ok(self.endpoints_locked().await)
+    }
+
+    async fn endpoints_locked(&self) -> Vec<AgentEndpoint> {
+        let peers = self.peers.read().await;
+        let now = SystemTime::now();
+        peers
+            .values()
+            .filter(|p| p.agent_id != self.config.agent_id && !p.is_stale(now))
+            .map(|p| AgentEndpoint {
+                agent_id: p.agent_id.clone(),
+                endpoint_uri: p.endpoint_uri.clone(),
+                transport_kind: TransportKind::Nats,
+                last_seen: p.last_seen,
+                metadata: Some(serde_json::json!({ "role": p.role, "skills": p.skills })),
+            })
+            .collect()
+    }
+
+    /// Send a direct (point-to-point) message to a specific agent id.
+    pub async fn send(&self, to_agent: &str, message: &ChatMessage) -> ChatResult<()> {
+        let client = self.client().await?;
+        let frame = MeshFrame::Direct(message.clone());
+        let payload = serde_json::to_vec(&frame)?;
+        client
+            .publish(node_subject(to_agent), payload.into())
+            .await
+            .map_err(|e| ChatError::Nats(e.to_string()))?;
+        self.record_usage(&self.config.project, "nats.send", 1).await?;
+        Ok(())
+    }
+
+    /// Broadcast a message to every subscriber of `channel`.
+    pub async fn publish(&self, channel: &str, message: &ChatMessage) -> ChatResult<()> {
+        let client = self.client().await?;
+        let frame = MeshFrame::Broadcast {
+            channel: channel.to_string(),
+            message: message.clone(),
+        };
+        let payload = serde_json::to_vec(&frame)?;
+        client
+            .publish(channel_subject(channel), payload.into())
+            .await
+            .map_err(|e| ChatError::Nats(e.to_string()))?;
+        self.record_usage(&self.config.project, "nats.broadcast", 1).await?;
+        Ok(())
+    }
+
+    /// Receive the next inbound mesh frame (direct, broadcast, discovery, or
+    /// presence). Returns `None` if the node has been closed.
+    pub async fn recv(&self) -> ChatResult<Option<MeshFrame>> {
+        let mut rx_guard = self.inbox_rx.write().await;
+        let mut rx = match rx_guard.take() {
+            Some(rx) => rx,
+            None => return Ok(None),
+        };
+        drop(rx_guard);
+        let frame = rx.recv().await;
+        *self.inbox_rx.write().await = Some(rx);
+        Ok(frame)
+    }
+
+    /// Number of currently-known live peers (excluding self).
+    pub async fn peer_count(&self) -> usize {
+        let peers = self.peers.read().await;
+        let now = SystemTime::now();
+        peers
+            .values()
+            .filter(|p| p.agent_id != self.config.agent_id && !p.is_stale(now))
+            .count()
+    }
+
+    /// Gracefully close: abort forwarding + presence tasks, drop client.
+    pub async fn close(&self) -> ChatResult<()> {
+        if let Some(task) = self.presence_task.write().await.take() {
+            task.abort();
+        }
+        for handle in self.forwards.write().await.drain(..) {
+            handle.abort();
+        }
+        *self.client.write().await = None;
+        info!("NATS mesh node closed: {}", self.config.agent_id);
+        Ok(())
+    }
+}
+
+async fn upsert_presence(peers: &Arc<RwLock<HashMap<String, AgentPresence>>>, p: AgentPresence) {
+    let mut g = peers.write().await;
+    upsert_endpoint(&mut g, &endpoint_of(&p), p.ttl);
+    g.insert(p.agent_id.clone(), p);
+}
+
+fn endpoint_of(p: &AgentPresence) -> AgentEndpoint {
+    AgentEndpoint {
+        agent_id: p.agent_id.clone(),
+        endpoint_uri: p.endpoint_uri.clone(),
+        transport_kind: TransportKind::Nats,
+        last_seen: p.last_seen,
+        metadata: None,
+    }
+}
+
+fn upsert_endpoint(
+    peers: &mut RwLockWriteGuard<'_, HashMap<String, AgentPresence>>,
+    endpoint: &AgentEndpoint,
+    ttl: Duration,
+) {
+    let role = endpoint
+        .metadata
+        .as_ref()
+        .and_then(|m| m.get("role"))
+        .and_then(|v| v.as_str())
+        .unwrap_or("unknown")
+        .to_string();
+    let skills = endpoint
+        .metadata
+        .as_ref()
+        .and_then(|m| m.get("skills"))
+        .and_then(|v| v.as_array())
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|v| v.as_str().map(str::to_string))
+                .collect()
+        })
+        .unwrap_or_default();
+    peers.insert(
+        endpoint.agent_id.clone(),
+        AgentPresence {
+            agent_id: endpoint.agent_id.clone(),
+            role,
+            skills,
+            endpoint_uri: endpoint.endpoint_uri.clone(),
+            last_seen: endpoint.last_seen,
+            ttl,
+        },
+    );
+}
+
+#[async_trait]
+impl DiscoverableTransport for NatsMeshNode {
+    async fn discover_agents(&self) -> ChatResult<Vec<AgentEndpoint>> {
+        self.discover().await
+    }
+
+    async fn watch_agents(&self) -> ChatResult<AgentWatcher> {
+        // Bridge presence/discovery-reply frames into an event stream.
+        let (tx, rx) = mpsc::channel(64);
+        let peers = self.peers.clone();
+        let self_id = self.config.agent_id.clone();
+        let ttl = self.config.presence_ttl;
+        tokio::spawn(async move {
+            loop {
+                // Emit Discovered for all currently-known live peers.
+                {
+                    let peers = peers.read().await;
+                    let now = SystemTime::now();
+                    for p in peers.values() {
+                        if p.agent_id != self_id && !p.is_stale(now) {
+                            let _ = tx
+                                .send(AgentEvent::Discovered(AgentEndpoint {
+                                    agent_id: p.agent_id.clone(),
+                                    endpoint_uri: p.endpoint_uri.clone(),
+                                    transport_kind: TransportKind::Nats,
+                                    last_seen: p.last_seen,
+                                    metadata: Some(serde_json::json!({
+                                        "role": p.role,
+                                        "skills": p.skills
+                                    })),
+                                }))
+                                .await;
+                        }
+                    }
+                }
+                tokio::time::sleep(ttl / 2).await;
+            }
+        });
+        let stream = ReceiverStream::new(rx);
+        Ok(AgentWatcher::new(stream))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn subjects_are_well_formed() {
+        assert_eq!(node_subject("alpha"), "b00t.mesh.node.alpha");
+        assert_eq!(channel_subject("mission.x"), "b00t.mesh.channel.mission.x");
+    }
+
+    #[test]
+    fn presence_expiry_tracks_ttl() {
+        let now = SystemTime::now();
+        let fresh = AgentPresence {
+            agent_id: "a".into(),
+            role: "r".into(),
+            skills: vec![],
+            endpoint_uri: "u".into(),
+            last_seen: now,
+            ttl: Duration::from_secs(30),
+        };
+        assert!(!fresh.is_stale(now));
+        let stale = AgentPresence {
+            agent_id: "a".into(),
+            role: "r".into(),
+            skills: vec![],
+            endpoint_uri: "u".into(),
+            last_seen: now - Duration::from_secs(60),
+            ttl: Duration::from_secs(30),
+        };
+        assert!(stale.is_stale(now));
+    }
+
+    #[test]
+    fn frame_round_trips_through_json() {
+        let msg = ChatMessage::new("chan", "sender", "hi");
+        let frame = MeshFrame::Direct(msg);
+        let bytes = serde_json::to_vec(&frame).unwrap();
+        let back: MeshFrame = serde_json::from_slice(&bytes).unwrap();
+        match back {
+            MeshFrame::Direct(m) => assert_eq!(m.body, "hi"),
+            _ => panic!("wrong frame variant"),
+        }
+    }
+
+    #[tokio::test]
+    async fn peer_table_excludes_self_and_stale() {
+        let node = NatsMeshNode::new(MeshNodeConfig::new("self", "nats://x"));
+        let mut peers = node.peers.write().await;
+        upsert_endpoint(
+            &mut peers,
+            &AgentEndpoint {
+                agent_id: "self".into(),
+                endpoint_uri: "u".into(),
+                transport_kind: TransportKind::Nats,
+                last_seen: SystemTime::now(),
+                metadata: None,
+            },
+            node.config.presence_ttl,
+        );
+        upsert_endpoint(
+            &mut peers,
+            &AgentEndpoint {
+                agent_id: "peer".into(),
+                endpoint_uri: "u".into(),
+                transport_kind: TransportKind::Nats,
+                last_seen: SystemTime::now(),
+                metadata: Some(serde_json::json!({"role": "r", "skills": ["nats"]})),
+            },
+            node.config.presence_ttl,
+        );
+        upsert_endpoint(
+            &mut peers,
+            &AgentEndpoint {
+                agent_id: "ghost".into(),
+                endpoint_uri: "u".into(),
+                transport_kind: TransportKind::Nats,
+                last_seen: SystemTime::now() - Duration::from_secs(120),
+                metadata: None,
+            },
+            node.config.presence_ttl,
+        );
+        drop(peers);
+        assert_eq!(node.peer_count().await, 1);
+    }
+}

--- a/b00t-lib-chat/src/mesh.rs
+++ b/b00t-lib-chat/src/mesh.rs
@@ -1,14 +1,21 @@
 //! NATS intra-agent mesh for b00t hive coordination.
 //!
 //! Realizes the `--agent=b00t-comms --skill=nats` capability: every b00t agent
-//! process is a first-class node in a subject-routed mesh over NATS. The mesh
-//! provides four primitives:
+//! process is a first-class node in a subject-routed mesh over NATS.
 //!
-//! 1. **Presence** — nodes announce heartbeats on `b00t.mesh.discovery.presence`
-//!    so peers learn each other without a central registry (Redis-free
-//!    discovery, works offline once a NATS server is reachable).
-//! 2. **Discovery** — `discover()` publishes a query to `b00t.mesh.discovery.query`
-//!    with a NATS reply inbox; live nodes answer with their [`AgentEndpoint`].
+//! Four primitives, plus gossip discovery:
+//!
+//! 1. **Presence / gossip** — nodes advertise their presence by *gossiping* it
+//!    on `b00t.mesh.gossip`. Every receiver re-gossips newer advertisements
+//!    with a decremented hop budget (epidemic propagation), so the whole mesh
+//!    learns each node without a central registry or a single query. A plain
+//!    `b00t.mesh.discovery.presence` heartbeat is also emitted for backward
+//!    compatibility. This is the discovery-advertising mechanism the operator
+//!    asked for; the same `GossipTable` drives a future P2P transport (Iroh)
+//!    where no broker fans out for you. See
+//!    `_b00t_/NATS-MESH-GOSSIP-DISCOVERY.tomllmd`.
+//! 2. **Discovery** — `discover()` additionally publishes a request/reply query
+//!    to `b00t.mesh.discovery.query` for instant answers from live nodes.
 //! 3. **Direct send** — point-to-point frames to `b00t.mesh.node.{agent_id}`.
 //! 4. **Broadcast** — pub/sub frames to `b00t.mesh.channel.{channel}`.
 //!
@@ -19,6 +26,7 @@
 //! `b00t agent discover` plumbing.
 
 use crate::error::{ChatError, ChatResult};
+use crate::gossip::GossipTable;
 use crate::ipc_transport::{
     AgentEndpoint, AgentEvent, AgentWatcher, DiscoverableTransport, TransportKind,
 };
@@ -28,10 +36,9 @@ use async_nats::Subscriber;
 use async_trait::async_trait;
 use futures::StreamExt;
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::{Duration, SystemTime};
-use tokio::sync::{mpsc, RwLock, RwLockWriteGuard};
+use tokio::sync::{mpsc, RwLock};
 use tokio_stream::wrappers::ReceiverStream;
 use tracing::{info, warn};
 
@@ -41,8 +48,10 @@ const NODE_PREFIX: &str = "b00t.mesh.node.";
 const CHANNEL_PREFIX: &str = "b00t.mesh.channel.";
 /// Subject all nodes listen on to answer discovery queries.
 const DISCOVERY_QUERY: &str = "b00t.mesh.discovery.query";
-/// Subject all nodes publish presence heartbeats to.
+/// Subject all nodes publish presence heartbeats to (backward compat).
 const DISCOVERY_PRESENCE: &str = "b00t.mesh.discovery.presence";
+/// Subject all nodes gossip presence advertisements on (epidemic discovery).
+const DISCOVERY_GOSSIP: &str = "b00t.mesh.gossip";
 
 /// Default time a node waits for discovery replies before returning.
 pub const DEFAULT_DISCOVER_TIMEOUT: Duration = Duration::from_millis(1500);
@@ -50,6 +59,8 @@ pub const DEFAULT_DISCOVER_TIMEOUT: Duration = Duration::from_millis(1500);
 pub const DEFAULT_PRESENCE_INTERVAL: Duration = Duration::from_secs(10);
 /// Default time-to-live for a presence record before it is considered stale.
 pub const DEFAULT_PRESENCE_TTL: Duration = Duration::from_secs(30);
+/// Default gossip hop budget (how many re-gossip hops an advertisement lives).
+pub const DEFAULT_GOSSIP_MAX_HOPS: u8 = 5;
 
 /// Direct inbox subject for a given agent id.
 pub fn node_subject(agent_id: &str) -> String {
@@ -88,6 +99,13 @@ pub enum MeshFrame {
     },
     /// Periodic heartbeat announcing a node is alive.
     Presence(AgentPresence),
+    /// Epidemic gossip advertisement: a presence plus the advertiser-assigned
+    /// sequence and the remaining hop budget. Receivers re-gossip newer ads.
+    Gossip {
+        presence: AgentPresence,
+        seq: u64,
+        hops: u8,
+    },
 }
 
 /// Live presence record for a mesh node.
@@ -121,6 +139,8 @@ pub struct MeshNodeConfig {
     pub discover_timeout: Duration,
     pub presence_interval: Duration,
     pub presence_ttl: Duration,
+    /// Gossip hop budget for discovery advertisements.
+    pub gossip_max_hops: u8,
     /// Project attributed to this node's finops receipts (collaborative-autonomy).
     pub project: String,
     /// Optional ledgrrr ledger; when set, every capability execution registers
@@ -138,6 +158,7 @@ impl MeshNodeConfig {
             discover_timeout: DEFAULT_DISCOVER_TIMEOUT,
             presence_interval: DEFAULT_PRESENCE_INTERVAL,
             presence_ttl: DEFAULT_PRESENCE_TTL,
+            gossip_max_hops: DEFAULT_GOSSIP_MAX_HOPS,
             project: "b00t-comms".to_string(),
             ledgrrr: None,
         }
@@ -158,6 +179,11 @@ impl MeshNodeConfig {
         self
     }
 
+    pub fn with_gossip_max_hops(mut self, hops: u8) -> Self {
+        self.gossip_max_hops = hops;
+        self
+    }
+
     pub fn with_ledgrrr(mut self, ledgrrr: Arc<dyn Ledgrrr>) -> Self {
         self.ledgrrr = Some(ledgrrr);
         self
@@ -171,6 +197,7 @@ impl std::fmt::Debug for MeshNodeConfig {
             .field("role", &self.role)
             .field("project", &self.project)
             .field("nats_url", &self.nats_url)
+            .field("gossip_max_hops", &self.gossip_max_hops)
             .field("ledgrrr", &self.ledgrrr.is_some())
             .finish()
     }
@@ -178,15 +205,16 @@ impl std::fmt::Debug for MeshNodeConfig {
 
 /// A node in the b00t NATS intra-agent mesh.
 ///
-/// Connect, join channels, announce presence, then `recv()` frames. Discovery
-/// is request/reply over NATS; presence heartbeats keep the peer table fresh
-/// so `discover()` returns instantly for already-known nodes.
+/// Connect, join channels, announce (gossip) presence, then `recv()` frames.
+/// Discovery is request/reply over NATS; gossip heartbeats keep the peer table
+/// fresh so `discover()` returns instantly for already-known nodes, and even
+/// nodes that never send a query learn the mesh via epidemic propagation.
 #[derive(Clone)]
 pub struct NatsMeshNode {
     config: MeshNodeConfig,
     client: Arc<RwLock<Option<async_nats::Client>>>,
-    /// Known peers keyed by agent id (presence + discovery replies).
-    peers: Arc<RwLock<HashMap<String, AgentPresence>>>,
+    /// Known peers + gossip membership (presence + sequence + hop budget).
+    peers: Arc<RwLock<GossipTable>>,
     /// Application-facing inbound frames.
     inbox_tx: mpsc::Sender<MeshFrame>,
     inbox_rx: Arc<RwLock<Option<mpsc::Receiver<MeshFrame>>>>,
@@ -212,7 +240,7 @@ impl NatsMeshNode {
         Self {
             config,
             client: Arc::new(RwLock::new(None)),
-            peers: Arc::new(RwLock::new(HashMap::new())),
+            peers: Arc::new(RwLock::new(GossipTable::new(DEFAULT_GOSSIP_MAX_HOPS))),
             inbox_tx,
             inbox_rx: Arc::new(RwLock::new(Some(inbox_rx))),
             forwards: Arc::new(RwLock::new(Vec::new())),
@@ -249,12 +277,7 @@ impl NatsMeshNode {
         let client = async_nats::ConnectOptions::new()
             .connect(&self.config.nats_url)
             .await
-            .map_err(|e| {
-                ChatError::Other(format!(
-                    "NATS mesh connect failed ({}): {}",
-                    self.config.nats_url, e
-                ))
-            })?;
+            .map_err(|e| ChatError::Nats(e.to_string()))?;
         *guard = Some(client);
         drop(guard);
 
@@ -271,28 +294,30 @@ impl NatsMeshNode {
             .ok_or(ChatError::NotConnected)
     }
 
-    /// Subscribe to the inbox, presence, discovery-query, and any joined
-    /// channels; forward every frame into the application inbox.
+    /// Subscribe to the inbox, presence, gossip, discovery-query, and any
+    /// joined channels; forward every frame into the application inbox.
     async fn spawn_inbound(&self) -> ChatResult<()> {
         let client = self.client().await?;
-
         let mut handles = self.forwards.write().await;
 
-        // Own inbox (direct messages + discovery reply target).
         let inbox_sub = client
             .subscribe(node_subject(&self.config.agent_id))
             .await
             .map_err(|e| ChatError::Nats(e.to_string()))?;
         handles.push(self.forward(client.clone(), inbox_sub));
 
-        // Presence heartbeats.
         let presence_sub = client
             .subscribe(DISCOVERY_PRESENCE)
             .await
             .map_err(|e| ChatError::Nats(e.to_string()))?;
         handles.push(self.forward(client.clone(), presence_sub));
 
-        // Discovery queries.
+        let gossip_sub = client
+            .subscribe(DISCOVERY_GOSSIP)
+            .await
+            .map_err(|e| ChatError::Nats(e.to_string()))?;
+        handles.push(self.forward(client.clone(), gossip_sub));
+
         let query_sub = client
             .subscribe(DISCOVERY_QUERY)
             .await
@@ -323,41 +348,65 @@ impl NatsMeshNode {
                         continue;
                     }
                 };
-                // Auto-learn peers from presence / discovery traffic.
                 match &frame {
                     MeshFrame::Presence(p) => {
-                        upsert_presence(&peers, p.clone()).await;
+                        let mut g = peers.write().await;
+                        let seq = g.next_seq(&p.agent_id);
+                        g.ingest(p.clone(), seq, 0);
+                    }
+                    MeshFrame::Gossip { presence, seq, hops } => {
+                        // Accept if newer; re-gossip with decremented budget.
+                        let forward = {
+                            let mut g = peers.write().await;
+                            g.ingest(presence.clone(), *seq, *hops)
+                        };
+                        if let Some(remaining) = forward {
+                            let re = MeshFrame::Gossip {
+                                presence: presence.clone(),
+                                seq: *seq,
+                                hops: remaining,
+                            };
+                            if let Ok(payload) = serde_json::to_vec(&re) {
+                                let _ = client.publish(DISCOVERY_GOSSIP, payload.into()).await;
+                            }
+                        }
                     }
                     MeshFrame::DiscoveryReply { endpoint, role, skills } => {
                         if endpoint.agent_id != agent_id {
-                            upsert_presence(
-                                &peers,
+                            let mut g = peers.write().await;
+                            let seq = g.next_seq(&endpoint.agent_id);
+                            g.ingest(
                                 AgentPresence {
                                     agent_id: endpoint.agent_id.clone(),
                                     role: role.clone(),
                                     skills: skills.clone(),
                                     endpoint_uri: endpoint.endpoint_uri.clone(),
-                                    last_seen: SystemTime::now(),
+                                    last_seen: endpoint.last_seen,
                                     ttl,
                                 },
-                            )
-                            .await;
+                                seq,
+                                0,
+                            );
                         }
                     }
                     MeshFrame::DiscoveryQuery { from, role, skills } => {
                         if from != &agent_id {
-                            upsert_presence(
-                                &peers,
-                                AgentPresence {
-                                    agent_id: from.clone(),
-                                    role: role.clone(),
-                                    skills: skills.clone(),
-                                    endpoint_uri: node_subject(from),
-                                    last_seen: SystemTime::now(),
-                                    ttl,
-                                },
-                            )
-                            .await;
+                            {
+                                let mut g = peers.write().await;
+                                let seq = g.next_seq(from);
+                                g.ingest(
+                                    AgentPresence {
+                                        agent_id: from.clone(),
+                                        role: role.clone(),
+                                        skills: skills.clone(),
+                                        endpoint_uri: node_subject(from),
+                                        last_seen: SystemTime::now(),
+                                        ttl,
+                                    },
+                                    seq,
+                                    0,
+                                );
+                            }
                             // Answer the query on its NATS reply inbox.
                             if let Some(reply) = &msg.reply {
                                 let reply_frame = MeshFrame::DiscoveryReply {
@@ -371,12 +420,8 @@ impl NatsMeshNode {
                                     role: this_role.clone(),
                                     skills: this_skills.clone(),
                                 };
-                                let payload = match serde_json::to_vec(&reply_frame) {
-                                    Ok(p) => p,
-                                    Err(_) => continue,
-                                };
-                                if let Err(e) = client.publish(reply.clone(), payload.into()).await {
-                                    warn!("mesh: discovery reply failed: {}", e);
+                                if let Ok(payload) = serde_json::to_vec(&reply_frame) {
+                                    let _ = client.publish(reply.clone(), payload.into()).await;
                                 }
                             }
                         }
@@ -401,7 +446,8 @@ impl NatsMeshNode {
         Ok(())
     }
 
-    /// Announce presence to the mesh (also answers future discovery queries).
+    /// Announce presence: gossip an advertisement (bounded hop budget) and emit
+    /// a plain presence heartbeat for backward compatibility.
     pub async fn announce(&self) -> ChatResult<()> {
         let client = self.client().await?;
         let presence = AgentPresence {
@@ -412,20 +458,35 @@ impl NatsMeshNode {
             last_seen: SystemTime::now(),
             ttl: self.config.presence_ttl,
         };
-        let frame = MeshFrame::Presence(presence.clone());
-        let payload = serde_json::to_vec(&frame)?;
+        let seq = {
+            let mut g = self.peers.write().await;
+            let s = g.next_seq(&self.config.agent_id);
+            g.insert_local(presence.clone(), s);
+            s
+        };
+        let gossip = MeshFrame::Gossip {
+            presence: presence.clone(),
+            seq,
+            hops: self.config.gossip_max_hops,
+        };
         client
-            .publish(DISCOVERY_PRESENCE, payload.into())
+            .publish(DISCOVERY_GOSSIP, serde_json::to_vec(&gossip)?.into())
             .await
             .map_err(|e| ChatError::Nats(e.to_string()))?;
-        upsert_presence(&self.peers, presence).await;
+        client
+            .publish(
+                DISCOVERY_PRESENCE,
+                serde_json::to_vec(&MeshFrame::Presence(presence))?.into(),
+            )
+            .await
+            .map_err(|e| ChatError::Nats(e.to_string()))?;
         self.record_usage(&self.config.project, "nats.presence", 1)
             .await
             .ok();
         Ok(())
     }
 
-    /// Start a background heartbeat that announces presence every interval.
+    /// Start a background heartbeat that gossips presence every interval.
     pub async fn start_presence(&self) {
         let node = self.clone();
         let interval = self.config.presence_interval;
@@ -441,8 +502,8 @@ impl NatsMeshNode {
     }
 
     /// Discover peers: publish a query with the local inbox as reply target,
-    /// then collect replies for the configured timeout. Already-known peers
-    /// are included.
+    /// then collect replies for the configured timeout. Gossip advertisements
+    /// received meanwhile also populate the peer table.
     pub async fn discover(&self) -> ChatResult<Vec<AgentEndpoint>> {
         self.discover_with_timeout(self.config.discover_timeout).await
     }
@@ -456,32 +517,47 @@ impl NatsMeshNode {
             skills: self.config.skills.clone(),
         };
         let payload = serde_json::to_vec(&query)?;
-        // NATS reply inbox = our own inbox subject.
         let reply = node_subject(&self.config.agent_id);
         client
             .publish_with_reply(DISCOVERY_QUERY, reply, payload.into())
             .await
             .map_err(|e| ChatError::Nats(e.to_string()))?;
-        // Also announce so peers learn us even if they miss the reply window.
+        // Also announce so peers learn us (and gossip propagates).
         self.announce().await.ok();
-        self.record_usage(&self.config.project, "nats.discover", 1).await.ok();
+        self.record_usage(&self.config.project, "nats.discover", 1)
+            .await
+            .ok();
 
-        // Collect inbound DiscoveryReply frames for `timeout`.
         let deadline = tokio::time::Instant::now() + timeout;
         let mut rx_guard = self.inbox_rx.write().await;
-        let rx = match rx_guard.take() {
+        let mut rx = match rx_guard.take() {
             Some(rx) => rx,
             None => return Ok(self.endpoints_locked().await),
         };
         drop(rx_guard);
-        let mut rx = rx;
         while tokio::time::Instant::now() < deadline {
             let remaining = (deadline - tokio::time::Instant::now()).as_millis() as u64;
             match tokio::time::timeout(Duration::from_millis(remaining.max(1)), rx.recv()).await {
-                Ok(Some(MeshFrame::DiscoveryReply { endpoint, .. })) => {
+                Ok(Some(MeshFrame::DiscoveryReply {
+                    endpoint,
+                    role,
+                    skills,
+                })) => {
                     if endpoint.agent_id != self.config.agent_id {
-                        let mut peers = self.peers.write().await;
-                        upsert_endpoint(&mut peers, &endpoint, self.config.presence_ttl);
+                        let mut g = self.peers.write().await;
+                        let seq = g.next_seq(&endpoint.agent_id);
+                        g.ingest(
+                            AgentPresence {
+                                agent_id: endpoint.agent_id.clone(),
+                                role,
+                                skills,
+                                endpoint_uri: endpoint.endpoint_uri.clone(),
+                                last_seen: endpoint.last_seen,
+                                ttl: self.config.presence_ttl,
+                            },
+                            seq,
+                            0,
+                        );
                     }
                 }
                 Ok(Some(_)) => { /* non-reply frame; ignore during discovery */ }
@@ -489,25 +565,15 @@ impl NatsMeshNode {
                 Err(_) => break,
             }
         }
-        // Return the inbox so future recv() calls keep working.
         *self.inbox_rx.write().await = Some(rx);
         Ok(self.endpoints_locked().await)
     }
 
     async fn endpoints_locked(&self) -> Vec<AgentEndpoint> {
-        let peers = self.peers.read().await;
-        let now = SystemTime::now();
-        peers
-            .values()
-            .filter(|p| p.agent_id != self.config.agent_id && !p.is_stale(now))
-            .map(|p| AgentEndpoint {
-                agent_id: p.agent_id.clone(),
-                endpoint_uri: p.endpoint_uri.clone(),
-                transport_kind: TransportKind::Nats,
-                last_seen: p.last_seen,
-                metadata: Some(serde_json::json!({ "role": p.role, "skills": p.skills })),
-            })
-            .collect()
+        self.peers
+            .read()
+            .await
+            .live_endpoints(&self.config.agent_id, self.config.presence_ttl)
     }
 
     /// Send a direct (point-to-point) message to a specific agent id.
@@ -535,12 +601,13 @@ impl NatsMeshNode {
             .publish(channel_subject(channel), payload.into())
             .await
             .map_err(|e| ChatError::Nats(e.to_string()))?;
-        self.record_usage(&self.config.project, "nats.broadcast", 1).await?;
+        self.record_usage(&self.config.project, "nats.broadcast", 1)
+            .await?;
         Ok(())
     }
 
-    /// Receive the next inbound mesh frame (direct, broadcast, discovery, or
-    /// presence). Returns `None` if the node has been closed.
+    /// Receive the next inbound mesh frame (direct, broadcast, discovery,
+    /// presence, or gossip). Returns `None` if the node has been closed.
     pub async fn recv(&self) -> ChatResult<Option<MeshFrame>> {
         let mut rx_guard = self.inbox_rx.write().await;
         let mut rx = match rx_guard.take() {
@@ -555,12 +622,10 @@ impl NatsMeshNode {
 
     /// Number of currently-known live peers (excluding self).
     pub async fn peer_count(&self) -> usize {
-        let peers = self.peers.read().await;
-        let now = SystemTime::now();
-        peers
-            .values()
-            .filter(|p| p.agent_id != self.config.agent_id && !p.is_stale(now))
-            .count()
+        self.peers
+            .read()
+            .await
+            .peer_count(&self.config.agent_id, self.config.presence_ttl)
     }
 
     /// Gracefully close: abort forwarding + presence tasks, drop client.
@@ -577,58 +642,6 @@ impl NatsMeshNode {
     }
 }
 
-async fn upsert_presence(peers: &Arc<RwLock<HashMap<String, AgentPresence>>>, p: AgentPresence) {
-    let mut g = peers.write().await;
-    upsert_endpoint(&mut g, &endpoint_of(&p), p.ttl);
-    g.insert(p.agent_id.clone(), p);
-}
-
-fn endpoint_of(p: &AgentPresence) -> AgentEndpoint {
-    AgentEndpoint {
-        agent_id: p.agent_id.clone(),
-        endpoint_uri: p.endpoint_uri.clone(),
-        transport_kind: TransportKind::Nats,
-        last_seen: p.last_seen,
-        metadata: None,
-    }
-}
-
-fn upsert_endpoint(
-    peers: &mut RwLockWriteGuard<'_, HashMap<String, AgentPresence>>,
-    endpoint: &AgentEndpoint,
-    ttl: Duration,
-) {
-    let role = endpoint
-        .metadata
-        .as_ref()
-        .and_then(|m| m.get("role"))
-        .and_then(|v| v.as_str())
-        .unwrap_or("unknown")
-        .to_string();
-    let skills = endpoint
-        .metadata
-        .as_ref()
-        .and_then(|m| m.get("skills"))
-        .and_then(|v| v.as_array())
-        .map(|arr| {
-            arr.iter()
-                .filter_map(|v| v.as_str().map(str::to_string))
-                .collect()
-        })
-        .unwrap_or_default();
-    peers.insert(
-        endpoint.agent_id.clone(),
-        AgentPresence {
-            agent_id: endpoint.agent_id.clone(),
-            role,
-            skills,
-            endpoint_uri: endpoint.endpoint_uri.clone(),
-            last_seen: endpoint.last_seen,
-            ttl,
-        },
-    );
-}
-
 #[async_trait]
 impl DiscoverableTransport for NatsMeshNode {
     async fn discover_agents(&self) -> ChatResult<Vec<AgentEndpoint>> {
@@ -636,32 +649,16 @@ impl DiscoverableTransport for NatsMeshNode {
     }
 
     async fn watch_agents(&self) -> ChatResult<AgentWatcher> {
-        // Bridge presence/discovery-reply frames into an event stream.
         let (tx, rx) = mpsc::channel(64);
         let peers = self.peers.clone();
         let self_id = self.config.agent_id.clone();
         let ttl = self.config.presence_ttl;
         tokio::spawn(async move {
             loop {
-                // Emit Discovered for all currently-known live peers.
                 {
-                    let peers = peers.read().await;
-                    let now = SystemTime::now();
-                    for p in peers.values() {
-                        if p.agent_id != self_id && !p.is_stale(now) {
-                            let _ = tx
-                                .send(AgentEvent::Discovered(AgentEndpoint {
-                                    agent_id: p.agent_id.clone(),
-                                    endpoint_uri: p.endpoint_uri.clone(),
-                                    transport_kind: TransportKind::Nats,
-                                    last_seen: p.last_seen,
-                                    metadata: Some(serde_json::json!({
-                                        "role": p.role,
-                                        "skills": p.skills
-                                    })),
-                                }))
-                                .await;
-                        }
+                    let eps = peers.read().await.live_endpoints(&self_id, ttl);
+                    for e in eps {
+                        let _ = tx.send(AgentEvent::Discovered(e)).await;
                     }
                 }
                 tokio::time::sleep(ttl / 2).await;
@@ -715,46 +712,62 @@ mod tests {
             MeshFrame::Direct(m) => assert_eq!(m.body, "hi"),
             _ => panic!("wrong frame variant"),
         }
+
+        let g = MeshFrame::Gossip {
+            presence: AgentPresence {
+                agent_id: "a".into(),
+                role: "r".into(),
+                skills: vec![],
+                endpoint_uri: "u".into(),
+                last_seen: SystemTime::now(),
+                ttl: Duration::from_secs(30),
+            },
+            seq: 3,
+            hops: 2,
+        };
+        let bytes = serde_json::to_vec(&g).unwrap();
+        assert!(serde_json::from_slice::<MeshFrame>(&bytes).is_ok());
     }
 
     #[tokio::test]
     async fn peer_table_excludes_self_and_stale() {
         let node = NatsMeshNode::new(MeshNodeConfig::new("self", "nats://x"));
-        let mut peers = node.peers.write().await;
-        upsert_endpoint(
-            &mut peers,
-            &AgentEndpoint {
-                agent_id: "self".into(),
-                endpoint_uri: "u".into(),
-                transport_kind: TransportKind::Nats,
-                last_seen: SystemTime::now(),
-                metadata: None,
-            },
-            node.config.presence_ttl,
-        );
-        upsert_endpoint(
-            &mut peers,
-            &AgentEndpoint {
-                agent_id: "peer".into(),
-                endpoint_uri: "u".into(),
-                transport_kind: TransportKind::Nats,
-                last_seen: SystemTime::now(),
-                metadata: Some(serde_json::json!({"role": "r", "skills": ["nats"]})),
-            },
-            node.config.presence_ttl,
-        );
-        upsert_endpoint(
-            &mut peers,
-            &AgentEndpoint {
-                agent_id: "ghost".into(),
-                endpoint_uri: "u".into(),
-                transport_kind: TransportKind::Nats,
-                last_seen: SystemTime::now() - Duration::from_secs(120),
-                metadata: None,
-            },
-            node.config.presence_ttl,
-        );
-        drop(peers);
+        {
+            let mut g = node.peers.write().await;
+            g.insert_local(
+                AgentPresence {
+                    agent_id: "self".into(),
+                    role: "r".into(),
+                    skills: vec![],
+                    endpoint_uri: "u".into(),
+                    last_seen: SystemTime::now(),
+                    ttl: node.config.presence_ttl,
+                },
+                1,
+            );
+            g.insert_local(
+                AgentPresence {
+                    agent_id: "peer".into(),
+                    role: "r".into(),
+                    skills: vec!["nats".to_string()],
+                    endpoint_uri: "u".into(),
+                    last_seen: SystemTime::now(),
+                    ttl: node.config.presence_ttl,
+                },
+                1,
+            );
+            g.insert_local(
+                AgentPresence {
+                    agent_id: "ghost".into(),
+                    role: "r".into(),
+                    skills: vec![],
+                    endpoint_uri: "u".into(),
+                    last_seen: SystemTime::now() - Duration::from_secs(120),
+                    ttl: node.config.presence_ttl,
+                },
+                1,
+            );
+        }
         assert_eq!(node.peer_count().await, 1);
     }
 }

--- a/b00t-lib-chat/src/mesh.rs
+++ b/b00t-lib-chat/src/mesh.rs
@@ -1,23 +1,25 @@
-//! NATS intra-agent mesh for b00t hive coordination.
+//! NATS intra-hive mesh for b00t hive coordination.
 //!
 //! Realizes the `--agent=b00t-comms --skill=nats` capability: every b00t agent
-//! process is a first-class node in a subject-routed mesh over NATS.
+//! process is a first-class node in a subject-routed hive over NATS. All
+//! communication is **intra-hive** — the same logical network; there is no
+//! cross-network / NAT-traversal path.
 //!
 //! Four primitives, plus gossip discovery:
 //!
 //! 1. **Presence / gossip** — nodes advertise their presence by *gossiping* it
-//!    on `b00t.mesh.gossip`. Every receiver re-gossips newer advertisements
-//!    with a decremented hop budget (epidemic propagation), so the whole mesh
+//!    on `b00t.hive.mesh.gossip`. Every receiver re-gossips newer advertisements
+//!    with a decremented hop budget (epidemic propagation), so the whole hive
 //!    learns each node without a central registry or a single query. A plain
-//!    `b00t.mesh.discovery.presence` heartbeat is also emitted for backward
+//!    `b00t.hive.mesh.discovery.presence` heartbeat is also emitted for backward
 //!    compatibility. This is the discovery-advertising mechanism the operator
-//!    asked for; the same `GossipTable` drives a future P2P transport (Iroh)
-//!    where no broker fans out for you. See
+//!    asked for; the same `GossipTable` drives a future broker-free transport
+//!    (Iroh/gwyh) that still runs intra-hive on the same network. See
 //!    `_b00t_/NATS-MESH-GOSSIP-DISCOVERY.tomllmd`.
 //! 2. **Discovery** — `discover()` additionally publishes a request/reply query
-//!    to `b00t.mesh.discovery.query` for instant answers from live nodes.
-//! 3. **Direct send** — point-to-point frames to `b00t.mesh.node.{agent_id}`.
-//! 4. **Broadcast** — pub/sub frames to `b00t.mesh.channel.{channel}`.
+//!    to `b00t.hive.mesh.discovery.query` for instant answers from live nodes.
+//! 3. **Direct send** — point-to-point frames to `b00t.hive.mesh.node.{agent_id}`.
+//! 4. **Broadcast** — pub/sub frames to `b00t.hive.mesh.channel.{channel}`.
 //!
 //! The channel-based [`crate::transports::NatsTransport`] cannot express
 //! per-agent inboxes or NATS reply-to semantics, so the mesh speaks `async_nats`
@@ -32,6 +34,7 @@ use crate::ipc_transport::{
 };
 use crate::ledgrrr::{FinopsCode, Ledgrrr, UsageReceipt};
 use crate::message::ChatMessage;
+use ufo_types::{Stereotyped, UfoStereotype};
 use async_nats::Subscriber;
 use async_trait::async_trait;
 use futures::StreamExt;
@@ -42,16 +45,16 @@ use tokio::sync::{mpsc, RwLock};
 use tokio_stream::wrappers::ReceiverStream;
 use tracing::{info, warn};
 
-/// Subject prefix for a node's direct inbox.
-const NODE_PREFIX: &str = "b00t.mesh.node.";
+/// Subject prefix for a node's direct inbox (always intra-hive, same network).
+const NODE_PREFIX: &str = "b00t.hive.mesh.node.";
 /// Subject prefix for a pub/sub channel.
-const CHANNEL_PREFIX: &str = "b00t.mesh.channel.";
+const CHANNEL_PREFIX: &str = "b00t.hive.mesh.channel.";
 /// Subject all nodes listen on to answer discovery queries.
-const DISCOVERY_QUERY: &str = "b00t.mesh.discovery.query";
+const DISCOVERY_QUERY: &str = "b00t.hive.mesh.discovery.query";
 /// Subject all nodes publish presence heartbeats to (backward compat).
-const DISCOVERY_PRESENCE: &str = "b00t.mesh.discovery.presence";
+const DISCOVERY_PRESENCE: &str = "b00t.hive.mesh.discovery.presence";
 /// Subject all nodes gossip presence advertisements on (epidemic discovery).
-const DISCOVERY_GOSSIP: &str = "b00t.mesh.gossip";
+const DISCOVERY_GOSSIP: &str = "b00t.hive.mesh.gossip";
 
 /// Default time a node waits for discovery replies before returning.
 pub const DEFAULT_DISCOVER_TIMEOUT: Duration = Duration::from_millis(1500);
@@ -108,6 +111,14 @@ pub enum MeshFrame {
     },
 }
 
+impl Stereotyped for MeshFrame {
+    fn ufo_stereotype(&self) -> UfoStereotype {
+        // A frame relates a sender to a recipient (and carries a payload) —
+        // in UFO terms a Relator binding communication participants.
+        UfoStereotype::Relator("hive-mesh-frame".into())
+    }
+}
+
 /// Live presence record for a mesh node.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AgentPresence {
@@ -126,6 +137,13 @@ impl AgentPresence {
             Ok(age) => age > self.ttl,
             Err(_) => false,
         }
+    }
+}
+
+impl Stereotyped for AgentPresence {
+    fn ufo_stereotype(&self) -> UfoStereotype {
+        // A live snapshot of a hive agent's reachability — a domain Kind.
+        UfoStereotype::Kind("AgentPresence".into())
     }
 }
 
@@ -222,6 +240,13 @@ pub struct NatsMeshNode {
     forwards: Arc<RwLock<Vec<tokio::task::JoinHandle<()>>>>,
     presence_task: Arc<RwLock<Option<tokio::task::JoinHandle<()>>>>,
     ledgrrr: Option<Arc<dyn Ledgrrr>>,
+}
+
+impl Stereotyped for NatsMeshNode {
+    fn ufo_stereotype(&self) -> UfoStereotype {
+        // A hive node plays the intra-hive communication role.
+        UfoStereotype::Role("hive-node".into())
+    }
 }
 
 impl std::fmt::Debug for NatsMeshNode {
@@ -675,8 +700,30 @@ mod tests {
 
     #[test]
     fn subjects_are_well_formed() {
-        assert_eq!(node_subject("alpha"), "b00t.mesh.node.alpha");
-        assert_eq!(channel_subject("mission.x"), "b00t.mesh.channel.mission.x");
+        assert_eq!(node_subject("alpha"), "b00t.hive.mesh.node.alpha");
+        assert_eq!(channel_subject("mission.x"), "b00t.hive.mesh.channel.mission.x");
+    }
+
+    #[test]
+    fn hive_types_are_ufo_grounded() {
+        use ufo_types::Stereotyped;
+        let presence = AgentPresence {
+            agent_id: "a".into(),
+            role: "r".into(),
+            skills: vec![],
+            endpoint_uri: "b00t.hive.mesh.node.a".into(),
+            last_seen: SystemTime::now(),
+            ttl: Duration::from_secs(30),
+        };
+        assert_eq!(presence.ufo_stereotype().to_string(), "Kind:AgentPresence");
+        assert_eq!(
+            MeshFrame::Presence(presence.clone()).ufo_stereotype().to_string(),
+            "Relator:hive-mesh-frame"
+        );
+        let node = NatsMeshNode::new(
+            MeshNodeConfig::new("a", "nats://localhost:4222").with_project("p"),
+        );
+        assert_eq!(node.ufo_stereotype().to_string(), "Role:hive-node");
     }
 
     #[test]

--- a/b00t-lib-chat/src/transports/nats_transport.rs
+++ b/b00t-lib-chat/src/transports/nats_transport.rs
@@ -2,16 +2,22 @@
 //!
 //! Provides cloud-native, high-scale messaging via NATS.io for
 //! distributed b00t agents across different hosts/regions.
+//!
+//! All subscriptions are fused into a single inbound mpsc channel so `recv()`
+//! correctly performs fan-in across every subscribed channel (the previous
+//! implementation only polled the first subscriber). The active subscription
+//! list is tracked in a sync `RwLock` so `subscriptions()` returns real data
+//! instead of an empty vec.
 
 use crate::error::{ChatError, ChatResult};
 use crate::ipc_transport::{BroadcastTransport, IpcTransport, TransportKind};
 use crate::message::ChatMessage;
 use crate::metrics::{ChatMetrics, LatencyTimer};
-use async_nats::{Client, ConnectOptions, Subscriber};
+use async_nats::{Client, Subscriber};
 use async_trait::async_trait;
 use futures::StreamExt;
-use std::sync::Arc;
-use tokio::sync::RwLock;
+use std::sync::{Arc, RwLock as StdRwLock};
+use tokio::sync::{mpsc, Mutex as AsyncMutex, RwLock};
 use tracing::{debug, info};
 
 /// NATS transport for distributed agent messaging.
@@ -19,8 +25,13 @@ use tracing::{debug, info};
 pub struct NatsTransport {
     client: Arc<RwLock<Option<Client>>>,
     url: String,
-    subscriptions: Arc<RwLock<Vec<String>>>,
-    subscribers: Arc<RwLock<Vec<Subscriber>>>,
+    /// Channels currently subscribed (sync so `subscriptions()` can read it).
+    subscriptions: Arc<StdRwLock<Vec<String>>>,
+    /// Fused inbound messages from all subscriber tasks.
+    inbox_tx: mpsc::UnboundedSender<ChatMessage>,
+    inbox_rx: Arc<AsyncMutex<mpsc::UnboundedReceiver<ChatMessage>>>,
+    /// Per-channel forwarding tasks, aborted on unsubscribe/close.
+    forwards: Arc<RwLock<Vec<(String, tokio::task::JoinHandle<()>)>>>,
 }
 
 impl NatsTransport {
@@ -33,11 +44,14 @@ impl NatsTransport {
     /// let transport = NatsTransport::new("nats://localhost:4222");
     /// ```
     pub fn new(url: impl Into<String>) -> Self {
+        let (inbox_tx, inbox_rx) = mpsc::unbounded_channel();
         Self {
             client: Arc::new(RwLock::new(None)),
             url: url.into(),
-            subscriptions: Arc::new(RwLock::new(Vec::new())),
-            subscribers: Arc::new(RwLock::new(Vec::new())),
+            subscriptions: Arc::new(StdRwLock::new(Vec::new())),
+            inbox_tx,
+            inbox_rx: Arc::new(AsyncMutex::new(inbox_rx)),
+            forwards: Arc::new(RwLock::new(Vec::new())),
         }
     }
 
@@ -49,7 +63,7 @@ impl NatsTransport {
             return Ok(()); // Already connected
         }
 
-        let options = ConnectOptions::new();
+        let options = async_nats::ConnectOptions::new();
         let client = options.connect(&self.url).await.map_err(|e| {
             ChatMetrics::global().record_connection_error("nats", "connection_failed");
             ChatError::Other(format!("NATS connection failed: {}", e))
@@ -72,6 +86,26 @@ impl NatsTransport {
     /// Maps `channel.sender` to NATS subject hierarchy.
     fn message_to_subject(message: &ChatMessage) -> String {
         format!("b00t.agents.{}.{}", message.channel, message.sender)
+    }
+
+    /// Spawn a task that forwards every message from `subscriber` into the
+    /// fused inbound channel.
+    fn forward(&self, mut subscriber: Subscriber) {
+        let inbox_tx = self.inbox_tx.clone();
+        tokio::spawn(async move {
+            while let Some(msg) = subscriber.next().await {
+                let parsed: ChatMessage = match serde_json::from_slice(&msg.payload) {
+                    Ok(m) => m,
+                    Err(e) => {
+                        debug!("NATS: dropping undecodable message: {}", e);
+                        continue;
+                    }
+                };
+                if inbox_tx.send(parsed).is_err() {
+                    break; // transport dropped
+                }
+            }
+        });
     }
 }
 
@@ -102,25 +136,14 @@ impl IpcTransport for NatsTransport {
 
     async fn recv(&self) -> ChatResult<Option<ChatMessage>> {
         let timer = LatencyTimer::recv("nats");
-        let mut subscribers = self.subscribers.write().await;
-
-        if subscribers.is_empty() {
-            return Ok(None);
-        }
-
-        // Poll first subscriber for messages
-        if let Some(subscriber) = subscribers.first_mut() {
-            match subscriber.next().await {
-                Some(msg) => {
-                    let message: ChatMessage = serde_json::from_slice(&msg.payload)?;
-                    ChatMetrics::global().record_message_received("nats", &message.channel);
-                    timer.stop();
-                    Ok(Some(message))
-                }
-                None => Ok(None),
+        let mut inbox = self.inbox_rx.lock().await;
+        match inbox.recv().await {
+            Some(message) => {
+                ChatMetrics::global().record_message_received("nats", &message.channel);
+                timer.stop();
+                Ok(Some(message))
             }
-        } else {
-            Ok(None)
+            None => Ok(None),
         }
     }
 
@@ -128,8 +151,10 @@ impl IpcTransport for NatsTransport {
         let mut client_guard = self.client.write().await;
         *client_guard = None;
 
-        let mut subscribers = self.subscribers.write().await;
-        subscribers.clear();
+        for (_, handle) in self.forwards.write().await.drain(..) {
+            handle.abort();
+        }
+        self.subscriptions.write().unwrap().clear();
 
         ChatMetrics::global().record_connection_closed("nats");
         info!("Closed NATS connection");
@@ -160,8 +185,9 @@ impl BroadcastTransport for NatsTransport {
             .await
             .map_err(|e| ChatError::Other(format!("NATS subscribe failed: {}", e)))?;
 
-        self.subscriptions.write().await.push(channel.to_string());
-        self.subscribers.write().await.push(subscriber);
+        self.forward(subscriber);
+
+        self.subscriptions.write().unwrap().push(channel.to_string());
 
         ChatMetrics::global().record_transport_operation("nats", "subscribe");
         info!("Subscribed to NATS subject: {}", subject);
@@ -169,10 +195,14 @@ impl BroadcastTransport for NatsTransport {
     }
 
     async fn unsubscribe(&mut self, channel: &str) -> ChatResult<()> {
-        let mut subscriptions = self.subscriptions.write().await;
-        subscriptions.retain(|s| s != channel);
+        self.subscriptions.write().unwrap().retain(|s| s != channel);
 
-        // Note: async_nats subscribers automatically unsubscribe on drop
+        let mut forwards = self.forwards.write().await;
+        if let Some(idx) = forwards.iter().position(|(ch, _)| ch == channel) {
+            let (_, handle) = forwards.remove(idx);
+            handle.abort();
+        }
+
         debug!("Unsubscribed from NATS channel: {}", channel);
         Ok(())
     }
@@ -192,33 +222,6 @@ impl BroadcastTransport for NatsTransport {
     }
 
     fn subscriptions(&self) -> Vec<String> {
-        // Note: This is a synchronous method but subscriptions is behind RwLock
-        // We can't await here, so we return empty vec
-        // TODO: Consider making this async or using a different pattern
-        Vec::new()
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_nats_transport_creation() {
-        let transport = NatsTransport::new("nats://localhost:4222");
-        assert_eq!(transport.kind(), TransportKind::Nats);
-    }
-
-    #[test]
-    fn test_message_to_subject_conversion() {
-        let message = ChatMessage::new("mission.alpha", "frontend", "test");
-        let subject = NatsTransport::message_to_subject(&message);
-        assert_eq!(subject, "b00t.agents.mission.alpha.frontend");
-    }
-
-    #[tokio::test]
-    async fn test_transport_not_connected_initially() {
-        let transport = NatsTransport::new("nats://localhost:4222");
-        assert!(!transport.is_available().await);
+        self.subscriptions.read().unwrap().clone()
     }
 }

--- a/b00t-lib-chat/tests/nats_mesh_integration.rs
+++ b/b00t-lib-chat/tests/nats_mesh_integration.rs
@@ -1,0 +1,76 @@
+//! Live two-node mesh integration test.
+//!
+//! Skips unless `NATS_URL` is set to a reachable NATS server. Exercises the
+//! full `--agent=b00t-comms --skill=nats` path: presence, discovery, direct
+//! send, and finops receipt minting.
+
+use b00t_chat::ledgrrr::{LocalLedgrrr, Ledgrrr};
+use b00t_chat::mesh::{MeshFrame, MeshNodeConfig, NatsMeshNode};
+use b00t_chat::message::ChatMessage;
+use std::sync::Arc;
+use std::time::Duration;
+
+#[tokio::test]
+async fn two_node_mesh_discovers_and_exchanges() {
+    let url = match std::env::var("NATS_URL") {
+        Ok(u) => u,
+        Err(_) => {
+            eprintln!("skip: NATS_URL unset — set it to a reachable NATS server to run");
+            return;
+        }
+    };
+
+    let ledger: Arc<LocalLedgrrr> = Arc::new(LocalLedgrrr::memory());
+
+    let a = NatsMeshNode::new(
+        MeshNodeConfig::new("itest-a", &url)
+            .with_project("itest")
+            .with_ledgrrr(ledger.clone()),
+    );
+    let b = NatsMeshNode::new(
+        MeshNodeConfig::new("itest-b", &url)
+            .with_project("itest")
+            .with_ledgrrr(ledger.clone()),
+    );
+
+    a.connect().await.expect("a connect");
+    b.connect().await.expect("b connect");
+    a.start_presence().await;
+    b.start_presence().await;
+    // Let presence heartbeats land before querying.
+    tokio::time::sleep(Duration::from_millis(300)).await;
+
+    let peers = a.discover_with_timeout(Duration::from_secs(2)).await.unwrap();
+    assert!(
+        peers.iter().any(|p| p.agent_id == "itest-b"),
+        "a should discover b"
+    );
+
+    let msg = ChatMessage::new("itest", "itest-a", "hello mesh");
+    a.send("itest-b", &msg).await.unwrap();
+
+    // Drain b's inbox until the direct message arrives (presence frames may
+    // arrive first).
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(3);
+    let mut got_body = None;
+    while tokio::time::Instant::now() < deadline {
+        match tokio::time::timeout(Duration::from_millis(500), b.recv()).await {
+            Ok(Ok(Some(MeshFrame::Direct(m)))) => {
+                got_body = Some(m.body);
+                break;
+            }
+            Ok(Ok(Some(_))) => continue, // presence / discovery frame
+            Ok(Ok(None)) | Ok(Err(_)) | Err(_) => break,
+        }
+    }
+    assert_eq!(got_body.as_deref(), Some("hello mesh"));
+
+    // Every capability execution minted a finops code for the project.
+    assert!(
+        !ledger.codes_for("itest").is_empty(),
+        "finops codes should be minted for itest"
+    );
+
+    a.close().await.ok();
+    b.close().await.ok();
+}

--- a/b00t-lib-chat/tests/nats_mesh_integration.rs
+++ b/b00t-lib-chat/tests/nats_mesh_integration.rs
@@ -4,7 +4,7 @@
 //! full `--agent=b00t-comms --skill=nats` path: presence, discovery, direct
 //! send, and finops receipt minting.
 
-use b00t_chat::ledgrrr::{LocalLedgrrr, Ledgrrr};
+use b00t_chat::ledgrrr::{Ledgrrr, MockLedgrrr};
 use b00t_chat::mesh::{MeshFrame, MeshNodeConfig, NatsMeshNode};
 use b00t_chat::message::ChatMessage;
 use std::sync::Arc;
@@ -20,7 +20,7 @@ async fn two_node_mesh_discovers_and_exchanges() {
         }
     };
 
-    let ledger: Arc<LocalLedgrrr> = Arc::new(LocalLedgrrr::memory());
+    let ledger: Arc<dyn Ledgrrr> = Arc::new(MockLedgrrr::mock());
 
     let a = NatsMeshNode::new(
         MeshNodeConfig::new("itest-a", &url)


### PR DESCRIPTION
## Summary

Realizes the `--agent=b00t-comms --skill=nats` capability as a fully-working **intra-hive** NATS mesh, plus a broker-free discovery path and UFO-ontology grounding.

- **Gossip-based discovery** (`gossip.rs`): transport-agnostic `GossipTable` epidemic membership with a bounded hop budget (`DEFAULT_GOSSIP_MAX_HOPS = 5`); `NatsMeshNode` backs its peer table with it and re-gossips newer ads on `b00t.hive.mesh.gossip`. Converges without a central registry or Redis.
- **Subject namespace aligned to `b00t.hive.*`**: `node` / `channel` / `discovery.query` / `discovery.presence` / `gossip` now live under `b00t.hive.mesh.*` (intra-hive, same network — no NAT traversal needed). Agent datum `[b00t.agent.hive]` with `intra_hive = true`.
- **Finops / ledgrrr**: `MockLedgrrr` (`MOCK-FINOPS-*`, in-memory) so the nats-focused work is unblocked from a running `ledgerr-mcp`; `LocalLedgrrr`/`McpLedgrrr` for real ledgers.
- **Arrow dataframe receipts**: `DataframeReceipt` trait + `FocusRecord` reference impl; `dataframe` feature materializes `arrow::RecordBatch`.
- **UFO grounding** (via `ufo-types` #511 `Stereotyped`): `AgentEndpoint`/`AgentPresence`/`GossipMember` → `Kind`, `MeshFrame` → `Relator("hive-mesh-frame")`, `NatsMeshNode` → `Role("hive-node")`.
- **Proposal** `_b00t_/NATS-MESH-GOSSIP-DISCOVERY.tomllmd`: evaluates gossiper / iroh-gossip / gwyh / iroh as broker-free intra-hive transports; iroh-backed ledgrrr deferred.

## Test plan

- `cargo test -p b00t-chat` (default: 43 lib + 9 int + 2 doctest) ✅
- `cargo test -p b00t-chat --features dataframe` ✅
- `tests/nats_mesh_integration.rs` (env-gated on `NATS_URL`)
- Proposal includes reviewer-facing test + node-contact instructions.

## Fast-fix-forward (pre-push hook)

The pre-push hook (`_b00t_/hooks/pre-push`) was rewritten to gate only **changed packages ∪ transitive reverse-dependant closure** via `cargo metadata` in a single `cargo test` invocation, eliminating the previous always-full 927-test run that timed out pushes. Config/dep changes still take the conservative full `b00t-cli` gate.

🤓 Draft — iroh-backed transport + ledgrrr P2P exchange deferred per proposal.