### PR TITLE
feat: cherry-pick store-helixdb, irontology bridge, store lifecycle onto #687

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -319,8 +319,6 @@ ooda-state.json
 *.wasm
 # Generated/runtime artifacts
 _b00t_/k8s/serena-config/
-_b00t_/learn/typescript.md
-_b00t_/learn/whoami-agent-flag.md
 _b00t_/lmcache.capability.toml
 _b00t_/typescript.skill.toml
 evidence/

--- a/.gitignore
+++ b/.gitignore
@@ -317,3 +317,17 @@ session-guards.json
 exec-audit.json
 ooda-state.json
 *.wasm
+# Generated/runtime artifacts
+_b00t_/k8s/serena-config/
+_b00t_/learn/typescript.md
+_b00t_/learn/whoami-agent-flag.md
+_b00t_/lmcache.capability.toml
+_b00t_/typescript.skill.toml
+evidence/
+fine-tune/
+lfmf-telemetry.jsonl
+server-keys.json
+spotlight.jsonl
+unsloth_compiled_cache/
+vendor/pi-mono/
+"vscode.\360\237\206\232/vscode-docs/"

--- a/.mcp.json
+++ b/.mcp.json
@@ -47,6 +47,10 @@
         "http://localhost:3000/sse"
       ],
       "env": {}
+    },
+    "ledgrrr": {
+      "command": "/home/brianh/.local/bin/ledgerr-mcp-server",
+      "type": "stdio"
     }
   }
 }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1366,7 +1366,7 @@ version = "0.1.0"
 
 [[package]]
 name = "b00t-admin"
-version = "0.9.5"
+version = "0.9.9"
 dependencies = [
  "axum 0.8.9",
  "b00t-c0re-lib",
@@ -1388,7 +1388,7 @@ dependencies = [
 
 [[package]]
 name = "b00t-ast"
-version = "0.9.5"
+version = "0.9.9"
 dependencies = [
  "anyhow",
  "clap",
@@ -1404,7 +1404,7 @@ dependencies = [
 
 [[package]]
 name = "b00t-azure-cp"
-version = "0.9.5"
+version = "0.9.9"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -1428,7 +1428,7 @@ dependencies = [
 
 [[package]]
 name = "b00t-bouncer"
-version = "0.9.5"
+version = "0.9.9"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1442,7 +1442,7 @@ dependencies = [
 
 [[package]]
 name = "b00t-c0re-a2a"
-version = "0.9.5"
+version = "0.9.9"
 dependencies = [
  "chrono",
  "serde",
@@ -1455,7 +1455,7 @@ dependencies = [
 
 [[package]]
 name = "b00t-c0re-gov"
-version = "0.9.5"
+version = "0.9.9"
 dependencies = [
  "async-trait",
  "b00t-c0re-lib",
@@ -1470,7 +1470,7 @@ dependencies = [
 
 [[package]]
 name = "b00t-c0re-hierarchy"
-version = "0.9.5"
+version = "0.9.9"
 dependencies = [
  "b00t-c0re-gov",
  "chrono",
@@ -1482,7 +1482,7 @@ dependencies = [
 
 [[package]]
 name = "b00t-c0re-lib"
-version = "0.9.5"
+version = "0.9.9"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -1497,6 +1497,7 @@ dependencies = [
  "duct",
  "futures",
  "grafeo",
+ "helix-db",
  "hex",
  "keyring",
  "lazy_static",
@@ -1542,7 +1543,7 @@ dependencies = [
 
 [[package]]
 name = "b00t-chat"
-version = "0.9.5"
+version = "0.9.9"
 dependencies = [
  "anyhow",
  "arrow",
@@ -1585,7 +1586,7 @@ dependencies = [
 
 [[package]]
 name = "b00t-cli"
-version = "0.9.5"
+version = "0.9.9"
 dependencies = [
  "anyhow",
  "apalis",
@@ -1678,7 +1679,7 @@ dependencies = [
 
 [[package]]
 name = "b00t-datum-core"
-version = "0.9.5"
+version = "0.9.9"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1690,7 +1691,7 @@ dependencies = [
 
 [[package]]
 name = "b00t-embed"
-version = "0.9.5"
+version = "0.9.9"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1711,7 +1712,7 @@ dependencies = [
 
 [[package]]
 name = "b00t-grok"
-version = "0.9.5"
+version = "0.9.9"
 dependencies = [
  "anyhow",
  "async-openai",
@@ -1730,7 +1731,7 @@ dependencies = [
 
 [[package]]
 name = "b00t-ipc"
-version = "0.9.5"
+version = "0.9.9"
 dependencies = [
  "anyhow",
  "async-nats",
@@ -1750,7 +1751,7 @@ dependencies = [
 
 [[package]]
 name = "b00t-l3dg3rr-viz"
-version = "0.9.5"
+version = "0.9.9"
 dependencies = [
  "blake3",
  "kasuari",
@@ -1761,7 +1762,7 @@ dependencies = [
 
 [[package]]
 name = "b00t-lsp"
-version = "0.9.5"
+version = "0.9.9"
 dependencies = [
  "anyhow",
  "b00t-datum-core",
@@ -1775,7 +1776,7 @@ dependencies = [
 
 [[package]]
 name = "b00t-mcp"
-version = "0.9.5"
+version = "0.9.9"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -1819,7 +1820,7 @@ dependencies = [
 
 [[package]]
 name = "b00t-mermaid-wasm"
-version = "0.9.5"
+version = "0.9.9"
 dependencies = [
  "mermaid-rs-renderer",
  "wasm-bindgen",
@@ -1827,7 +1828,7 @@ dependencies = [
 
 [[package]]
 name = "b00t-py"
-version = "0.9.5"
+version = "0.9.9"
 dependencies = [
  "anyhow",
  "b00t-c0re-lib",
@@ -1842,14 +1843,14 @@ dependencies = [
 
 [[package]]
 name = "b00t-reflect-types"
-version = "0.9.5"
+version = "0.9.9"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "b00t-ui-wasm"
-version = "0.9.5"
+version = "0.9.9"
 dependencies = [
  "dioxus",
  "dioxus-web",
@@ -1866,7 +1867,7 @@ dependencies = [
 
 [[package]]
 name = "b00t-zellij"
-version = "0.9.5"
+version = "0.9.9"
 dependencies = [
  "b00t-c0re-lib",
  "chrono",
@@ -4645,6 +4646,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
+name = "faststr"
+version = "0.2.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ca7d44d22004409a61c393afb3369c8f7bb74abcae49fe249ee01dcc3002113"
+dependencies = [
+ "bytes",
+ "rkyv",
+ "serde",
+ "simdutf8",
+]
+
+[[package]]
 name = "fax"
 version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5857,6 +5870,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "helix-db"
+version = "2.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677f1a3f2ae40782c06af09f5a7e4ad4141956f381ec9a2a2305c6b07fc75529"
+dependencies = [
+ "chrono",
+ "helix-dsl-macros",
+ "inventory",
+ "reqwest 0.13.4",
+ "serde",
+ "sonic-rs",
+ "thiserror 2.0.18",
+ "tokio",
+]
+
+[[package]]
+name = "helix-dsl-macros"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4708418e04e017cf1f4169591923697f270382f7cc86e53a2d44838218164354"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
 name = "hermit-abi"
 version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6620,6 +6660,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "inventory"
+version = "0.3.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4f0c30c76f2f4ccee3fe55a2435f691ca00c0e4bd87abe4f4a851b1d4dac39b"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6842,7 +6891,7 @@ dependencies = [
 
 [[package]]
 name = "k0mmand3r"
-version = "0.9.5"
+version = "0.9.9"
 dependencies = [
  "decimal-rs",
  "indexmap 2.14.0",
@@ -7715,6 +7764,26 @@ checksum = "f9563a7d5556636e74bbd8773241fbcbc5c89b9f6bfdc97b29b56e740c2c74b9"
 dependencies = [
  "typeid_prefix",
  "typeid_suffix",
+]
+
+[[package]]
+name = "munge"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e17401f259eba956ca16491461b6e8f72913a0a114e39736ce404410f915a0c"
+dependencies = [
+ "munge_macro",
+]
+
+[[package]]
+name = "munge_macro"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4568f25ccbd45ab5d5603dc34318c1ec56b117531781260002151b8530a9f931"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -9343,6 +9412,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "ptr_meta"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b9a0cf95a1196af61d4f1cbdab967179516d9a4a4312af1f31948f8f6224a79"
+dependencies = [
+ "ptr_meta_derive",
+]
+
+[[package]]
+name = "ptr_meta_derive"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7347867d0a7e1208d93b46767be83e2b8f978c3dad35f775ac8d8847551d6fe1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
 name = "pulldown-cmark"
 version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9590,6 +9679,15 @@ name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rancor"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daff8b7b3ccf5f7ba270b3e7a0a4d4c701c5797e38dec27c7e2c3dbb830fed1c"
+dependencies = [
+ "ptr_meta",
+]
 
 [[package]]
 name = "rand"
@@ -9969,6 +10067,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
+name = "rend"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "663ba70707f96e871406fe10d68128412e619b06d1d47cb91c3a4c6501176240"
+
+[[package]]
 name = "reqwest"
 version = "0.12.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10026,7 +10130,9 @@ checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
 dependencies = [
  "base64 0.22.1",
  "bytes",
+ "encoding_rs",
  "futures-core",
+ "h2",
  "http 1.4.2",
  "http-body",
  "http-body-util",
@@ -10035,6 +10141,7 @@ dependencies = [
  "hyper-util",
  "js-sys",
  "log",
+ "mime",
  "percent-encoding",
  "pin-project-lite",
  "quinn",
@@ -10175,6 +10282,35 @@ dependencies = [
  "oxilangtag",
  "oxiri",
  "rio_api",
+]
+
+[[package]]
+name = "rkyv"
+version = "0.8.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "815cc8a37159a463064825246cadb07961e25cd9885908606f6d08a98d8f8874"
+dependencies = [
+ "bytes",
+ "hashbrown 0.17.1",
+ "indexmap 2.14.0",
+ "munge",
+ "ptr_meta",
+ "rancor",
+ "rend",
+ "rkyv_derive",
+ "tinyvec",
+ "uuid",
+]
+
+[[package]]
+name = "rkyv_derive"
+version = "0.8.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0ed1a78a1b19d184b0daa629dd9a024573173ec7d485b287cb369fb3607cc1c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -11400,6 +11536,45 @@ dependencies = [
  "byteorder",
  "libc",
  "winapi",
+]
+
+[[package]]
+name = "sonic-number"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3775c3390edf958191f1ab1e8c5c188907feebd0f3ce1604cb621f72961dbf32"
+dependencies = [
+ "cfg-if 1.0.4",
+]
+
+[[package]]
+name = "sonic-rs"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d971cc77a245ccf1756dbd1a87c3e7f709c0191464096510d43eec056d0f2c4f"
+dependencies = [
+ "ahash",
+ "bumpalo",
+ "bytes",
+ "cfg-if 1.0.4",
+ "faststr",
+ "itoa",
+ "ref-cast",
+ "serde",
+ "simdutf8",
+ "sonic-number",
+ "sonic-simd",
+ "thiserror 2.0.18",
+ "zmij",
+]
+
+[[package]]
+name = "sonic-simd"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f99e664ecd2d85a68c87e3c7a3cfe691f647ea9e835de984aba4d54a41f817d4"
+dependencies = [
+ "cfg-if 1.0.4",
 ]
 
 [[package]]
@@ -12991,7 +13166,7 @@ dependencies = [
 
 [[package]]
 name = "ufo-types"
-version = "0.9.5"
+version = "0.9.9"
 dependencies = [
  "chrono",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ resolver = "2"
 [workspace.package]
 # 🤓 Version management centralized in b00t-c0re-lib
 # All workspace crates inherit from the single source of truth
-version = "0.9.5"
+version = "0.9.9"
 edition = "2024"
 authors = ["Brian Horakh <brian@promptexecution.com>"]
 license = "MIT"

--- a/_b00t_/datums/CAP-ONTOLOGY-INDEX.tomllmd
+++ b/_b00t_/datums/CAP-ONTOLOGY-INDEX.tomllmd
@@ -80,12 +80,19 @@ what      = "Walks Rust source via syn → RustTerm/OntologyGraph (Entity vs Act
 invoke    = "cargo run -p ontology-extractor -- --crate-path <PATH>"
 tier      = "ch0nky"
 
-[native.neumann_store]
+[native.helixdb_store]
 location  = "b00t-c0re-lib/src/irontology_bridge.rs"
-crate_dep = "storage-neumann = 0.1 (default feature)"
-what      = "Persistent fact store at ~/.b00t/neumann/<ns>/; FactRecord ingest + triple query"
+crate_dep = "helix-db = 2.0 (default feature)"
+what      = "Remote labeled-property-graph store via helix-db HTTP client; FactRecord + EdgeRecord CRUD"
 invoke    = "b00t grok digest --topic <TOPIC> <CONTENT>; b00t grok ask <QUERY>"
 mcp_tools = ["b00t_grok_digest", "b00t_grok_ask", "b00t_grok_learn", "b00t_grok_status"]
+tier      = "sm0l"
+
+[native.neumann_store]
+location  = "b00t-c0re-lib/src/irontology_bridge.rs (legacy, feature=store-neumann)"
+crate_dep = "storage-neumann = 0.1 (legacy)"
+what      = "ARCHIVED — Persistent fact store at ~/.b00t/neumann/<ns>/; use helixdb or oxigraph instead"
+status    = "ARCHIVED — not actively maintained"
 tier      = "sm0l"
 
 [native.oxigraph_store]

--- a/_b00t_/learn/typescript.md
+++ b/_b00t_/learn/typescript.md
@@ -1,0 +1,151 @@
+# TypeScript Canonical Patterns — assimilated from AllThingsSmitty/typescript-tips-everyone-should-know
+# 🤓 b00t learn typescript  →  loads all 15 patterns
+# 🤓 b00t grok ask "how to narrow types in typescript" -t typescript  → semantic search
+# 🤓 CC0-1.0 license — public domain, safe to use everywhere
+# Source: https://github.com/AllThingsSmitty/typescript-tips-everyone-should-know
+
+## 1. Prefer `unknown` over `any`
+
+`unknown` forces type narrowing before use. `any` disables the type system.
+
+```typescript
+function parse(data: unknown) {
+  if (typeof data === "string") return data.toUpperCase(); // OK
+  // data.toUpperCase(); // ERROR without check
+}
+```
+
+## 2. Let inference do the work
+
+Don't annotate types the compiler already knows.
+
+```typescript
+const name = "Ada";           // inferred: "Ada"
+const nums = [1, 2, 3];       // inferred: number[]
+// Better than: const name: string = "Ada"  — widens unnecessarily
+```
+
+## 3. Prefer `satisfies` over `as`
+
+`satisfies` validates shape while preserving literal types. `as` silently widens.
+
+```typescript
+const routes = { home: "/", about: "/about" } satisfies Record<string, string>;
+// routes.home is "/" (literal), not string
+```
+
+## 4. Derive types from values (single source of truth)
+
+Don't duplicate types from runtime values.
+
+```typescript
+const roles = ["admin", "user", "guest"] as const;
+type Role = (typeof roles)[number];  // "admin" | "user" | "guest"
+```
+
+## 5. Make invalid states impossible (discriminated unions)
+
+Prevent impossible combinations at the type level.
+
+```typescript
+type State =
+  | { status: "loading" }
+  | { status: "success"; data: User }
+  | { status: "error"; error: Error };
+// Cannot have data while loading. Cannot have error while success.
+```
+
+## 6. Exhaustive checks with `never`
+
+Compiler catches missing cases when you add new states.
+
+```typescript
+default: {
+  const _exhaustive: never = state; // Error if new state unhandled
+  return _exhaustive;
+}
+```
+
+## 7. `as const` for constants
+
+Preserves literal types instead of widening.
+
+```typescript
+const theme = { mode: "dark" } as const;
+// typeof theme.mode = "dark" (not string)
+```
+
+## 8. Type predicates for reusable narrowing
+
+Connect runtime checks to compile-time type narrowing.
+
+```typescript
+function isUser(v: unknown): v is User {
+  return typeof v === "object" && v !== null && "id" in v;
+}
+if (isUser(data)) data.id; // narrowed to User
+```
+
+## 9. Build types from existing types (utility types)
+
+Transform, don't duplicate.
+
+```typescript
+type Preview = Pick<User, "id" | "name">;
+type NoId = Omit<User, "id">;
+type PartialUser = Partial<User>;
+```
+Key utilities: `Pick`, `Omit`, `Partial`, `Required`, `ReturnType`, `Parameters`, indexed access `T["key"]`.
+
+## 10. Validate external data at runtime (zod)
+
+TypeScript types disappear at runtime. Validate API boundaries.
+
+```typescript
+const UserSchema = z.object({ id: z.string(), name: z.string() });
+type User = z.infer<typeof UserSchema>;
+```
+
+## 11. Avoid `enum` — use `as const` unions
+
+Literal unions are simpler to refactor, serialize, and type-narrow.
+
+```typescript
+const roles = ["admin", "user"] as const;  // prefer this
+// enum Role { Admin, User }              // over this
+```
+
+## 12. Prefer inferable generics
+
+Let TypeScript infer generic parameters from arguments.
+
+```typescript
+function first<T>(arr: T[]): T { return arr[0]; }
+first([1, 2, 3]); // T inferred as number, no explicit annotation
+```
+
+## 13. Enable strict compiler options
+
+The real payoff of TypeScript:
+
+```json
+{
+  "strict": true,
+  "useUnknownInCatchVariables": true,
+  "noUncheckedIndexedAccess": true,
+  "exactOptionalPropertyTypes": true
+}
+```
+
+## 14. Template literal types
+
+Powerful for routes, events, CSS, and query keys.
+
+```typescript
+type Route = `/api/${string}`;
+type EventName = `on${Capitalize<string>}`;
+```
+
+## 15. Type-safe ≠ runtime safe
+
+TypeScript improves correctness but doesn't validate at runtime. Always validate external boundaries (APIs, forms, env vars, user input).

--- a/_b00t_/learn/whoami-agent-flag.md
+++ b/_b00t_/learn/whoami-agent-flag.md
@@ -1,0 +1,2 @@
+---
+b00t whoami --agent=operator fails - 'unexpected argument --agent' in installed binary. Use: b00t whoami --agent=operator fails - 'unexpected argument --agent' in installed binary. Use --role=operator instead. Branch task/learn-role-agent-flag is implementing this. Dogfood lesson: always verify flag availability before using. <!-- salvaged:topic_overflow -->

--- a/b00t-c0re-lib/Cargo.toml
+++ b/b00t-c0re-lib/Cargo.toml
@@ -21,11 +21,12 @@ name = "generate_schemas"
 path = "src/bin/generate_schemas.rs"
 
 [features]
-default = ["store-neumann"]
+default = ["store-helixdb"]
 python = ["pyo3"]
 ledgrrr-events = []
-store-neumann = ["dep:storage-neumann"]
+store-neumann = ["dep:storage-neumann"]  # ARCHIVED/LEGACY — use store-helixdb or store-oxigraph
 store-oxigraph = ["dep:oxigraph"]
+store-helixdb = ["dep:helix-db"]
 oxigraph = ["store-oxigraph"]
 store-grafeo = ["dep:grafeo"]
 store-zvec = ["dep:zvec"]
@@ -74,6 +75,7 @@ futures = "0.3"
 cfg-if = "1.0.4"
 oxigraph = { version = "0.5.8", optional = true }
 storage-neumann = { version = "0.1", optional = true }
+helix-db = { version = "2.0", optional = true }
 grafeo = { version = "0.5.42", features = ["ai", "storage", "gql"], optional = true }
 zvec = { git = "https://github.com/zvec-ai/zvec-rust.git", tag = "v0.5.0", optional = true }
 b00t-ipc = { path = "../b00t-ipc", features = ["nats"], optional = true }

--- a/b00t-c0re-lib/src/irontology_bridge.rs
+++ b/b00t-c0re-lib/src/irontology_bridge.rs
@@ -5,27 +5,34 @@
 //! - `b00t_datum!` macro: declarative DSL → `DatumNode` literal
 //! - `IrontologyBridgeClient`: wraps the active store backend for ingest/query without MCP subprocess
 //!   (MCP transport pending: vendor/irontology-mcp has no main.rs yet)
-//! - Storage: Cargo-selected backend, using default paths
-//!   `~/.b00t/neumann/<namespace>/` for Neumann and
-//!   `~/.b00t/oxigraph/<namespace>/` for Oxigraph
+//! - Storage: Cargo-selected backend (`store-helixdb` default, `store-oxigraph` or legacy `store-neumann`)
+//!
+//! # Backends
+//! - **HelixDB** (default): remote labeled-property-graph via helix-db HTTP client
+//! - **Oxigraph**: embedded SPARQL 1.1 RDF store at `~/.b00t/oxigraph/<namespace>/`
+//! - **Neumann** (archived/legacy): embedded SQLite triple store at `~/.b00t/neumann/<namespace>/`
 //!
 //! # Semantic mapping
 //! b00t datum → irontology `FactRecord` triples:
 //!   subject   = `b00t:datum/<topic>/<uuid>`
 //!   predicate = `b00t:hasContent` | `b00t:hasTag` | `b00t:hasClass` | `<custom_predicate>`
 //!   object    = JSON Value (String for content/tags, object for complex predicates)
-//!
-//! 🤓 Embeddings deferred: NeumannStore accepts EmbeddingRecord but generation requires
-//!    active inference stack (vllm/ollama). Facts-only path works today; vector search
-//!    is additive once `b00t hive activate inference-qwen3` runs.
 
 use serde::{Deserialize, Serialize};
 
-#[cfg(all(feature = "store-neumann", feature = "store-oxigraph"))]
-compile_error!("Enable exactly one b00t-c0re-lib storage backend: store-neumann OR store-oxigraph.");
+#[cfg(any(
+    all(feature = "store-neumann", feature = "store-oxigraph"),
+    all(feature = "store-neumann", feature = "store-helixdb"),
+    all(feature = "store-oxigraph", feature = "store-helixdb"),
+))]
+compile_error!("Enable exactly one storage backend: store-neumann, store-oxigraph, or store-helixdb.");
 
-#[cfg(not(any(feature = "store-neumann", feature = "store-oxigraph")))]
-compile_error!("Enable one b00t-c0re-lib storage backend: store-neumann OR store-oxigraph.");
+#[cfg(not(any(
+    feature = "store-neumann",
+    feature = "store-oxigraph",
+    feature = "store-helixdb",
+)))]
+compile_error!("Enable one storage backend: store-neumann, store-oxigraph, or store-helixdb.");
 
 // ── Core datum type ───────────────────────────────────────────────────────────
 
@@ -103,6 +110,7 @@ pub struct StoreConfig {
     pub data_path: Option<std::path::PathBuf>,
 }
 
+#[deprecated(note = "Neumann is archived/legacy. Use helixdb (default) or oxigraph instead.")]
 pub type NeumannConfig = StoreConfig;
 
 #[async_trait::async_trait]
@@ -117,12 +125,16 @@ pub trait KnowledgeStoreBackend: Clone + Send + Sync + 'static {
 }
 
 cfg_if::cfg_if! {
-    if #[cfg(feature = "store-oxigraph")] {
+    if #[cfg(feature = "store-helixdb")] {
+        pub type ActiveKnowledgeStore = HelixDBStore;
+        pub const COMPILED_KNOWLEDGE_BACKEND: &str = "helixdb";
+    } else if #[cfg(feature = "store-oxigraph")] {
         pub type ActiveKnowledgeStore = OxigraphStore;
         pub const COMPILED_KNOWLEDGE_BACKEND: &str = "oxigraph";
     }
 }
 
+// Legacy / archived — Neumann is not actively maintained.
 #[cfg(feature = "store-neumann")]
 pub type ActiveKnowledgeStore = NeumannStore;
 
@@ -283,6 +295,176 @@ impl KnowledgeStoreBackend for NeumannStore {
         self.inner
             .upsert_edges(edges.into_iter().map(Into::into).collect())
             .await
+    }
+}
+
+// ── HelixDB Store (default) ──────────────────────────────────────────────
+// Facts stored as `"Fact"`-labeled nodes with subject/predicate/object properties.
+// Edges stored as `"Edge"`-labeled nodes with from/to/kind/weight properties.
+
+#[cfg(feature = "store-helixdb")]
+#[derive(Clone)]
+pub struct HelixDBStore {
+    client: std::sync::Arc<helix_db::Client>,
+}
+
+#[cfg(feature = "store-helixdb")]
+#[async_trait::async_trait]
+impl KnowledgeStoreBackend for HelixDBStore {
+    fn try_new(config: StoreConfig) -> anyhow::Result<Self> {
+        let url = if config.endpoint.is_empty()
+            || config.endpoint == "local"
+            || config.endpoint == "http://localhost:7777"
+        {
+            None
+        } else {
+            Some(config.endpoint.as_str())
+        };
+        let client = helix_db::Client::new(url)
+            .map_err(|e| anyhow::anyhow!("HelixDB client init error: {e}"))?;
+        Ok(Self {
+            client: std::sync::Arc::new(client),
+        })
+    }
+
+    async fn query(&self, query: SemanticQuery) -> anyhow::Result<QueryResult> {
+        use helix_db::dsl::prelude::*;
+
+        let traversal = match (&query.subject, &query.predicate) {
+            (None, None) => g()
+                .n_with_label("Fact")
+                .value_map(Some(vec!["subject", "predicate", "object"])),
+            _ => {
+                let mut preds = Vec::new();
+                if let Some(ref subject) = query.subject {
+                    preds.push(SourcePredicate::eq("subject", subject.clone()));
+                }
+                if let Some(ref predicate) = query.predicate {
+                    preds.push(SourcePredicate::eq("predicate", predicate.clone()));
+                }
+                let combined = preds
+                    .into_iter()
+                    .reduce(|a, b| SourcePredicate::and(vec![a, b]))
+                    .unwrap();
+                g().n_with_label_where("Fact", combined)
+                    .value_map(Some(vec!["subject", "predicate", "object"]))
+            }
+        };
+
+        let batch = read_batch()
+            .var_as("facts", traversal)
+            .returning(["facts"]);
+
+        let request = DynamicQueryRequest::read(batch);
+        let response: serde_json::Value = self
+            .client
+            .query()
+            .dynamic(request)
+            .send()
+            .await
+            .map_err(|e| anyhow::anyhow!("HelixDB query error: {e}"))?;
+
+        let facts = response["facts"]
+            .as_array()
+            .map(|arr| {
+                arr.iter()
+                    .filter_map(|item| {
+                        let subject = item["subject"].as_str()?.to_string();
+                        let predicate = item["predicate"].as_str()?.to_string();
+                        let object = match item["object"].as_str() {
+                            Some(s) => serde_json::Value::String(s.to_string()),
+                            None => item["object"].clone(),
+                        };
+                        Some(FactRecord {
+                            subject,
+                            predicate,
+                            object,
+                        })
+                    })
+                    .collect()
+            })
+            .unwrap_or_default();
+
+        Ok(QueryResult { facts })
+    }
+
+    async fn upsert_facts(&self, facts: Vec<FactRecord>) -> anyhow::Result<()> {
+        use helix_db::dsl::prelude::*;
+
+        if facts.is_empty() {
+            return Ok(());
+        }
+
+        let mut batch = write_batch();
+        let mut var_names = Vec::with_capacity(facts.len());
+        for (i, fact) in facts.iter().enumerate() {
+            let var_name = format!("f{i}");
+            let object_str = match &fact.object {
+                serde_json::Value::String(s) => s.clone(),
+                other => other.to_string(),
+            };
+            batch = batch.var_as(
+                &var_name,
+                g().add_n(
+                    "Fact",
+                    vec![
+                        ("subject", PropertyInput::from(fact.subject.clone())),
+                        ("predicate", PropertyInput::from(fact.predicate.clone())),
+                        ("object", PropertyInput::from(object_str)),
+                    ],
+                ),
+            );
+            var_names.push(var_name);
+        }
+        let batch = batch.returning(var_names);
+
+        let request = DynamicQueryRequest::write(batch);
+        self.client
+            .query::<serde_json::Value>()
+            .dynamic(request)
+            .send()
+            .await
+            .map_err(|e| anyhow::anyhow!("HelixDB upsert error: {e}"))?;
+
+        Ok(())
+    }
+
+    async fn upsert_edges(&self, edges: Vec<EdgeRecord>) -> anyhow::Result<()> {
+        use helix_db::dsl::prelude::*;
+
+        if edges.is_empty() {
+            return Ok(());
+        }
+
+        let mut batch = write_batch();
+        let mut var_names = Vec::with_capacity(edges.len());
+        for (i, edge) in edges.iter().enumerate() {
+            let var_name = format!("e{i}");
+            batch = batch.var_as(
+                &var_name,
+                g().add_n(
+                    "Edge",
+                    vec![
+                        ("from", PropertyInput::from(edge.from.clone())),
+                        ("to", PropertyInput::from(edge.to.clone())),
+                        ("kind", PropertyInput::from(format!("{:?}", edge.kind))),
+                        ("weight", PropertyInput::from(edge.weight as f64)),
+                    ],
+                ),
+            );
+            var_names.push(var_name);
+        }
+        let batch = batch.returning(var_names);
+
+        let request = DynamicQueryRequest::write(batch);
+        self.client
+            .query::<serde_json::Value>()
+            .dynamic(request)
+            .send()
+            .await
+            .map_err(|e| anyhow::anyhow!("HelixDB upsert edges error: {e}"))?;
+
+        Ok(())
     }
 }
 
@@ -734,10 +916,12 @@ mod tests {
 
     #[test]
     fn test_compiled_knowledge_backend_is_active_backend() {
-        #[cfg(feature = "store-neumann")]
-        assert_eq!(compiled_knowledge_backend(), "neumann");
+        #[cfg(feature = "store-helixdb")]
+        assert_eq!(compiled_knowledge_backend(), "helixdb");
         #[cfg(feature = "store-oxigraph")]
         assert_eq!(compiled_knowledge_backend(), "oxigraph");
+        #[cfg(feature = "store-neumann")]
+        assert_eq!(compiled_knowledge_backend(), "neumann");
     }
 
     #[test]

--- a/b00t-c0re-lib/src/rhai_engine.rs
+++ b/b00t-c0re-lib/src/rhai_engine.rs
@@ -589,7 +589,7 @@ mod tests {
             .execute_script("compiled_knowledge_backend()")
             .unwrap()
             .cast::<String>();
-        assert!(["neumann", "oxigraph"].contains(&backend.as_str()));
+        assert!(["helixdb", "oxigraph", "neumann"].contains(&backend.as_str()));
 
         let result = engine
             .execute_script("knowledge_backend_matches(compiled_knowledge_backend())")

--- a/b00t-c0re-lib/src/store.rs
+++ b/b00t-c0re-lib/src/store.rs
@@ -178,6 +178,58 @@ pub fn query(tags: &BTreeMap<String, String>) -> Result<Vec<StoreEntry>> {
         .collect())
 }
 
+// ── Influence attribution (AL-1.0) ──────────────────────────────────────────
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct InfluenceSource {
+    pub source_key: String,
+    pub ratio: f64,
+    pub score: f64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct InfluenceReceipt {
+    pub subject: String,
+    pub sources: Vec<InfluenceSource>,
+}
+
+/// 🤓 Minimal AL-1.0 attribution: normalises raw scores into ratios summing to 1.0.
+///    Does not persist — callers (e.g. evidence records) attach the receipt directly.
+pub fn put_influence(subject: &str, scored_sources: &[(String, f64)]) -> Result<InfluenceReceipt> {
+    let total: f64 = scored_sources.iter().map(|(_, score)| score).sum();
+    let sources = scored_sources
+        .iter()
+        .map(|(source_key, score)| InfluenceSource {
+            source_key: source_key.clone(),
+            ratio: if total > 0.0 { score / total } else { 0.0 },
+            score: *score,
+        })
+        .collect();
+    Ok(InfluenceReceipt {
+        subject: subject.to_string(),
+        sources,
+    })
+}
+
+// ── Init / Status ─────────────────────────────────────────────────────────
+
+/// Initialise the knowledge store directory.
+pub fn init() -> Result<()> {
+    std::fs::create_dir_all(store_root()).context("failed to create store root")?;
+    Ok(())
+}
+
+/// Return (object count, total bytes) across all stored entries.
+pub fn status() -> (usize, u64) {
+    match load_manifest() {
+        Ok(manifest) => {
+            let bytes = manifest.entries.iter().map(|e| e.size_bytes).sum();
+            (manifest.entries.len(), bytes)
+        }
+        Err(_) => (0, 0),
+    }
+}
+
 // ── Sync (local → remote placeholder) ─────────────────────────────────────
 
 /// Sync stored objects to a remote S3/R2 bucket using credential datums.
@@ -216,11 +268,13 @@ pub fn sync(provider: &str) -> Result<()> {
 // ── Cross-engine validation ─────────────────────────────────────────────────
 
 /// 🤓 AL-1.0 two-engine invariant applied to b00t's data fabric.
-///    Validates that Store manifest entries have matching facts in NeumannStore
-///    and that content hashes are consistent. Returns discrepancy report.
+///    Validates that Store manifest entries have matching facts in the
+///    compiled knowledge backend and that content hashes are consistent.
+///    Returns discrepancy report.
 pub fn validate_consistency() -> Result<CrossEngineReport> {
     let manifest = load_manifest()?;
     let mut report = CrossEngineReport {
+        backend: crate::compiled_knowledge_backend().to_string(),
         manifest_entries: manifest.entries.len(),
         related_facts: 0,
         hash_matches: 0,
@@ -256,7 +310,7 @@ pub fn validate_consistency() -> Result<CrossEngineReport> {
                 Some(subjects) => {
                     report.hash_matches += 1;
                     if subjects.len() > 1 {
-                        // Multiple Neumann entries for same checksum — normal for multiple consumers
+                        // Multiple backend entries for same checksum — normal for multiple consumers
                     }
                 }
                 None => {
@@ -269,7 +323,7 @@ pub fn validate_consistency() -> Result<CrossEngineReport> {
             }
         }
 
-        // Orphan facts: Neumann facts without matching store entries
+        // Orphan facts: backend facts without matching store entries
         let manifest_checksums: std::collections::HashSet<&str> = manifest.entries.iter()
             .map(|e| e.checksum.as_str())
             .collect();
@@ -287,6 +341,7 @@ pub fn validate_consistency() -> Result<CrossEngineReport> {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CrossEngineReport {
+    pub backend: String,
     pub manifest_entries: usize,
     pub related_facts: usize,
     pub hash_matches: usize,
@@ -303,7 +358,7 @@ pub struct Discrepancy {
     pub detail: String,
 }
 
-// ── Internal: NeumannStore async bridge ────────────────────────────────────
+// ── Internal: knowledge-backend async bridge ────────────────────────────────
 
 fn block_on_store<F, Fut, T>(f: F) -> Result<Result<T>>
 where
@@ -418,32 +473,4 @@ mod tests {
 
 // ── Store lifecycle + influence tracking ───────────────────────────────────
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct InfluenceSource {
-    pub source_key: String,
-    pub ratio: f64,
-    pub score: f64,
-}
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct InfluenceReceipt {
-    pub sources: Vec<InfluenceSource>,
-}
-
-pub fn init() -> Result<()> {
-    Ok(())
-}
-
-pub fn status() -> (usize, u64) {
-    (0, 0)
-}
-
-pub fn put_influence(_skill: &str, sources: &[(String, f64)]) -> Result<InfluenceReceipt> {
-    Ok(InfluenceReceipt {
-        sources: sources.iter().map(|(k, r)| InfluenceSource {
-            source_key: k.clone(),
-            ratio: *r,
-            score: 0.5,
-        }).collect(),
-    })
-}

--- a/b00t-cli/src/commands/install.rs
+++ b/b00t-cli/src/commands/install.rs
@@ -972,9 +972,12 @@ hint = "Test stack"
 
     #[test]
     fn test_gate_knowledge_backend_fails_for_mismatch() {
-        let mismatched = match b00t_c0re_lib::compiled_knowledge_backend() {
+        let active = b00t_c0re_lib::compiled_knowledge_backend();
+        let mismatched = match active {
+            "helixdb" => "oxigraph",
+            "oxigraph" => "helixdb",
             "neumann" => "oxigraph",
-            _ => "neumann",
+            _ => "helixdb",
         };
         let gates = vec![GateSpec {
             command: None,

--- a/b00t-cli/src/commands/store.rs
+++ b/b00t-cli/src/commands/store.rs
@@ -40,11 +40,11 @@ pub enum StoreCommands {
         #[clap(long, help = "Credential provider (cloudflare-r2, aws-s3)")]
         provider: String,
     },
-    #[clap(about = "Initialise the knowledge store directory + NeumannStore backend")]
+    #[clap(about = "Initialise the knowledge store directory + backend")]
     Init,
     #[clap(about = "Show store status (backend, object count, disk usage)")]
     Status,
-    #[clap(about = "Cross-engine consistency check: Store ↔ NeumannStore ↔ blobs")]
+    #[clap(about = "Cross-engine consistency check: Store ↔ knowledge backend ↔ blobs")]
     Validate,
 }
 
@@ -119,6 +119,7 @@ pub fn handle_store_command(cmd: &StoreCommands) -> anyhow::Result<()> {
         }
         StoreCommands::Validate => {
             let report = b00t_c0re_lib::store::validate_consistency()?;
+            println!("Backend:          {}", report.backend);
             println!("Manifest entries: {}", report.manifest_entries);
             println!("Related facts:    {}", report.related_facts);
             println!("Hash matches:     {}", report.hash_matches);


### PR DESCRIPTION
## Adds to PR #687

5 cherry-picked commits from `fix/store-conflict-markers` onto #687's branch:

| Commit | Change |
|---|---|
| eba7688f | store-helixdb feature + helix-db dep + .mcp.json ledgrrr wiring |
| 9d8b4244 | HelixDB backend in irontology_bridge, rhai_engine updates |
| 99007a88 | store lifecycle (init/status/validate/influence) |
| 3df11520 | CLI install/store command alignment |
| 1de74527 | Cargo.lock regenerated |

Builds cleanly on top of #687 — 0 errors.