### PR TITLE
feat(datum): DatumType::Pipeline + PipelineDatum

### DIFF
--- a/b00t-cli/src/datum_pipeline.rs
+++ b/b00t-cli/src/datum_pipeline.rs
@@ -1,0 +1,482 @@
+use crate::traits::*;
+use crate::{BootDatum, PipelineConfig, get_config};
+use anyhow::{Result, anyhow};
+use std::path::{Path, PathBuf};
+use std::time::Instant;
+
+/// A registered pipeline — a multi-stage, b00t-native discoverable capability.
+///
+/// Unlike `JustfileDatum` (which wraps a separately-executable `justfile`
+/// artifact interpreted by the external `just` binary), a pipeline's stages
+/// are declared inline in the datum's own `*.pipeline.tomllm` config — there
+/// is no external pipeline interpreter binary to shell out to. Full stage
+/// contracts (input/output/depends_on) are intentionally NOT modeled here;
+/// that's the consuming application's job (see
+/// `PIPELINE-DATUM-UFO-FOUNDATION.tomllmd` §Task 4). At this layer a stage is
+/// just a name, and `CliExecutor::execute` validates + reports the resolved
+/// stage sequence rather than dispatching real work — real dispatch is wired
+/// in a later task's `JobExecutor`↔`ComputeProvider` bridge.
+pub struct PipelineDatum {
+    pub datum: BootDatum,
+    /// Path to the `*.pipeline.tomllm` file describing this pipeline.
+    pub pipeline_path: PathBuf,
+    /// Ordered stage names, read once at construction from
+    /// `[b00t.pipeline].stages`.
+    stages: Vec<String>,
+}
+
+impl PipelineDatum {
+    pub fn from_config(name: &str, path: &str) -> Result<Self> {
+        let (config, filename) = get_config(name, path).map_err(|e| anyhow!("{}", e))?;
+        let datum = config.b00t;
+        let pipeline_path = Self::resolve_pipeline_path(&datum, path, &filename)?;
+        let stages = Self::stage_names(&datum);
+        Ok(PipelineDatum {
+            datum,
+            pipeline_path,
+            stages,
+        })
+    }
+
+    pub fn from_datum(datum: BootDatum, base_dir: &Path) -> Result<Self> {
+        let fallback_filename = format!("{}.pipeline.tomllm", datum.name);
+        let pipeline_path = Self::resolve_pipeline_path(
+            &datum,
+            &base_dir.display().to_string(),
+            &fallback_filename,
+        )?;
+        let stages = Self::stage_names(&datum);
+        Ok(PipelineDatum {
+            datum,
+            pipeline_path,
+            stages,
+        })
+    }
+
+    fn stage_names(datum: &BootDatum) -> Vec<String> {
+        datum
+            .pipeline
+            .as_ref()
+            .and_then(|p| p.stages.clone())
+            .unwrap_or_default()
+    }
+
+    /// Resolve the on-disk path of the pipeline definition.
+    /// `[b00t.pipeline].path` overrides; otherwise falls back to the file
+    /// that `get_config` (or the caller) discovered this datum in — a
+    /// pipeline's definition IS its datum file, unlike a justfile which
+    /// wraps a separate artifact.
+    fn resolve_pipeline_path(
+        datum: &BootDatum,
+        base_dir: &str,
+        discovered_filename: &str,
+    ) -> Result<PathBuf> {
+        let relative = datum
+            .pipeline
+            .as_ref()
+            .and_then(|p| p.path.as_deref())
+            .unwrap_or(discovered_filename);
+
+        let base = Path::new(base_dir);
+        let path = if Path::new(relative).is_absolute() {
+            PathBuf::from(relative)
+        } else {
+            base.join(relative)
+        };
+        Ok(path)
+    }
+
+    fn pipeline_config(&self) -> PipelineConfig {
+        self.datum.pipeline.clone().unwrap_or_default()
+    }
+
+    /// The ordered stage names declared by this pipeline.
+    pub fn stages(&self) -> &[String] {
+        &self.stages
+    }
+}
+
+impl TryFrom<(&str, &str)> for PipelineDatum {
+    type Error = anyhow::Error;
+    fn try_from((name, path): (&str, &str)) -> Result<Self, Self::Error> {
+        Self::from_config(name, path)
+    }
+}
+
+impl DatumChecker for PipelineDatum {
+    fn is_installed(&self) -> bool {
+        // No single external binary gates a pipeline the way `just` gates a
+        // JustfileDatum — a pipeline with zero declared stages is the closest
+        // analog to "not installed": it's a datum that exists but declares
+        // nothing runnable.
+        self.pipeline_path.exists() && !self.stages.is_empty()
+    }
+
+    fn current_version(&self) -> Option<String> {
+        // Use mtime as the "version" — same convention as JustfileDatum.
+        std::fs::metadata(&self.pipeline_path)
+            .ok()
+            .and_then(|m| m.modified().ok())
+            .map(|t| {
+                t.duration_since(std::time::UNIX_EPOCH)
+                    .map(|d| d.as_secs().to_string())
+                    .unwrap_or_else(|_| "unknown".to_string())
+            })
+    }
+
+    fn desired_version(&self) -> Option<String> {
+        self.datum.desires.clone()
+    }
+
+    fn version_status(&self) -> VersionStatus {
+        if !self.pipeline_path.exists() {
+            VersionStatus::Missing
+        } else if self.stages.is_empty() {
+            VersionStatus::Missing
+        } else {
+            VersionStatus::Unknown // pipelines don't carry semver
+        }
+    }
+}
+
+impl StatusProvider for PipelineDatum {
+    fn name(&self) -> &str {
+        &self.datum.name
+    }
+    fn subsystem(&self) -> &str {
+        "pipeline"
+    }
+    fn hint(&self) -> &str {
+        &self.datum.hint
+    }
+    fn is_disabled(&self) -> bool {
+        false
+    }
+}
+
+impl FilterLogic for PipelineDatum {
+    fn is_available(&self) -> bool {
+        self.pipeline_path.exists()
+    }
+    fn prerequisites_satisfied(&self) -> bool {
+        !self.stages.is_empty()
+    }
+    fn evaluate_constraints(&self, require: &[String]) -> bool {
+        self.evaluate_constraints_default(require)
+    }
+}
+
+impl ConstraintEvaluator for PipelineDatum {
+    fn datum(&self) -> &BootDatum {
+        &self.datum
+    }
+}
+
+impl DatumProvider for PipelineDatum {
+    fn datum(&self) -> &BootDatum {
+        &self.datum
+    }
+}
+
+// ── CliExecutor impl ──────────────────────────────────────────────────────────
+
+impl CliExecutor for PipelineDatum {
+    /// Validates and resolves the requested stage sequence.
+    ///
+    /// 🤓 Deliberate divergence from `JustfileDatum::execute`: there is no
+    /// external interpreter (like `just`) to hand this off to yet. Real
+    /// per-stage dispatch (local shell-out, `ComputeProvider` submission,
+    /// parallel fan-out) is `JobExecutor`'s job, wired in a later task. This
+    /// method's contract for now: validate the pipeline is well-formed and
+    /// report the stage order that *would* run — `value` is a `" -> "`
+    /// joined stage list, `declared_effects` flags it as a dispatching
+    /// operation so sandboxing/audit treats it consistently with a real run.
+    fn execute(&self, args: &[String]) -> Result<ExecOutput<String>> {
+        if !self.pipeline_path.exists() {
+            return Err(anyhow!(
+                "pipeline definition not found: {}",
+                self.pipeline_path.display()
+            ));
+        }
+        if self.stages.is_empty() {
+            return Err(anyhow!(
+                "pipeline '{}' declares no stages",
+                self.datum.name
+            ));
+        }
+
+        let selected = self.resolve_selected_stages(args)?;
+        let start = Instant::now();
+        let value = selected.join(" -> ");
+
+        Ok(ExecOutput {
+            value,
+            exit_code: 0,
+            duration_ms: start.elapsed().as_millis() as u64,
+            sandbox: self.sandbox_requirements(),
+            sandbox_kind: self
+                .allowed_sandboxes()
+                .into_iter()
+                .next()
+                .unwrap_or(SandboxKind::None),
+            io_method: self.io_method(),
+            declared_effects: vec!["pipeline-stage-dispatch".to_string()],
+        })
+    }
+
+    fn dry_run(&self, args: &[String]) -> Result<ExecPlan> {
+        let selected = self.resolve_selected_stages(args)?;
+
+        let sandbox_kind = self
+            .allowed_sandboxes()
+            .into_iter()
+            .next()
+            .unwrap_or(SandboxKind::None);
+        let io_method = IoMethod::for_sandbox(&sandbox_kind);
+
+        Ok(ExecPlan {
+            command_line: format!("pipeline {}: {}", self.datum.name, selected.join(" -> ")),
+            working_dir: self
+                .pipeline_path
+                .parent()
+                .map(PathBuf::from)
+                .unwrap_or_else(|| PathBuf::from(".")),
+            env: vec![],
+            declared_effects: vec!["pipeline-stage-dispatch".to_string()],
+            sandbox_kind,
+            io_method,
+        })
+    }
+
+    /// One `CommandSignature` per declared stage — a pipeline's stages are
+    /// its "recipes". No parameters/dependencies are modeled at this layer.
+    fn list_commands(&self) -> Result<Vec<CommandSignature>> {
+        Ok(self
+            .stages
+            .iter()
+            .map(|s| CommandSignature {
+                name: s.clone(),
+                description: None,
+                parameters: vec![],
+                dependencies: vec![],
+                private: false,
+            })
+            .collect())
+    }
+
+    fn sandbox_requirements(&self) -> SandboxRequirements {
+        let caps = self.pipeline_config().capabilities.unwrap_or_default();
+        let pipeline_dir = self
+            .pipeline_path
+            .parent()
+            .map(PathBuf::from)
+            .unwrap_or_else(|| PathBuf::from("."));
+
+        let mut filesystem = vec![pipeline_dir];
+        if let Some(paths) = caps.filesystem {
+            for p in paths {
+                let path = if Path::new(&p).is_absolute() {
+                    PathBuf::from(&p)
+                } else {
+                    self.pipeline_path
+                        .parent()
+                        .unwrap_or_else(|| Path::new("."))
+                        .join(&p)
+                };
+                if !filesystem.contains(&path) {
+                    filesystem.push(path);
+                }
+            }
+        }
+
+        SandboxRequirements {
+            network: caps.network.unwrap_or(false),
+            filesystem,
+            env_vars: caps.env_vars.unwrap_or_default(),
+            secrets: caps.secrets.unwrap_or_default(),
+            max_duration: None,
+        }
+    }
+
+    fn allowed_sandboxes(&self) -> Vec<SandboxKind> {
+        let config = self.pipeline_config();
+        if let Some(kinds) = config.allowed_sandboxes {
+            kinds.iter().map(|s| SandboxKind::from_str(s)).collect()
+        } else if let Some(single) = config.sandbox {
+            vec![SandboxKind::from_str(&single)]
+        } else {
+            // Default: None (direct execution) is always permitted
+            vec![SandboxKind::None]
+        }
+    }
+
+    fn io_method(&self) -> IoMethod {
+        let preferred_sandbox = self
+            .allowed_sandboxes()
+            .into_iter()
+            .next()
+            .unwrap_or(SandboxKind::None);
+        IoMethod::for_sandbox(&preferred_sandbox)
+    }
+}
+
+impl PipelineDatum {
+    /// Resolve which declared stages to run: explicit `args` select a subset
+    /// (order preserved, unknown names rejected), empty `args` selects all
+    /// stages in declaration order.
+    fn resolve_selected_stages(&self, args: &[String]) -> Result<Vec<String>> {
+        if args.is_empty() {
+            return Ok(self.stages.clone());
+        }
+        let mut selected = Vec::with_capacity(args.len());
+        for a in args {
+            if !self.stages.contains(a) {
+                return Err(anyhow!(
+                    "pipeline '{}' has no stage named '{}' (known stages: {})",
+                    self.datum.name,
+                    a,
+                    self.stages.join(", ")
+                ));
+            }
+            selected.push(a.clone());
+        }
+        Ok(selected)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::PipelineConfig;
+    use std::io::Write;
+    use tempfile::NamedTempFile;
+
+    fn tmp(c: &str) -> NamedTempFile {
+        let mut f = NamedTempFile::new().unwrap();
+        write!(f, "{}", c).unwrap();
+        f
+    }
+
+    fn mkd(path: &std::path::Path, stages: &[&str]) -> PipelineDatum {
+        let mut datum = BootDatum {
+            name: "test-pipeline".to_string(),
+            ..Default::default()
+        };
+        datum.pipeline = Some(PipelineConfig {
+            stages: Some(stages.iter().map(|s| s.to_string()).collect()),
+            ..Default::default()
+        });
+        PipelineDatum {
+            datum,
+            pipeline_path: path.to_path_buf(),
+            stages: stages.iter().map(|s| s.to_string()).collect(),
+        }
+    }
+
+    #[test]
+    fn is_installed_true_when_file_exists_and_has_stages() {
+        let f = tmp("[b00t]\nname = \"x\"\n");
+        let d = mkd(f.path(), &["extract", "generate", "inject"]);
+        assert!(d.is_installed());
+    }
+
+    #[test]
+    fn is_installed_false_when_no_stages() {
+        let f = tmp("[b00t]\nname = \"x\"\n");
+        let d = mkd(f.path(), &[]);
+        assert!(!d.is_installed());
+    }
+
+    #[test]
+    fn is_installed_false_when_file_missing() {
+        let d = mkd(Path::new("/nonexistent/pipeline.pipeline.tomllm"), &["a"]);
+        assert!(!d.is_installed());
+    }
+
+    #[test]
+    fn list_commands_returns_one_per_stage_in_order() {
+        let f = tmp("[b00t]\nname = \"x\"\n");
+        let d = mkd(f.path(), &["extract", "generate", "inject"]);
+        let cmds = d.list_commands().unwrap();
+        let names: Vec<&str> = cmds.iter().map(|c| c.name.as_str()).collect();
+        assert_eq!(names, vec!["extract", "generate", "inject"]);
+        assert!(cmds.iter().all(|c| !c.private));
+    }
+
+    #[test]
+    fn execute_with_no_args_runs_all_stages_in_order() {
+        let f = tmp("[b00t]\nname = \"x\"\n");
+        let d = mkd(f.path(), &["extract", "generate", "inject"]);
+        let out = d.execute(&[]).unwrap();
+        assert_eq!(out.value, "extract -> generate -> inject");
+        assert_eq!(out.exit_code, 0);
+    }
+
+    #[test]
+    fn execute_with_args_selects_subset() {
+        let f = tmp("[b00t]\nname = \"x\"\n");
+        let d = mkd(f.path(), &["extract", "generate", "inject"]);
+        let out = d.execute(&["generate".to_string()]).unwrap();
+        assert_eq!(out.value, "generate");
+    }
+
+    #[test]
+    fn execute_rejects_unknown_stage() {
+        let f = tmp("[b00t]\nname = \"x\"\n");
+        let d = mkd(f.path(), &["extract", "generate"]);
+        let err = d.execute(&["bogus".to_string()]).unwrap_err();
+        assert!(err.to_string().contains("bogus"));
+    }
+
+    #[test]
+    fn execute_fails_when_no_stages_declared() {
+        let f = tmp("[b00t]\nname = \"x\"\n");
+        let d = mkd(f.path(), &[]);
+        assert!(d.execute(&[]).is_err());
+    }
+
+    #[test]
+    fn execute_fails_when_pipeline_file_missing() {
+        let d = mkd(Path::new("/nonexistent/pipeline.pipeline.tomllm"), &["a"]);
+        assert!(d.execute(&[]).is_err());
+    }
+
+    #[test]
+    fn dry_run_reports_stage_sequence_without_side_effects_field_conflation() {
+        let f = tmp("[b00t]\nname = \"x\"\n");
+        let d = mkd(f.path(), &["extract", "generate"]);
+        let plan = d.dry_run(&[]).unwrap();
+        assert!(plan.command_line.contains("extract -> generate"));
+        assert_eq!(plan.declared_effects, vec!["pipeline-stage-dispatch"]);
+    }
+
+    #[test]
+    fn allowed_sandboxes_defaults_to_none() {
+        let f = tmp("[b00t]\nname = \"x\"\n");
+        let d = mkd(f.path(), &["a"]);
+        assert_eq!(d.allowed_sandboxes(), vec![SandboxKind::None]);
+    }
+
+    #[test]
+    fn sandbox_requirements_includes_pipeline_dir() {
+        let f = tmp("[b00t]\nname = \"x\"\n");
+        let d = mkd(f.path(), &["a"]);
+        let reqs = d.sandbox_requirements();
+        let pipeline_dir = f.path().parent().unwrap().to_path_buf();
+        assert!(reqs.filesystem.contains(&pipeline_dir));
+    }
+
+    #[test]
+    fn version_status_missing_when_no_stages() {
+        let f = tmp("[b00t]\nname = \"x\"\n");
+        let d = mkd(f.path(), &[]);
+        assert_eq!(d.version_status(), VersionStatus::Missing);
+    }
+
+    #[test]
+    fn version_status_unknown_when_installed() {
+        let f = tmp("[b00t]\nname = \"x\"\n");
+        let d = mkd(f.path(), &["a"]);
+        assert_eq!(d.version_status(), VersionStatus::Unknown);
+    }
+}

--- a/b00t-cli/src/datum_proof.rs
+++ b/b00t-cli/src/datum_proof.rs
@@ -378,6 +378,7 @@ impl BootDatum {
             Some(DatumType::Vscode)      => self.prove_vscode(),
             Some(DatumType::K8s)         => self.prove_k8s(),
             Some(DatumType::Justfile)    => self.prove_justfile(),
+            Some(DatumType::Pipeline)    => Ok(()),
             Some(DatumType::Job)         => self.prove_job(),
             Some(DatumType::Stack)       => self.prove_stack(),
             Some(DatumType::Agent)       => self.prove_agent(),

--- a/b00t-cli/src/lib.rs
+++ b/b00t-cli/src/lib.rs
@@ -105,6 +105,7 @@ pub mod datum_gemini;
 pub mod training_examples;
 pub mod datum_job;
 pub mod datum_justfile;
+pub mod datum_pipeline;
 pub mod datum_k8s;
 pub mod datum_mcp;
 pub mod datum_repo;
@@ -748,6 +749,10 @@ pub struct BootDatum {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub justfile: Option<JustfileConfig>,
 
+    // Pipeline datum configuration
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub pipeline: Option<PipelineConfig>,
+
     // RAG / learn metadata
     pub learn: Option<LearnMeta>,
     pub lfmf_category: Option<String>,
@@ -1246,6 +1251,52 @@ pub struct JustfileConfig {
     pub capabilities: Option<JustfileCapabilities>,
 }
 
+/// Sandbox capabilities declared by a pipeline datum.
+/// Same contract semantics as `JustfileCapabilities` — tested, not requested.
+#[derive(Deserialize, Serialize, Debug, Clone, PartialEq, Default)]
+pub struct PipelineCapabilities {
+    /// Whether network egress is permitted while dispatching pipeline stages
+    pub network: Option<bool>,
+    /// Filesystem paths visible while dispatching pipeline stages (globs supported)
+    pub filesystem: Option<Vec<String>>,
+    /// Environment variable patterns readable during dispatch (globs supported)
+    pub env_vars: Option<Vec<String>>,
+    /// Secret names that must be injected by the sandbox, never logged
+    pub secrets: Option<Vec<String>>,
+}
+
+/// Pipeline datum configuration — declares stages and executor metadata for a
+/// `*.pipeline.tomllm` multi-stage pipeline.
+/// 🤓 Mirrors `JustfileConfig`'s shape. Divergence: `stages` replaces
+///    `recipe_groups`/`role_pattern` (a pipeline's "recipes" are its ordered
+///    stages, not role-filtered justfile groups) and there is no
+///    `allow_side_effects` toggle — dispatching a pipeline stage is always
+///    declared as a side effect (see `datum_pipeline.rs`), the way `job`/`gate`
+///    datums don't expose a toggle either. Full stage contracts (input/output/
+///    depends_on) are modeled by the consuming application, not here — see
+///    PIPELINE-DATUM-UFO-FOUNDATION.tomllmd.
+#[derive(Deserialize, Serialize, Debug, Clone, PartialEq, Default)]
+pub struct PipelineConfig {
+    /// Path to the pipeline definition file, relative to project root.
+    /// Defaults to the discovered `*.pipeline.tomllm` datum file itself —
+    /// unlike a justfile, a pipeline has no separate externally-executable
+    /// artifact at this layer.
+    pub path: Option<String>,
+    /// MCP server (or job-dispatch surface) datum name that runs this pipeline's
+    /// stages (e.g. "job-mcp"). Real dispatch is wired in a later task.
+    pub mcp_server: Option<String>,
+    /// Ordered stage names. No per-stage contract (input/output/depends_on) at
+    /// this layer — see `PIPELINE-DATUM-UFO-FOUNDATION.tomllmd` for the full
+    /// stage-contract design owned by the consuming application.
+    pub stages: Option<Vec<String>>,
+    /// Execution context: "local" | "container" | "wasm" (single preferred sandbox)
+    pub sandbox: Option<String>,
+    /// Ordered subset of sandbox kinds this pipeline is compatible with
+    pub allowed_sandboxes: Option<Vec<String>>,
+    /// eBPF-scoped capabilities — tested contract, not a request
+    pub capabilities: Option<PipelineCapabilities>,
+}
+
 // DatumType — b00t's typed datum registry.
 // 🤓 single source of truth: add new variants ONLY here. The macro below derives:
 //    from_type_token, base_suffix, all_base_suffixes, from_filename, extension_for_type.
@@ -1277,6 +1328,7 @@ pub enum DatumType {
     Job,
     Ai,
     Justfile,
+    Pipeline,
     Hardware,
     Overlay,
     Runtime,
@@ -1430,7 +1482,7 @@ impl DatumType {
             | Self::Runtime | Self::Nix => SemanticClass::Infra,
             Self::Agent | Self::Role | Self::Ai | Self::Training => SemanticClass::Agent,
             Self::Mcp | Self::McpServer | Self::Api | Self::Schema => SemanticClass::Protocol,
-            Self::Skill | Self::Job | Self::Hook | Self::Gate => SemanticClass::Skill,
+            Self::Skill | Self::Job | Self::Hook | Self::Gate | Self::Pipeline => SemanticClass::Skill,
             Self::Config | Self::Bash | Self::Cli | Self::Justfile
             | Self::Plan | Self::Vendor | Self::Ooda => SemanticClass::Tool,
             Self::Stack | Self::Repo | Self::Vscode | Self::Apt => SemanticClass::Repo,
@@ -1546,6 +1598,7 @@ impl DatumType {
         // Ai is the umbrella; model/ai_model tokens map here (reverse dot: name.model.ai.tomllmd)
         Ai          => ["ai", "model", "ai_model"]   => ".ai",
         Justfile    => ["justfile"]                  => ".justfile",
+        Pipeline    => ["pipeline"]                  => ".pipeline",
         Hardware    => ["hardware"]                  => ".hardware",
         Overlay     => ["overlay"]                   => ".overlay",
         Runtime     => ["runtime", "wrap", "launcher"] => ".runtime",
@@ -4244,7 +4297,7 @@ hint = "containers"
             entangled_docker: None, entangled_k8s: None, channel_prefix: None,
             depends_on: None, members: None, orchestration: None,
             model_hf_id: None, model_size_gb: None, model_size_4bit_gb: None,
-            stack: None, job: None, skill: None, dsn: None, justfile: None,
+            stack: None, job: None, skill: None, dsn: None, justfile: None, pipeline: None,
             learn: None, lfmf_category: None, usage: None, provides: None,
             protocol: None, implements: None, hook_detect: None,
             hook_install: None, hook_update: None, hook_learn: None,

--- a/b00t-cli/src/traits.rs
+++ b/b00t-cli/src/traits.rs
@@ -561,6 +561,7 @@ pub struct ExecPlan {
 }
 
 /// Monadic execution result — wraps output with full provenance.
+#[derive(Debug)]
 pub struct ExecOutput<T> {
     pub value: T,
     pub exit_code: i32,


### PR DESCRIPTION
## Summary
- Registers `DatumType::Pipeline` in the `datum_type_table!` macro, mirroring `DatumType::Justfile` exactly (`"pipeline"` suffix → `.pipeline`, `SemanticClass::Skill`). Makes `*.pipeline.tomllm` files real, typed, `b00t .`-discoverable datums instead of ad-hoc free-form TOML.
- New `PipelineConfig`/`PipelineCapabilities` structs on `BootDatum`, same contract shape as `JustfileConfig`/`JustfileCapabilities` (sandbox capabilities are tested, not requested).
- New `datum_pipeline.rs`: `PipelineDatum` implements the full trait set `JustfileDatum` implements (`DatumChecker`, `StatusProvider`, `FilterLogic`, `ConstraintEvaluator`, `DatumProvider`, `CliExecutor`), plus 14 unit tests. Divergence from `JustfileDatum`: a pipeline's stages are declared inline in its own datum file (no external `just`-like interpreter binary), so `execute`/`dry_run` validate + report the resolved stage sequence rather than dispatching real work — real per-stage dispatch is `JobExecutor`'s job, wired separately (see `PIPELINE-DATUM-UFO-FOUNDATION.tomllmd`).
- `prove_pipeline` wired into `datum_proof.rs`'s match as a no-op stub for now (no external binary to prove against).

Two bugfixes applied on top of the original implementation, found by running the test suite before committing:
- `ExecOutput<T>` was missing `#[derive(Debug)]` — every other exec-result type in `traits.rs` derives `Debug`; a test's `.unwrap_err()` call requires the `Ok` type to be `Debug`.
- The `make_datum` test helper in `lib.rs` constructs `BootDatum` via an explicit field-by-field literal (not `..Default::default()`), so it needed the new `pipeline` field added or every existing call site would fail to compile.

This closes out Task 2 of `PIPELINE-DATUM-UFO-FOUNDATION.tomllmd`, alongside Task 1 (#652), Task 3 (#654), and the skill-datum/--role work (#655).

## Test plan
- [x] `cargo test -p b00t-cli --lib datum_pipeline` — 14 passed, 0 failed
- [x] `cargo test -p b00t-cli --lib` (full suite) — 943 passed, 0 failed, 4 ignored — no regressions
- [x] `cargo test --lib --quiet -p b00t-cli -p b00t-mcp -p b00t-py` (pre-push hook) — pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)