### PR TITLE
feat(learn): --agent/--role scoping flag + standardize Claude Code skill datums

### DIFF
--- a/_b00t_/brainstorming.skill.tomllm
+++ b/_b00t_/brainstorming.skill.tomllm
@@ -1,0 +1,29 @@
+[b00t]
+name = "brainstorming"
+type = "skill"
+version = "0.1.0"
+hint = "Explore user intent, requirements, and design before implementation"
+
+[b00t.skill]
+description = """
+You MUST use this before any creative work — creating features, building components, adding functionality, or modifying behavior. Explores user intent, requirements and design before implementation.
+"""
+source = "Claude Code built-in skill (superpowers plugin) — no external assimilation source"
+tags = ["planning", "requirements", "design", "creative-work"]
+tier = "sm0l"
+complexity = 2
+
+[b00t.learn]
+topic = "brainstorming"
+inline = """
+You MUST use this before any creative work — creating features, building components, adding functionality, or modifying behavior. Explores user intent, requirements and design before implementation.
+
+Invoke via the Skill tool in Claude Code: skill="brainstorming".
+"""
+
+# b00t:map v1
+# summary: Explore user intent, requirements, and design before implementation
+# tags: planning, requirements, design, creative-work
+# tier: sm0l
+# cmds: b00t learn brainstorming
+# complexity: 2

--- a/_b00t_/dispatching-parallel-agents.skill.tomllm
+++ b/_b00t_/dispatching-parallel-agents.skill.tomllm
@@ -1,0 +1,29 @@
+[b00t]
+name = "dispatching-parallel-agents"
+type = "skill"
+version = "0.1.0"
+hint = "Dispatch independent tasks to parallel sub-agents when there's no shared state"
+
+[b00t.skill]
+description = """
+Use when facing 2+ independent tasks that can be worked on without shared state or sequential dependencies.
+"""
+source = "Claude Code built-in skill (superpowers plugin) — no external assimilation source"
+tags = ["parallelism", "sub-agents", "delegation", "compound-engineering"]
+tier = "ch0nky"
+complexity = 4
+
+[b00t.learn]
+topic = "dispatching-parallel-agents"
+inline = """
+Use when facing 2+ independent tasks that can be worked on without shared state or sequential dependencies.
+
+Invoke via the Skill tool in Claude Code: skill="dispatching-parallel-agents".
+"""
+
+# b00t:map v1
+# summary: Dispatch independent tasks to parallel sub-agents when there's no shared state
+# tags: parallelism, sub-agents, delegation, compound-engineering
+# tier: ch0nky
+# cmds: b00t learn dispatching-parallel-agents
+# complexity: 4

--- a/_b00t_/executing-plans.skill.tomllm
+++ b/_b00t_/executing-plans.skill.tomllm
@@ -1,0 +1,29 @@
+[b00t]
+name = "executing-plans"
+type = "skill"
+version = "0.1.0"
+hint = "Execute a written implementation plan in a separate session with review checkpoints"
+
+[b00t.skill]
+description = """
+Use when you have a written implementation plan to execute in a separate session with review checkpoints.
+"""
+source = "Claude Code built-in skill (superpowers plugin) — no external assimilation source"
+tags = ["execution", "plans", "checkpoints", "review"]
+tier = "ch0nky"
+complexity = 4
+
+[b00t.learn]
+topic = "executing-plans"
+inline = """
+Use when you have a written implementation plan to execute in a separate session with review checkpoints.
+
+Invoke via the Skill tool in Claude Code: skill="executing-plans".
+"""
+
+# b00t:map v1
+# summary: Execute a written implementation plan in a separate session with review checkpoints
+# tags: execution, plans, checkpoints, review
+# tier: ch0nky
+# cmds: b00t learn executing-plans
+# complexity: 4

--- a/_b00t_/finishing-a-development-branch.skill.tomllm
+++ b/_b00t_/finishing-a-development-branch.skill.tomllm
@@ -1,0 +1,29 @@
+[b00t]
+name = "finishing-a-development-branch"
+type = "skill"
+version = "0.1.0"
+hint = "Decide how to integrate completed work — merge, PR, or cleanup"
+
+[b00t.skill]
+description = """
+Use when implementation is complete, all tests pass, and you need to decide how to integrate the work — guides completion of development work by presenting structured options for merge, PR, or cleanup.
+"""
+source = "Claude Code built-in skill (superpowers plugin) — no external assimilation source"
+tags = ["git", "merge", "pr", "branch-completion"]
+tier = "sm0l"
+complexity = 3
+
+[b00t.learn]
+topic = "finishing-a-development-branch"
+inline = """
+Use when implementation is complete, all tests pass, and you need to decide how to integrate the work — guides completion of development work by presenting structured options for merge, PR, or cleanup.
+
+Invoke via the Skill tool in Claude Code: skill="finishing-a-development-branch".
+"""
+
+# b00t:map v1
+# summary: Decide how to integrate completed work — merge, PR, or cleanup
+# tags: git, merge, pr, branch-completion
+# tier: sm0l
+# cmds: b00t learn finishing-a-development-branch
+# complexity: 3

--- a/_b00t_/receiving-code-review.skill.tomllm
+++ b/_b00t_/receiving-code-review.skill.tomllm
@@ -1,0 +1,29 @@
+[b00t]
+name = "receiving-code-review"
+type = "skill"
+version = "0.1.0"
+hint = "Evaluate code review feedback with technical rigor, not performative agreement"
+
+[b00t.skill]
+description = """
+Use when receiving code review feedback, before implementing suggestions, especially if feedback seems unclear or technically questionable — requires technical rigor and verification, not performative agreement or blind implementation.
+"""
+source = "Claude Code built-in skill (superpowers plugin) — no external assimilation source"
+tags = ["code-review", "feedback", "verification"]
+tier = "sm0l"
+complexity = 3
+
+[b00t.learn]
+topic = "receiving-code-review"
+inline = """
+Use when receiving code review feedback, before implementing suggestions, especially if feedback seems unclear or technically questionable — requires technical rigor and verification, not performative agreement or blind implementation.
+
+Invoke via the Skill tool in Claude Code: skill="receiving-code-review".
+"""
+
+# b00t:map v1
+# summary: Evaluate code review feedback with technical rigor, not performative agreement
+# tags: code-review, feedback, verification
+# tier: sm0l
+# cmds: b00t learn receiving-code-review
+# complexity: 3

--- a/_b00t_/requesting-code-review.skill.tomllm
+++ b/_b00t_/requesting-code-review.skill.tomllm
@@ -1,0 +1,29 @@
+[b00t]
+name = "requesting-code-review"
+type = "skill"
+version = "0.1.0"
+hint = "Verify work meets requirements before merging or calling it done"
+
+[b00t.skill]
+description = """
+Use when completing tasks, implementing major features, or before merging to verify work meets requirements.
+"""
+source = "Claude Code built-in skill (superpowers plugin) — no external assimilation source"
+tags = ["code-review", "verification", "merge-readiness"]
+tier = "sm0l"
+complexity = 2
+
+[b00t.learn]
+topic = "requesting-code-review"
+inline = """
+Use when completing tasks, implementing major features, or before merging to verify work meets requirements.
+
+Invoke via the Skill tool in Claude Code: skill="requesting-code-review".
+"""
+
+# b00t:map v1
+# summary: Verify work meets requirements before merging or calling it done
+# tags: code-review, verification, merge-readiness
+# tier: sm0l
+# cmds: b00t learn requesting-code-review
+# complexity: 2

--- a/_b00t_/subagent-driven-development.skill.tomllm
+++ b/_b00t_/subagent-driven-development.skill.tomllm
@@ -1,0 +1,29 @@
+[b00t]
+name = "subagent-driven-development"
+type = "skill"
+version = "0.1.0"
+hint = "Execute an implementation plan's independent tasks via sub-agents in the current session"
+
+[b00t.skill]
+description = """
+Use when executing implementation plans with independent tasks in the current session.
+"""
+source = "Claude Code built-in skill (superpowers plugin) — no external assimilation source"
+tags = ["sub-agents", "execution", "delegation"]
+tier = "ch0nky"
+complexity = 4
+
+[b00t.learn]
+topic = "subagent-driven-development"
+inline = """
+Use when executing implementation plans with independent tasks in the current session.
+
+Invoke via the Skill tool in Claude Code: skill="subagent-driven-development".
+"""
+
+# b00t:map v1
+# summary: Execute an implementation plan's independent tasks via sub-agents in the current session
+# tags: sub-agents, execution, delegation
+# tier: ch0nky
+# cmds: b00t learn subagent-driven-development
+# complexity: 4

--- a/_b00t_/test-driven-development.skill.tomllm
+++ b/_b00t_/test-driven-development.skill.tomllm
@@ -1,0 +1,29 @@
+[b00t]
+name = "test-driven-development"
+type = "skill"
+version = "0.1.0"
+hint = "Write the test before the implementation, for any feature or bugfix"
+
+[b00t.skill]
+description = """
+Use when implementing any feature or bugfix, before writing implementation code.
+"""
+source = "Claude Code built-in skill (superpowers plugin) — no external assimilation source"
+tags = ["tdd", "testing", "b00t-development-principle"]
+tier = "sm0l"
+complexity = 2
+
+[b00t.learn]
+topic = "test-driven-development"
+inline = """
+Use when implementing any feature or bugfix, before writing implementation code.
+
+Invoke via the Skill tool in Claude Code: skill="test-driven-development".
+"""
+
+# b00t:map v1
+# summary: Write the test before the implementation, for any feature or bugfix
+# tags: tdd, testing, b00t-development-principle
+# tier: sm0l
+# cmds: b00t learn test-driven-development
+# complexity: 2

--- a/_b00t_/using-git-worktrees.skill.tomllm
+++ b/_b00t_/using-git-worktrees.skill.tomllm
@@ -1,0 +1,29 @@
+[b00t]
+name = "using-git-worktrees"
+type = "skill"
+version = "0.1.0"
+hint = "Isolate feature work from the current workspace via a git worktree"
+
+[b00t.skill]
+description = """
+Use when starting feature work that needs isolation from current workspace or before executing implementation plans — ensures an isolated workspace exists via native tools or git worktree fallback.
+"""
+source = "Claude Code built-in skill (superpowers plugin) — no external assimilation source"
+tags = ["git", "worktrees", "isolation"]
+tier = "sm0l"
+complexity = 3
+
+[b00t.learn]
+topic = "using-git-worktrees"
+inline = """
+Use when starting feature work that needs isolation from current workspace or before executing implementation plans — ensures an isolated workspace exists via native tools or git worktree fallback.
+
+Invoke via the Skill tool in Claude Code: skill="using-git-worktrees".
+"""
+
+# b00t:map v1
+# summary: Isolate feature work from the current workspace via a git worktree
+# tags: git, worktrees, isolation
+# tier: sm0l
+# cmds: b00t learn using-git-worktrees
+# complexity: 3

--- a/_b00t_/using-superpowers.skill.tomllm
+++ b/_b00t_/using-superpowers.skill.tomllm
@@ -1,0 +1,29 @@
+[b00t]
+name = "using-superpowers"
+type = "skill"
+version = "0.1.0"
+hint = "Establish how to find and use skills at the start of any conversation"
+
+[b00t.skill]
+description = """
+Use when starting any conversation — establishes how to find and use skills, requiring skill invocation before ANY response including clarifying questions.
+"""
+source = "Claude Code built-in skill (superpowers plugin) — no external assimilation source"
+tags = ["skills", "meta", "conversation-start"]
+tier = "sm0l"
+complexity = 2
+
+[b00t.learn]
+topic = "using-superpowers"
+inline = """
+Use when starting any conversation — establishes how to find and use skills, requiring skill invocation before ANY response including clarifying questions.
+
+Invoke via the Skill tool in Claude Code: skill="using-superpowers".
+"""
+
+# b00t:map v1
+# summary: Establish how to find and use skills at the start of any conversation
+# tags: skills, meta, conversation-start
+# tier: sm0l
+# cmds: b00t learn using-superpowers
+# complexity: 2

--- a/_b00t_/verification-before-completion.skill.tomllm
+++ b/_b00t_/verification-before-completion.skill.tomllm
@@ -1,0 +1,29 @@
+[b00t]
+name = "verification-before-completion"
+type = "skill"
+version = "0.1.0"
+hint = "Run verification commands and confirm output before claiming work is done — evidence before assertions"
+
+[b00t.skill]
+description = """
+Use when about to claim work is complete, fixed, or passing, before committing or creating PRs — requires running verification commands and confirming output before making any success claims; evidence before assertions always.
+"""
+source = "Claude Code built-in skill (superpowers plugin) — no external assimilation source"
+tags = ["verification", "evidence", "completion-claims"]
+tier = "sm0l"
+complexity = 3
+
+[b00t.learn]
+topic = "verification-before-completion"
+inline = """
+Use when about to claim work is complete, fixed, or passing, before committing or creating PRs — requires running verification commands and confirming output before making any success claims; evidence before assertions always.
+
+Invoke via the Skill tool in Claude Code: skill="verification-before-completion".
+"""
+
+# b00t:map v1
+# summary: Run verification commands and confirm output before claiming work is done — evidence before assertions
+# tags: verification, evidence, completion-claims
+# tier: sm0l
+# cmds: b00t learn verification-before-completion
+# complexity: 3

--- a/_b00t_/writing-plans.skill.tomllm
+++ b/_b00t_/writing-plans.skill.tomllm
@@ -1,0 +1,29 @@
+[b00t]
+name = "writing-plans"
+type = "skill"
+version = "0.1.0"
+hint = "Turn a spec/requirements into a written plan before touching code"
+
+[b00t.skill]
+description = """
+Use when you have a spec or requirements for a multi-step task, before touching code.
+"""
+source = "Claude Code built-in skill (superpowers plugin) — no external assimilation source"
+tags = ["planning", "spec", "multi-step-tasks"]
+tier = "sm0l"
+complexity = 3
+
+[b00t.learn]
+topic = "writing-plans"
+inline = """
+Use when you have a spec or requirements for a multi-step task, before touching code.
+
+Invoke via the Skill tool in Claude Code: skill="writing-plans".
+"""
+
+# b00t:map v1
+# summary: Turn a spec/requirements into a written plan before touching code
+# tags: planning, spec, multi-step-tasks
+# tier: sm0l
+# cmds: b00t learn writing-plans
+# complexity: 3

--- a/_b00t_/writing-skills.skill.tomllm
+++ b/_b00t_/writing-skills.skill.tomllm
@@ -1,0 +1,29 @@
+[b00t]
+name = "writing-skills"
+type = "skill"
+version = "0.1.0"
+hint = "Create, edit, or verify Claude Code skills before deployment"
+
+[b00t.skill]
+description = """
+Use when creating new skills, editing existing skills, or verifying skills work before deployment.
+"""
+source = "Claude Code built-in skill (superpowers plugin) — no external assimilation source"
+tags = ["skills", "meta", "authoring"]
+tier = "ch0nky"
+complexity = 4
+
+[b00t.learn]
+topic = "writing-skills"
+inline = """
+Use when creating new skills, editing existing skills, or verifying skills work before deployment.
+
+Invoke via the Skill tool in Claude Code: skill="writing-skills".
+"""
+
+# b00t:map v1
+# summary: Create, edit, or verify Claude Code skills before deployment
+# tags: skills, meta, authoring
+# tier: ch0nky
+# cmds: b00t learn writing-skills
+# complexity: 4

--- a/b00t-cli/src/commands/learn.rs
+++ b/b00t-cli/src/commands/learn.rs
@@ -75,9 +75,29 @@ pub struct LearnArgs {
     // E1: skip learn if evidence already proves competency
     #[arg(long, help = "Force load even if competency evidence exists (E1)")]
     pub force: bool,
+
+    // 🤓 --agent is an alias for --role: b00t's other commands (e.g. whoami) already
+    //    call this concept "role"; --agent is accepted as a synonym so agent-facing
+    //    callers (MCP tools, agent harnesses) can use whichever term reads naturally.
+    //    Sets _B00T_ROLE for the duration of this call — same mechanism whoami's
+    //    --role already relies on — so role-scoped datum/RAG resolution downstream
+    //    picks it up without new plumbing.
+    #[arg(long, visible_alias = "agent", help = "Scope learning to a role/agent (matches role datum; alias: --agent)")]
+    pub role: Option<String>,
 }
 
 pub async fn handle_learn(path: &str, args: LearnArgs) -> Result<()> {
+    // 🤓 --role/--agent: scope this call's role context for downstream role-aware
+    //    lookups (E1 skill-key evidence, RAG/grok query scoping) via the same
+    //    _B00T_ROLE env var whoami's --role already relies on. Safety: this process
+    //    is single-threaded through this point (before any spawned work reads the
+    //    var), so a plain env write is sufficient — no async task has raced ahead.
+    if let Some(ref role) = args.role {
+        unsafe {
+            std::env::set_var("_B00T_ROLE", role);
+        }
+    }
+
     // 🤓 merge positional topic + --topic flag; --topic wins (MCP compat: passes named flags)
     let topic_val = args.topic_flag.or(args.topic);
 


### PR DESCRIPTION
## Summary
- Adds `--role <ROLE>` to `b00t learn`, aliased as `--agent` (`--agent` reads more naturally for agent-facing callers like MCP tools/harnesses). Scopes the call's `_B00T_ROLE` env var — the same mechanism `whoami --role` already relies on — so downstream E1 skill-key evidence and RAG/grok query resolution pick up the role context without new plumbing.
- Registers 13 Claude Code built-in skills (superpowers plugin) as standard `.skill.tomllm` datums, so `b00t learn <skill-name>` resolves them through the normal datum-search path instead of requiring bespoke handling: `requesting-code-review`, `executing-plans`, `writing-skills`, `subagent-driven-development`, `dispatching-parallel-agents`, `finishing-a-development-branch`, `test-driven-development`, `verification-before-completion`, `receiving-code-review`, `using-git-worktrees`, `writing-plans`, `using-superpowers`, `brainstorming`.
- `systematic-debugging` intentionally excluded — a richer pre-existing datum already covers it (full recipes, `depends_on`, `composes_with`); registering a generic stub would have regressed it.

## Test plan
- [x] `cargo check -p b00t-cli` clean in isolated worktree
- [x] `b00t learn brainstorming` and `b00t learn systematic-debugging` both resolve via the existing datum-search path (score=12), confirming new files are picked up through the same mechanism as pre-existing skill datums
- [x] `cargo test -p b00t-cli --lib` — 929 passed, 0 failed (pre-push hook)

🤖 Generated with [Claude Code](https://claude.com/claude-code)