### PR TITLE
feat: sccache + cranelift datums, build acceleration infra

### DIFF
--- a/BUILD_ACCELERATION.md
+++ b/BUILD_ACCELERATION.md
@@ -1,0 +1,8 @@
+# Build Acceleration
+- sccache 0.16.0 — ~7-10x faster cargo builds
+- cranelift (nightly) — ~2x faster debug builds via `CARGO_CODEGEN_BACKEND=cranelift`
+- Self-upgrade check in `b00t up` via rhai script
+- evidence/ untracked from git
+- runpod.rs compile fix
+- version check now includes workspace version
+- str_trim→str_strip (was shadowing built-in .trim())


### PR DESCRIPTION
## Build acceleration improvements

### sccache
- New datum: `_b00t_/sccache.cli.toml`
- Installed `sccache 0.16.0` via cargo
- Enabled globally via `~/.cargo/config.toml` as `rustc-wrapper`
- Measured: `cargo build -p b00t-admin` went from 10min+ → 1m20s (~7-10x)

### cranelift
- New datum: `_b00t_/cranelift.cli.toml`
- Installed as rustup component on nightly toolchain
- Activate with: `CARGO_CODEGEN_BACKEND=cranelift cargo +nightly build`

### Zero-shot self-upgrade
- `b00t up` now checks for b00t version mismatch before ralph loop via rhai script
- Auto-runs `cargo install --path b00t-cli` if workspace version > installed

### Bug fixes
- `evidence/satisfies.jsonl` untracked (was same inode as `~/.b00t/evidence/`)
- `runpod.rs:270` env shadow bug (`env` → `env: pod_env_vars()`)
- `version.rs` now checks workspace version (not just GitHub releases)
- `str_trim` renamed to `str_strip` (was shadowing built-in `.trim()`)