### PR TITLE
feat(chat): hive transport abstraction — pluggable NATS/memory/iroh

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1549,6 +1549,7 @@ dependencies = [
  "async-nats",
  "async-stream",
  "async-trait",
+ "bytes",
  "chrono",
  "cron",
  "dirs",
@@ -12384,6 +12385,7 @@ dependencies = [
  "futures-core",
  "pin-project-lite",
  "tokio",
+ "tokio-util",
 ]
 
 [[package]]

--- a/b00t-lib-chat/Cargo.toml
+++ b/b00t-lib-chat/Cargo.toml
@@ -18,10 +18,11 @@ crate-type = ["cdylib", "rlib"]
 [dependencies]
 async-nats = "0.45.0"
 rumqttc = "0.25"
+bytes = "1"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tokio = { version = "1.0", features = ["full"] }
-tokio-stream = "0.1"
+tokio-stream = { version = "0.1", features = ["sync"] }
 uuid = { version = "1.0", features = ["v4", "serde"] }
 thiserror = "2.0.17"
 chrono = { version = "0.4", features = ["serde"] }
@@ -64,7 +65,12 @@ rand = "0.8"
 tempfile = "3.0"
 
 [features]
-default = []
+default = ["nats"]
+# NATS broker backend for the hive transport (disable via --no-default-features
+# to run broker-free on the in-memory transport).
+nats = []
+# Iroh NodeId/QUIC backend for the hive transport (strategic substrate).
+iroh = []
 python = ["pyo3"]
 wasm = ["wasm-bindgen", "js-sys", "web-sys", "serde-wasm-bindgen"]
 # Concrete Apache Arrow materialization for dataframe-typed receipts.

--- a/b00t-lib-chat/src/hive_transport.rs
+++ b/b00t-lib-chat/src/hive_transport.rs
@@ -1,0 +1,252 @@
+//! Hive transport abstraction — broker-neutral substrate for the intra-hive mesh.
+//!
+//! The mesh needs only a small, broker-shaped surface: connect, publish to a
+//! subject, and subscribe to a subject's stream. `HiveTransport` is that
+//! surface. Concrete impls are pluggable:
+//!
+//! - [`NatsHiveTransport`] (feature `nats`, default) — the current NATS broker.
+//! - [`MemoryHiveTransport`] — in-process pub/sub, broker-free; backs tests and
+//!   the gossip-first discovery path with no external broker.
+//! - [`IrohHiveTransport`] (feature `iroh`) — strategic NodeId/QUIC substrate;
+//!   stub until the iroh backend is wired.
+//!
+//! `NatsMeshNode` holds an `Arc<dyn HiveTransport>`, so the broker is fully
+//! behind the abstraction and can be `#[cfg]`-disabled or swapped (gossip is the
+//! initial discovery that hands off/establishes to whichever broker is active).
+
+use crate::error::{ChatError, ChatResult};
+use crate::ipc_transport::TransportKind;
+use async_trait::async_trait;
+use futures::stream::BoxStream;
+use futures::StreamExt;
+use std::fmt::Debug;
+use std::sync::Arc;
+
+/// Broker-neutral surface the intra-hive mesh requires.
+///
+/// Subjects follow the `b00t.hive.mesh.*` namespace (see `mesh.rs`). Reply
+/// semantics are expressed by publishing to a subject (the querier's own inbox),
+/// so no broker-specific reply primitive is needed.
+#[async_trait]
+pub trait HiveTransport: Send + Sync + Debug {
+    /// Establish the broker connection for `url` (URL form is transport-defined).
+    async fn connect(&self, url: &str) -> ChatResult<()>;
+    /// Fire-and-forget publish of raw bytes to a subject.
+    async fn publish(&self, subject: &str, payload: &[u8]) -> ChatResult<()>;
+    /// Subscribe to a subject; yields raw frame payloads as they arrive.
+    async fn subscribe(&self, subject: &str) -> ChatResult<BoxStream<'static, Vec<u8>>>;
+    /// Transport kind, for telemetry.
+    fn kind(&self) -> TransportKind;
+    /// Whether a connection is currently established.
+    async fn is_available(&self) -> bool;
+    /// Tear down the connection.
+    async fn close(&self) -> ChatResult<()>;
+}
+
+#[cfg(feature = "nats")]
+pub use nats_impl::NatsHiveTransport;
+
+#[cfg(feature = "nats")]
+mod nats_impl {
+    use super::*;
+    use tokio::sync::RwLock;
+
+    /// NATS-backed hive transport (the default broker).
+    #[derive(Debug, Default)]
+    pub struct NatsHiveTransport {
+        client: Arc<RwLock<Option<async_nats::Client>>>,
+    }
+
+    impl NatsHiveTransport {
+        pub fn new() -> Self {
+            Self::default()
+        }
+    }
+
+    #[async_trait]
+    impl HiveTransport for NatsHiveTransport {
+        async fn connect(&self, url: &str) -> ChatResult<()> {
+            let client = async_nats::connect(url)
+                .await
+                .map_err(|e| ChatError::Nats(e.to_string()))?;
+            *self.client.write().await = Some(client);
+            Ok(())
+        }
+
+        async fn publish(&self, subject: &str, payload: &[u8]) -> ChatResult<()> {
+            let client = {
+                let guard = self.client.read().await;
+                guard
+                    .as_ref()
+                    .ok_or_else(|| ChatError::Other("hive transport not connected".into()))?
+                    .clone()
+            };
+            let bytes = bytes::Bytes::copy_from_slice(payload);
+            client
+                .publish(subject.to_string(), bytes)
+                .await
+                .map_err(|e| ChatError::Nats(e.to_string()))
+        }
+
+        async fn subscribe(&self, subject: &str) -> ChatResult<BoxStream<'static, Vec<u8>>> {
+            let client = {
+                let guard = self.client.read().await;
+                guard
+                    .as_ref()
+                    .ok_or_else(|| ChatError::Other("hive transport not connected".into()))?
+                    .clone()
+            };
+            let sub = client
+                .subscribe(subject.to_string())
+                .await
+                .map_err(|e| ChatError::Nats(e.to_string()))?;
+            let stream = sub.map(|m| m.payload.to_vec());
+            Ok(Box::pin(stream))
+        }
+
+        fn kind(&self) -> TransportKind {
+            TransportKind::Nats
+        }
+
+        async fn is_available(&self) -> bool {
+            self.client.read().await.is_some()
+        }
+
+        async fn close(&self) -> ChatResult<()> {
+            *self.client.write().await = None;
+            Ok(())
+        }
+    }
+}
+
+/// In-process pub/sub transport — fully broker-free.
+///
+/// All clones share one registry (Arc), so multiple `NatsMeshNode`s built from
+/// cloned `MemoryHiveTransport`s communicate with no external broker. This backs
+/// the gossip-first discovery path and broker-free tests.
+#[derive(Debug, Clone, Default)]
+pub struct MemoryHiveTransport {
+    subs: Arc<tokio::sync::Mutex<std::collections::HashMap<String, Vec<tokio::sync::broadcast::Sender<Vec<u8>>>>>>,
+}
+
+impl MemoryHiveTransport {
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+#[async_trait]
+impl HiveTransport for MemoryHiveTransport {
+    async fn connect(&self, _url: &str) -> ChatResult<()> {
+        Ok(())
+    }
+
+    async fn publish(&self, subject: &str, payload: &[u8]) -> ChatResult<()> {
+        let subs = self.subs.lock().await;
+        if let Some(senders) = subs.get(subject) {
+            for s in senders {
+                let _ = s.send(payload.to_vec());
+            }
+        }
+        Ok(())
+    }
+
+    async fn subscribe(&self, subject: &str) -> ChatResult<BoxStream<'static, Vec<u8>>> {
+        use tokio_stream::wrappers::BroadcastStream;
+        let (tx, rx) = tokio::sync::broadcast::channel(1024);
+        self.subs
+            .lock()
+            .await
+            .entry(subject.to_string())
+            .or_default()
+            .push(tx);
+        // Drop lagged/closed signals; keep only live payloads.
+        let stream = BroadcastStream::new(rx).filter_map(|r| async move {
+            match r {
+                Ok(v) => Some(v),
+                Err(_) => None,
+            }
+        });
+        Ok(Box::pin(stream))
+    }
+
+    fn kind(&self) -> TransportKind {
+        TransportKind::Memory
+    }
+
+    async fn is_available(&self) -> bool {
+        true
+    }
+
+    async fn close(&self) -> ChatResult<()> {
+        self.subs.lock().await.clear();
+        Ok(())
+    }
+}
+
+/// Iroh-backed hive transport (feature `iroh`) — strategic NodeId/QUIC substrate.
+///
+/// Stub: the iroh crate is not yet wired. Enabling feature `iroh` compiles this
+/// placeholder; real endpoint dialing + topic gossip is the follow-up that makes
+/// iroh a drop-in alternate to the NATS broker for intra-hive discovery.
+#[cfg(feature = "iroh")]
+pub use iroh_impl::IrohHiveTransport;
+
+#[cfg(feature = "iroh")]
+mod iroh_impl {
+    use super::*;
+
+    #[derive(Debug, Default)]
+    pub struct IrohHiveTransport {
+        _node: Option<()>,
+    }
+
+    impl IrohHiveTransport {
+        pub fn new() -> Self {
+            Self::default()
+        }
+    }
+
+    #[async_trait]
+    impl HiveTransport for IrohHiveTransport {
+        async fn connect(&self, _url: &str) -> ChatResult<()> {
+            Err(ChatError::Other(
+                "iroh HiveTransport not yet implemented — wire the iroh node/endpoint and topic gossip"
+                    .into(),
+            ))
+        }
+        async fn publish(&self, _subject: &str, _payload: &[u8]) -> ChatResult<()> {
+            Err(ChatError::Other("iroh HiveTransport not yet implemented".into()))
+        }
+        async fn subscribe(&self, _subject: &str) -> ChatResult<BoxStream<'static, Vec<u8>>> {
+            Err(ChatError::Other("iroh HiveTransport not yet implemented".into()))
+        }
+        fn kind(&self) -> TransportKind {
+            TransportKind::Iroh
+        }
+        async fn is_available(&self) -> bool {
+            false
+        }
+        async fn close(&self) -> ChatResult<()> {
+            Ok(())
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn memory_transport_delivers_published_frames() {
+        let shared = Arc::new(MemoryHiveTransport::new());
+        let sub = shared.subscribe("b00t.hive.mesh.node.a").await.unwrap();
+        shared
+            .publish("b00t.hive.mesh.node.a", b"hello")
+            .await
+            .unwrap();
+        let mut sub = sub;
+        let got = sub.next().await.unwrap();
+        assert_eq!(got, b"hello");
+    }
+}

--- a/b00t-lib-chat/src/ipc_transport.rs
+++ b/b00t-lib-chat/src/ipc_transport.rs
@@ -126,6 +126,7 @@ pub enum TransportKind {
     Nats,
     Tcp,
     Memory, // For testing
+    Iroh,   // iroh NodeId/QUIC substrate (strategic hive transport)
 }
 
 impl std::fmt::Display for TransportKind {
@@ -136,6 +137,7 @@ impl std::fmt::Display for TransportKind {
             TransportKind::Nats => write!(f, "nats"),
             TransportKind::Tcp => write!(f, "tcp"),
             TransportKind::Memory => write!(f, "memory"),
+            TransportKind::Iroh => write!(f, "iroh"),
         }
     }
 }

--- a/b00t-lib-chat/src/lib.rs
+++ b/b00t-lib-chat/src/lib.rs
@@ -32,6 +32,7 @@ pub mod discovery;
 pub mod dataframe_receipt;
 pub mod error;
 pub mod gossip;
+pub mod hive_transport;
 pub mod ipc_transport;
 pub mod ledgrrr;
 pub mod mesh;

--- a/b00t-lib-chat/src/mesh.rs
+++ b/b00t-lib-chat/src/mesh.rs
@@ -27,23 +27,42 @@
 //! [`crate::ipc_transport::DiscoverableTransport`] trait so it can slot into
 //! `b00t agent discover` plumbing.
 
-use crate::error::{ChatError, ChatResult};
+use crate::error::ChatResult;
 use crate::gossip::GossipTable;
-use crate::ipc_transport::{
-    AgentEndpoint, AgentEvent, AgentWatcher, DiscoverableTransport, TransportKind,
-};
+use crate::hive_transport::HiveTransport;
+#[cfg(not(feature = "nats"))]
+use crate::hive_transport::MemoryHiveTransport;
+use crate::ipc_transport::{AgentEndpoint, AgentEvent, AgentWatcher, DiscoverableTransport};
 use crate::ledgrrr::{FinopsCode, Ledgrrr, UsageReceipt};
 use crate::message::ChatMessage;
 use ufo_types::{Stereotyped, UfoStereotype};
-use async_nats::Subscriber;
 use async_trait::async_trait;
+use futures::stream::BoxStream;
 use futures::StreamExt;
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::{Duration, SystemTime};
 use tokio::sync::{mpsc, RwLock};
 use tokio_stream::wrappers::ReceiverStream;
 use tracing::{info, warn};
+
+#[cfg(feature = "nats")]
+use crate::hive_transport::NatsHiveTransport;
+
+/// The default transport for a mesh node. With the `nats` feature enabled this
+/// is the NATS broker; without it (e.g. `#[cfg]`-disabled broker), it falls back
+/// to the in-process broker-free [`MemoryHiveTransport`] so the mesh still runs.
+fn default_transport() -> Arc<dyn HiveTransport> {
+    #[cfg(feature = "nats")]
+    {
+        Arc::new(NatsHiveTransport::new())
+    }
+    #[cfg(not(feature = "nats"))]
+    {
+        Arc::new(MemoryHiveTransport::new())
+    }
+}
 
 /// Subject prefix for a node's direct inbox (always intra-hive, same network).
 const NODE_PREFIX: &str = "b00t.hive.mesh.node.";
@@ -164,6 +183,9 @@ pub struct MeshNodeConfig {
     /// Optional ledgrrr ledger; when set, every capability execution registers
     /// a usage receipt and mints a finops code.
     pub ledgrrr: Option<Arc<dyn Ledgrrr>>,
+    /// Broker-neutral transport. Defaults to NATS (or in-memory when the `nats`
+    /// feature is disabled) so the mesh runs broker-free if desired.
+    pub transport: Arc<dyn HiveTransport>,
 }
 
 impl MeshNodeConfig {
@@ -179,7 +201,15 @@ impl MeshNodeConfig {
             gossip_max_hops: DEFAULT_GOSSIP_MAX_HOPS,
             project: "b00t-comms".to_string(),
             ledgrrr: None,
+            transport: default_transport(),
         }
+    }
+
+    /// Override the hive transport (e.g. plug in [`MemoryHiveTransport`] for a
+    /// broker-free node, or an iroh-backed transport once available).
+    pub fn with_transport(mut self, transport: Arc<dyn HiveTransport>) -> Self {
+        self.transport = transport;
+        self
     }
 
     pub fn with_role(mut self, role: impl Into<String>) -> Self {
@@ -216,6 +246,7 @@ impl std::fmt::Debug for MeshNodeConfig {
             .field("project", &self.project)
             .field("nats_url", &self.nats_url)
             .field("gossip_max_hops", &self.gossip_max_hops)
+            .field("transport", &self.transport.kind())
             .field("ledgrrr", &self.ledgrrr.is_some())
             .finish()
     }
@@ -230,7 +261,8 @@ impl std::fmt::Debug for MeshNodeConfig {
 #[derive(Clone)]
 pub struct NatsMeshNode {
     config: MeshNodeConfig,
-    client: Arc<RwLock<Option<async_nats::Client>>>,
+    /// Broker-neutral transport (NATS by default; memory/iroh pluggable).
+    transport: Arc<dyn HiveTransport>,
     /// Known peers + gossip membership (presence + sequence + hop budget).
     peers: Arc<RwLock<GossipTable>>,
     /// Application-facing inbound frames.
@@ -239,7 +271,22 @@ pub struct NatsMeshNode {
     /// Forwarding task handles, aborted on close.
     forwards: Arc<RwLock<Vec<tokio::task::JoinHandle<()>>>>,
     presence_task: Arc<RwLock<Option<tokio::task::JoinHandle<()>>>>,
+    /// Per-node lifecycle flag (separate from the transport's, so multiple nodes
+    /// sharing one in-process transport each manage their own inbound tasks).
+    live: Arc<AtomicBool>,
     ledgrrr: Option<Arc<dyn Ledgrrr>>,
+}
+
+impl NatsMeshNode {
+    /// The broker-neutral transport backing this node.
+    pub fn transport(&self) -> &Arc<dyn HiveTransport> {
+        &self.transport
+    }
+
+    /// Whether this node has connected and spawned its inbound tasks.
+    pub fn is_connected(&self) -> bool {
+        self.live.load(Ordering::SeqCst)
+    }
 }
 
 impl Stereotyped for NatsMeshNode {
@@ -263,13 +310,14 @@ impl NatsMeshNode {
         let ledgrrr = config.ledgrrr.clone();
         let (inbox_tx, inbox_rx) = mpsc::channel(256);
         Self {
+            transport: config.transport.clone(),
             config,
-            client: Arc::new(RwLock::new(None)),
             peers: Arc::new(RwLock::new(GossipTable::new(DEFAULT_GOSSIP_MAX_HOPS))),
             inbox_tx,
             inbox_rx: Arc::new(RwLock::new(Some(inbox_rx))),
             forwards: Arc::new(RwLock::new(Vec::new())),
             presence_task: Arc::new(RwLock::new(None)),
+            live: Arc::new(AtomicBool::new(false)),
             ledgrrr,
         }
     }
@@ -293,71 +341,51 @@ impl NatsMeshNode {
         Ok(Some(code))
     }
 
-    /// Connect to NATS and start the inbound forwarding task.
+    /// Connect the transport and start the inbound forwarding tasks.
     pub async fn connect(&self) -> ChatResult<()> {
-        let mut guard = self.client.write().await;
-        if guard.is_some() {
+        if self.live.swap(true, Ordering::SeqCst) {
             return Ok(());
         }
-        let client = async_nats::ConnectOptions::new()
-            .connect(&self.config.nats_url)
-            .await
-            .map_err(|e| ChatError::Nats(e.to_string()))?;
-        *guard = Some(client);
-        drop(guard);
-
+        self.transport.connect(&self.config.nats_url).await?;
         self.spawn_inbound().await?;
-        info!("NATS mesh node connected: {}", self.config.agent_id);
+        info!(
+            "hive mesh node connected ({:?}): {}",
+            self.transport.kind(),
+            self.config.agent_id
+        );
         Ok(())
-    }
-
-    async fn client(&self) -> ChatResult<async_nats::Client> {
-        self.client
-            .read()
-            .await
-            .clone()
-            .ok_or(ChatError::NotConnected)
     }
 
     /// Subscribe to the inbox, presence, gossip, discovery-query, and any
     /// joined channels; forward every frame into the application inbox.
     async fn spawn_inbound(&self) -> ChatResult<()> {
-        let client = self.client().await?;
         let mut handles = self.forwards.write().await;
 
-        let inbox_sub = client
-            .subscribe(node_subject(&self.config.agent_id))
-            .await
-            .map_err(|e| ChatError::Nats(e.to_string()))?;
-        handles.push(self.forward(client.clone(), inbox_sub));
+        let inbox_stream = self
+            .transport
+            .subscribe(&node_subject(&self.config.agent_id))
+            .await?;
+        handles.push(self.forward_stream(inbox_stream));
 
-        let presence_sub = client
-            .subscribe(DISCOVERY_PRESENCE)
-            .await
-            .map_err(|e| ChatError::Nats(e.to_string()))?;
-        handles.push(self.forward(client.clone(), presence_sub));
+        let presence_stream = self.transport.subscribe(DISCOVERY_PRESENCE).await?;
+        handles.push(self.forward_stream(presence_stream));
 
-        let gossip_sub = client
-            .subscribe(DISCOVERY_GOSSIP)
-            .await
-            .map_err(|e| ChatError::Nats(e.to_string()))?;
-        handles.push(self.forward(client.clone(), gossip_sub));
+        let gossip_stream = self.transport.subscribe(DISCOVERY_GOSSIP).await?;
+        handles.push(self.forward_stream(gossip_stream));
 
-        let query_sub = client
-            .subscribe(DISCOVERY_QUERY)
-            .await
-            .map_err(|e| ChatError::Nats(e.to_string()))?;
-        handles.push(self.forward(client.clone(), query_sub));
+        let query_stream = self.transport.subscribe(DISCOVERY_QUERY).await?;
+        handles.push(self.forward_stream(query_stream));
 
         Ok(())
     }
 
-    fn forward(
-        &self,
-        client: async_nats::Client,
-        mut sub: Subscriber,
-    ) -> tokio::task::JoinHandle<()> {
+    /// Consume a transport frame stream, demultiplex/discover/gossip, and forward
+    /// application frames into the inbox. Re-gossip and discovery replies are
+    /// published back through the same broker-neutral transport — no NATS reply
+    /// semantics are assumed.
+    fn forward_stream(&self, mut stream: BoxStream<'static, Vec<u8>>) -> tokio::task::JoinHandle<()> {
         let inbox_tx = self.inbox_tx.clone();
+        let transport = self.transport.clone();
         let agent_id = self.config.agent_id.clone();
         let peers = self.peers.clone();
         let this_role = self.config.role.clone();
@@ -365,8 +393,8 @@ impl NatsMeshNode {
         let endpoint_uri = node_subject(&agent_id);
         let ttl = self.config.presence_ttl;
         tokio::spawn(async move {
-            while let Some(msg) = sub.next().await {
-                let frame: MeshFrame = match serde_json::from_slice(&msg.payload) {
+            while let Some(payload) = stream.next().await {
+                let frame: MeshFrame = match serde_json::from_slice(&payload) {
                     Ok(f) => f,
                     Err(e) => {
                         warn!("mesh: dropping undecodable frame: {}", e);
@@ -392,7 +420,7 @@ impl NatsMeshNode {
                                 hops: remaining,
                             };
                             if let Ok(payload) = serde_json::to_vec(&re) {
-                                let _ = client.publish(DISCOVERY_GOSSIP, payload.into()).await;
+                                let _ = transport.publish(DISCOVERY_GOSSIP, &payload).await;
                             }
                         }
                     }
@@ -432,22 +460,20 @@ impl NatsMeshNode {
                                     0,
                                 );
                             }
-                            // Answer the query on its NATS reply inbox.
-                            if let Some(reply) = &msg.reply {
-                                let reply_frame = MeshFrame::DiscoveryReply {
-                                    endpoint: AgentEndpoint {
-                                        agent_id: agent_id.clone(),
-                                        endpoint_uri: endpoint_uri.clone(),
-                                        transport_kind: TransportKind::Nats,
-                                        last_seen: SystemTime::now(),
-                                        metadata: None,
-                                    },
-                                    role: this_role.clone(),
-                                    skills: this_skills.clone(),
-                                };
-                                if let Ok(payload) = serde_json::to_vec(&reply_frame) {
-                                    let _ = client.publish(reply.clone(), payload.into()).await;
-                                }
+                            // Answer the query on the querier's own inbox.
+                            let reply_frame = MeshFrame::DiscoveryReply {
+                                endpoint: AgentEndpoint {
+                                    agent_id: agent_id.clone(),
+                                    endpoint_uri: endpoint_uri.clone(),
+                                    transport_kind: transport.kind(),
+                                    last_seen: SystemTime::now(),
+                                    metadata: None,
+                                },
+                                role: this_role.clone(),
+                                skills: this_skills.clone(),
+                            };
+                            if let Ok(payload) = serde_json::to_vec(&reply_frame) {
+                                let _ = transport.publish(&node_subject(from), &payload).await;
                             }
                         }
                     }
@@ -462,19 +488,14 @@ impl NatsMeshNode {
 
     /// Join a pub/sub channel (start receiving broadcasts on it).
     pub async fn join(&self, channel: &str) -> ChatResult<()> {
-        let client = self.client().await?;
-        let sub = client
-            .subscribe(channel_subject(channel))
-            .await
-            .map_err(|e| ChatError::Nats(e.to_string()))?;
-        self.forwards.write().await.push(self.forward(client, sub));
+        let sub = self.transport.subscribe(&channel_subject(channel)).await?;
+        self.forwards.write().await.push(self.forward_stream(sub));
         Ok(())
     }
 
     /// Announce presence: gossip an advertisement (bounded hop budget) and emit
     /// a plain presence heartbeat for backward compatibility.
     pub async fn announce(&self) -> ChatResult<()> {
-        let client = self.client().await?;
         let presence = AgentPresence {
             agent_id: self.config.agent_id.clone(),
             role: self.config.role.clone(),
@@ -494,17 +515,15 @@ impl NatsMeshNode {
             seq,
             hops: self.config.gossip_max_hops,
         };
-        client
-            .publish(DISCOVERY_GOSSIP, serde_json::to_vec(&gossip)?.into())
-            .await
-            .map_err(|e| ChatError::Nats(e.to_string()))?;
-        client
+        self.transport
+            .publish(DISCOVERY_GOSSIP, &serde_json::to_vec(&gossip)?)
+            .await?;
+        self.transport
             .publish(
                 DISCOVERY_PRESENCE,
-                serde_json::to_vec(&MeshFrame::Presence(presence))?.into(),
+                &serde_json::to_vec(&MeshFrame::Presence(presence))?,
             )
-            .await
-            .map_err(|e| ChatError::Nats(e.to_string()))?;
+            .await?;
         self.record_usage(&self.config.project, "nats.presence", 1)
             .await
             .ok();
@@ -535,18 +554,15 @@ impl NatsMeshNode {
 
     /// Discover peers, waiting up to `timeout` for fresh replies.
     pub async fn discover_with_timeout(&self, timeout: Duration) -> ChatResult<Vec<AgentEndpoint>> {
-        let client = self.client().await?;
         let query = MeshFrame::DiscoveryQuery {
             from: self.config.agent_id.clone(),
             role: self.config.role.clone(),
             skills: self.config.skills.clone(),
         };
         let payload = serde_json::to_vec(&query)?;
-        let reply = node_subject(&self.config.agent_id);
-        client
-            .publish_with_reply(DISCOVERY_QUERY, reply, payload.into())
-            .await
-            .map_err(|e| ChatError::Nats(e.to_string()))?;
+        // Reply target is the querier's own inbox (encoded in `from`); no broker
+        // reply semantics required, so this works on any HiveTransport.
+        self.transport.publish(DISCOVERY_QUERY, &payload).await?;
         // Also announce so peers learn us (and gossip propagates).
         self.announce().await.ok();
         self.record_usage(&self.config.project, "nats.discover", 1)
@@ -603,29 +619,23 @@ impl NatsMeshNode {
 
     /// Send a direct (point-to-point) message to a specific agent id.
     pub async fn send(&self, to_agent: &str, message: &ChatMessage) -> ChatResult<()> {
-        let client = self.client().await?;
         let frame = MeshFrame::Direct(message.clone());
         let payload = serde_json::to_vec(&frame)?;
-        client
-            .publish(node_subject(to_agent), payload.into())
-            .await
-            .map_err(|e| ChatError::Nats(e.to_string()))?;
+        self.transport.publish(&node_subject(to_agent), &payload).await?;
         self.record_usage(&self.config.project, "nats.send", 1).await?;
         Ok(())
     }
 
     /// Broadcast a message to every subscriber of `channel`.
     pub async fn publish(&self, channel: &str, message: &ChatMessage) -> ChatResult<()> {
-        let client = self.client().await?;
         let frame = MeshFrame::Broadcast {
             channel: channel.to_string(),
             message: message.clone(),
         };
         let payload = serde_json::to_vec(&frame)?;
-        client
-            .publish(channel_subject(channel), payload.into())
-            .await
-            .map_err(|e| ChatError::Nats(e.to_string()))?;
+        self.transport
+            .publish(&channel_subject(channel), &payload)
+            .await?;
         self.record_usage(&self.config.project, "nats.broadcast", 1)
             .await?;
         Ok(())
@@ -653,7 +663,7 @@ impl NatsMeshNode {
             .peer_count(&self.config.agent_id, self.config.presence_ttl)
     }
 
-    /// Gracefully close: abort forwarding + presence tasks, drop client.
+    /// Gracefully close: abort forwarding + presence tasks, drop transport.
     pub async fn close(&self) -> ChatResult<()> {
         if let Some(task) = self.presence_task.write().await.take() {
             task.abort();
@@ -661,8 +671,9 @@ impl NatsMeshNode {
         for handle in self.forwards.write().await.drain(..) {
             handle.abort();
         }
-        *self.client.write().await = None;
-        info!("NATS mesh node closed: {}", self.config.agent_id);
+        self.live.store(false, Ordering::SeqCst);
+        self.transport.close().await.ok();
+        info!("hive mesh node closed: {}", self.config.agent_id);
         Ok(())
     }
 }

--- a/b00t-lib-chat/tests/hive_transport_integration.rs
+++ b/b00t-lib-chat/tests/hive_transport_integration.rs
@@ -1,0 +1,79 @@
+//! Broker-free integration test for the hive transport abstraction.
+//!
+//! Two `NatsMeshNode`s share one in-process [`MemoryHiveTransport`] (no NATS
+//! broker). Gossip is the initial discovery mechanism that hands off to the
+//! (memory) broker: `announce` gossips presence, `discover` publishes a query,
+//! peers learn each other via gossip + query/reply, and direct send/recv works.
+
+use b00t_chat::hive_transport::MemoryHiveTransport;
+use b00t_chat::mesh::{MeshNodeConfig, MeshFrame, NatsMeshNode};
+use std::sync::Arc;
+use tokio::time::Duration;
+
+#[tokio::test]
+async fn memory_transport_mesh_discovers_via_gossip() {
+    let shared = Arc::new(MemoryHiveTransport::new());
+
+    let a = NatsMeshNode::new(
+        MeshNodeConfig::new("alpha", "memory://local")
+            .with_transport(shared.clone())
+            .with_project("test"),
+    );
+    let b = NatsMeshNode::new(
+        MeshNodeConfig::new("bravo", "memory://local")
+            .with_transport(shared.clone())
+            .with_project("test"),
+    );
+
+    a.connect().await.unwrap();
+    b.connect().await.unwrap();
+    // Let the inbound forwarding tasks poll their streams before publishing.
+    tokio::time::sleep(Duration::from_millis(150)).await;
+
+    // Gossip-driven discovery: alpha announces, bravo learns via epidemic gossip.
+    a.announce().await.unwrap();
+    b.announce().await.unwrap();
+    tokio::time::sleep(Duration::from_millis(150)).await;
+
+    let discovered = a.discover_with_timeout(Duration::from_millis(500)).await.unwrap();
+    let ids: Vec<&str> = discovered.iter().map(|e| e.agent_id.as_str()).collect();
+    assert!(ids.contains(&"bravo"), "alpha should discover bravo via gossip: {ids:?}");
+
+    let discovered_b = b.discover_with_timeout(Duration::from_millis(500)).await.unwrap();
+    let ids_b: Vec<&str> = discovered_b.iter().map(|e| e.agent_id.as_str()).collect();
+    assert!(ids_b.contains(&"alpha"), "bravo should discover alpha: {ids_b:?}");
+
+    a.close().await.unwrap();
+    b.close().await.unwrap();
+}
+
+#[tokio::test]
+async fn memory_transport_direct_send_recv() {
+    let shared = Arc::new(MemoryHiveTransport::new());
+
+    let a = NatsMeshNode::new(
+        MeshNodeConfig::new("alpha", "memory://local").with_transport(shared.clone()),
+    );
+    let b = NatsMeshNode::new(
+        MeshNodeConfig::new("bravo", "memory://local").with_transport(shared.clone()),
+    );
+    a.connect().await.unwrap();
+    b.connect().await.unwrap();
+    a.announce().await.unwrap();
+
+    let msg = b00t_chat::message::ChatMessage::new("chan", "alpha", "hello bravo");
+    a.send("bravo", &msg).await.unwrap();
+
+    let frame = tokio::time::timeout(Duration::from_secs(2), b.recv())
+        .await
+        .unwrap()
+        .unwrap()
+        .unwrap();
+    match frame {
+        MeshFrame::Direct(m) => assert_eq!(m.body, "hello bravo"),
+        other => panic!("expected Direct frame, got {other:?}"),
+    }
+
+    a.close().await.unwrap();
+    b.close().await.unwrap();
+}


### PR DESCRIPTION
## Summary
Broker-neutral `HiveTransport` trait so NATS and iroh are both concrete impls; the mesh no longer depends on a raw NATS client. Stacks cleanly on the now-merged #653 (b00t.hive.mesh).

- `hive_transport.rs`: `HiveTransport` trait + `NatsHiveTransport` (cfg `nats`, default), `MemoryHiveTransport` (in-process, broker-free, shared-registry), `IrohHiveTransport` (cfg `iroh`, stub).
- `mesh.rs`: `NatsMeshNode` now holds `Arc<dyn HiveTransport>`; gossip remains the initial discovery that hands off to whichever broker is active. Per-node `AtomicBool` lifecycle so multiple nodes can share one in-process transport.
- `ipc_transport.rs`: add `TransportKind::Iroh`. `Cargo.toml`: `nats` (default, cfg-disablable) + `iroh` features; `tokio-stream` sync; `bytes` dep.

## Test plan
- Broker-free two-node integration (`tests/hive_transport_integration.rs`): gossip discovery + direct send/recv — **pass**.
- Builds green for `default`, `--no-default-features` (memory only), `--features dataframe`, `--features iroh`.
- Pre-rebase, the pre-push gate ran 923/927 b00t-cli tests pass (4 ignored).

## Dependency
Builds on #653 (squash-merged into `main`). This PR is the single transport-abstraction commit on top of `main`.

🤖 Generated with b00t agent (hive-mesh lane).